### PR TITLE
docs: add Cursor Cloud dev environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+CargoNext (`logistics`) is a **Frappe Framework v16 app** that depends on **ERPNext v16**. It is not a standalone service; it runs inside a Frappe **bench**.
+
+### Where things live (already set up in the VM snapshot)
+- Bench: `~/frappe-bench` (Python 3.14 virtualenv at `~/frappe-bench/env`, Node 24 for asset builds).
+- This repo is symlinked into the bench as `~/frappe-bench/apps/logistics -> /workspace`, so **edits to this repo are live** in the running site (Python changes need a process reload; JS/CSS are rebuilt by the `watch` process).
+- Site: `logistics.localhost` (default site). Desk URL: `http://logistics.localhost:8000` (Chrome/curl treat `*.localhost` as loopback).
+- Login: `Administrator` / `admin`. MariaDB `root` password: `frappe`.
+- `~/.bashrc` prepends Node 24 (`~/.nvm/versions/node/v24.18.0/bin`) and `~/.local/bin` (bench CLI) to `PATH`. Use a login shell so `bench` and Node 24 resolve.
+
+### Starting the app (services are NOT auto-started on boot — no systemd here)
+Run these in order before using the site:
+```bash
+sudo service mariadb start          # MariaDB (data persists in snapshot)
+sudo service redis-server start     # optional; bench starts its own redis on :13000/:11000
+cd ~/frappe-bench && bench start     # web (:8000), socketio (:9000), workers, redis, esbuild watch
+```
+`bench start` is long-running — run it in a tmux session and leave it running.
+
+### Testing / lint
+- Tests (Frappe runner): `cd ~/frappe-bench && bench --site logistics.localhost run-tests --app logistics` (or `--module <dotted.path>` for one module). The site already has `allow_tests: true`.
+- No dedicated linter is configured in this repo (no ruff/eslint/pre-commit config). For a quick syntax check: `~/frappe-bench/env/bin/python -m compileall -q /workspace/logistics`.
+
+### Non-obvious gotchas
+- **Two data-seed patches fail on a fresh install/migrate** and are app-side (not environment) issues: `logistics.patches.v1_0_seed_exhibit_activity_codes` (module `Exhibits` exists on disk under `logistics/exhibits/` but is missing from `logistics/modules.txt`), and `logistics.patches.v3_0_outlook_calendar_setup` (Outlook `Connected App` link). If you ever reinstall the app or re-run migrate, use `bench --site logistics.localhost migrate --skip-failing`. Core modules (Transport, Warehousing, Customs, Freight, Job Management, etc.) are unaffected.
+- Frappe v16 requires **Python 3.14** and **Node 24**; the bench `env` and `PATH` are already configured for this. Do not rebuild the bench env on the system Python 3.12.
+- To reset the ERPNext setup wizard state, `System Settings.setup_complete` is the flag; a Company (e.g. `Test Company`) has already been created via the wizard on this site.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for CargoNext (`logistics`), a Frappe Framework v16 app that depends on ERPNext v16, and documents it for future Cloud Agents.

The only repo change is a new `AGENTS.md`. All heavyweight setup (system packages, bench, site, DB) lives in the VM snapshot; a minimal update script (`pip install -e` of the app) refreshes deps on startup.

### Environment provisioned
- System deps: Python 3.14 (deadsnakes), Node 24 (nvm), MariaDB 10.11 (utf8mb4, root pw `frappe`), Redis 7, wkhtmltopdf, build libs.
- Bench at `~/frappe-bench` (Frappe v16 + ERPNext v16), repo symlinked as `apps/logistics -> /workspace`.
- Site `logistics.localhost` created; apps installed & migrated (`--skip-failing` for two app-side data-seed patches — see `AGENTS.md`).
- Dev server runs via `bench start` (web :8000, socketio :9000, workers, redis, esbuild watch).

### Verification
- Logged into the Desk, completed the ERPNext setup wizard, and created + persisted a CargoNext `Load Type` record ("Full Truck Load (FTL)").
- Ran the Frappe test runner on `logistics.sea_freight.test_penalty_utils` — 5/5 passed.
- Byte-compiled the `logistics` package (no syntax errors).

[cargonext_create_load_type.mp4](https://cursor.com/agents/bc-248909d7-e87b-4cdc-b202-502f7fa1fee3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcargonext_create_load_type.mp4)

[Load Type saved](https://cursor.com/agents/bc-248909d7-e87b-4cdc-b202-502f7fa1fee3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcargonext_load_type_saved.webp)
[Load Type list](https://cursor.com/agents/bc-248909d7-e87b-4cdc-b202-502f7fa1fee3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcargonext_load_type_list.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-248909d7-e87b-4cdc-b202-502f7fa1fee3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-248909d7-e87b-4cdc-b202-502f7fa1fee3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

