### PR TITLE
feat(air-freight): e-AWB parity phases 1-3 and CCS connectivity

### DIFF
--- a/logistics/air_freight/api/iata_cargo_xml_api.py
+++ b/logistics/air_freight/api/iata_cargo_xml_api.py
@@ -13,6 +13,9 @@ import json
 def receive_cargo_xml():
     """Receive incoming IATA Cargo-XML messages via webhook"""
     try:
+        from logistics.air_freight.iata_cargo_xml.webhook_auth import verify_inbound_webhook
+
+        verify_inbound_webhook()
         # Get XML content from request
         xml_content = frappe.request.get_data(as_text=True)
         
@@ -303,6 +306,35 @@ def _connection_message(mode, auth_result, connector=None):
     return "Production mode — messages POST to Cargo-XML Endpoint URL"
 
 
+@frappe.whitelist()
+def submit_consolidated_eawb(master_awb_name, include_house_manifest=1, include_house_awbs=0):
+    from logistics.air_freight.iata_cargo_xml.eawb_service import submit_consolidated_eawb as _submit
+
+    return _submit(
+        master_awb_name,
+        include_house_manifest=bool(int(include_house_manifest)),
+        include_house_awbs=bool(int(include_house_awbs)),
+    )
+
+
+@frappe.whitelist()
+def submit_house_eawb(iata_transaction_name):
+    from logistics.air_freight.iata_cargo_xml.eawb_service import submit_house_eawb as _submit
+
+    return _submit(iata_transaction_name)
+
+
+@frappe.whitelist()
+def validate_dg_autocheck(air_shipment):
+    from logistics.air_freight.iata_cargo_xml.integrations.dg_autocheck_client import (
+        validate_dangerous_goods,
+    )
+    from logistics.air_freight.utils.iata_settings_utils import get_settings
+
+    settings = get_settings(air_shipment=air_shipment)
+    return validate_dangerous_goods(air_shipment, settings)
+
+
 def _determine_message_type(xml_content):
     """Determine message type from XML content"""
     try:
@@ -321,8 +353,14 @@ def _determine_message_type(xml_content):
             return "FHL"
         elif root_tag.endswith("XFWB"):
             return "XFWB"
+        elif root_tag.endswith("XFNM"):
+            return "XFNM"
         elif root_tag.endswith("XFHL"):
             return "XFHL"
+        elif root_tag.endswith("XFZB"):
+            return "XFZB"
+        elif root_tag.endswith("XFSU"):
+            return "XFSU"
         elif root_tag.endswith("XSDG"):
             return "XSDG"
         

--- a/logistics/air_freight/api/iata_cargo_xml_api.py
+++ b/logistics/air_freight/api/iata_cargo_xml_api.py
@@ -225,6 +225,9 @@ def get_iata_settings(company=None, master_awb=None, air_shipment=None):
         ),
         "settings": {
             "cargo_xml_enabled": settings.cargo_xml_enabled,
+            "connection_mode": getattr(settings, "connection_mode", "Direct"),
+            "ccs_provider": getattr(settings, "ccs_provider", None),
+            "ccs_participant_code": getattr(settings, "ccs_participant_code", None),
             "dg_autocheck_enabled": settings.dg_autocheck_enabled,
             "cass_enabled": settings.cass_enabled,
             "tact_subscription": settings.tact_subscription,
@@ -239,19 +242,38 @@ def get_iata_settings(company=None, master_awb=None, air_shipment=None):
 
 
 @frappe.whitelist()
-def test_iata_connection():
+def test_iata_connection(company=None):
     """Test IATA API connection"""
     try:
         from logistics.air_freight.iata_cargo_xml.base_connector import IATAConnector
-        
-        connector = IATAConnector()
+        from logistics.air_freight.utils.iata_settings_utils import get_settings
+
+        settings = get_settings(company=company)
+        connector = IATAConnector(company=settings.company if settings else company)
         mode = connector.get_sandbox_mode()
         auth_result = connector.authenticate(sandbox_mode=mode)
-        
+
+        ccs_info = {}
+        if connector.uses_ccs_hub() and settings:
+            from logistics.air_freight.iata_cargo_xml.ccs.factory import get_ccs_connector
+
+            ccs = get_ccs_connector(settings)
+            endpoint, route_mode = ccs.resolve_endpoint(test_mode=mode == "sandbox_endpoint")
+            ccs_info = {
+                "provider": settings.ccs_provider,
+                "connector": ccs.connector_label(),
+                "endpoint": endpoint,
+                "route_mode": route_mode,
+                "participant_code": settings.ccs_participant_code,
+            }
+
         return {
             "success": auth_result,
             "mode": mode,
-            "message": _connection_message(mode, auth_result),
+            "connection_mode": getattr(settings, "connection_mode", "Direct") if settings else "Direct",
+            "uses_ccs_hub": connector.uses_ccs_hub(),
+            "ccs": ccs_info,
+            "message": _connection_message(mode, auth_result, connector),
         }
         
     except Exception as e:
@@ -267,11 +289,15 @@ def _get_sandbox_mode(settings):
     return "production"
 
 
-def _connection_message(mode, auth_result):
+def _connection_message(mode, auth_result, connector=None):
     if not auth_result:
         return "Connection failed"
     if mode == "sandbox_mock":
         return "Sandbox mock mode — no external HTTP required"
+    if connector and connector.uses_ccs_hub():
+        if mode == "sandbox_endpoint":
+            return "CCS Hub sandbox mode — messages POST to CCS test endpoint with PIMA routing"
+        return "CCS Hub production mode — messages POST to CCS provider endpoint with PIMA routing"
     if mode == "sandbox_endpoint":
         return "Sandbox endpoint mode — messages POST to Test Endpoint URL"
     return "Production mode — messages POST to Cargo-XML Endpoint URL"

--- a/logistics/air_freight/doctype/air_consolidation/air_consolidation.json
+++ b/logistics/air_freight/doctype/air_consolidation/air_consolidation.json
@@ -29,6 +29,7 @@
   "flight_number",
   "section_break_documents",
   "master_awb",
+  "auto_send_eawb",
   "house_awb_prefix",
   "column_break_4",
   "customs_declaration",
@@ -391,6 +392,14 @@
    "fieldtype": "Link",
    "label": "Master AWB",
    "options": "Master Air Waybill"
+  },
+  {
+   "default": "0",
+   "depends_on": "master_awb",
+   "description": "Automatically submit master e-AWB and house manifests when the consolidation is saved with a MAWB.",
+   "fieldname": "auto_send_eawb",
+   "fieldtype": "Check",
+   "label": "Auto-send e-AWB to Airline"
   },
   {
    "fieldname": "house_awb_prefix",

--- a/logistics/air_freight/doctype/air_consolidation/air_consolidation.py
+++ b/logistics/air_freight/doctype/air_consolidation/air_consolidation.py
@@ -425,6 +425,18 @@ class AirConsolidation(Document):
         """Actions after document update"""
         self.update_related_air_freight_jobs()
         self.send_consolidation_notifications()
+        if getattr(self, "auto_send_eawb", 0) and self.master_awb:
+            if self.is_new() or self.has_value_changed("auto_send_eawb") or self.has_value_changed("master_awb"):
+                try:
+                    mawb_status = frappe.db.get_value("Master Air Waybill", self.master_awb, "eawb_status")
+                    if mawb_status not in ("Accepted", "Submitted"):
+                        from logistics.air_freight.iata_cargo_xml.eawb_service import (
+                            auto_send_eawb_for_consolidation,
+                        )
+
+                        auto_send_eawb_for_consolidation(self.name)
+                except Exception:
+                    frappe.log_error(frappe.get_traceback(), "Air Consolidation auto-send e-AWB")
 
     def before_submit(self):
         if not self.consolidation_packages:

--- a/logistics/air_freight/doctype/air_freight_settings/air_freight_settings.json
+++ b/logistics/air_freight/doctype/air_freight_settings/air_freight_settings.json
@@ -56,6 +56,7 @@
   "document_settings_section",
   "auto_generate_house_awb",
   "auto_generate_master_awb",
+  "auto_send_eawb_default",
   "use_mawb_stock",
   "default_mawb_stock_range",
   "column_break_document",
@@ -372,6 +373,13 @@
    "fieldname": "auto_generate_master_awb",
    "fieldtype": "Check",
    "label": "Auto-generate Master AWB Number"
+  },
+  {
+   "default": "0",
+   "fieldname": "auto_send_eawb_default",
+   "fieldtype": "Check",
+   "label": "Auto-send e-AWB by Default",
+   "description": "Default the Send AWB to Airline option on new Master Air Waybills."
   },
   {
    "default": "0",

--- a/logistics/air_freight/doctype/air_shipment_iata_transaction/air_shipment_iata_transaction.js
+++ b/logistics/air_freight/doctype/air_shipment_iata_transaction/air_shipment_iata_transaction.js
@@ -1,0 +1,33 @@
+frappe.ui.form.on('Air Shipment IATA Transaction', {
+	refresh(frm) {
+		if (frm.is_new()) {
+			return;
+		}
+		if (frm.doc.eawb_enabled) {
+			if (!frm.doc.eawb_status || frm.doc.eawb_status === 'Not Created') {
+				frm.add_custom_button(__('Create e-AWB'), () => run_method(frm, 'create_eawb'), __('e-AWB'));
+			}
+			if (frm.doc.eawb_status === 'Created') {
+				frm.add_custom_button(__('Sign e-AWB'), () => run_method(frm, 'sign_eawb'), __('e-AWB'));
+			}
+			if (['Signed', 'Created'].includes(frm.doc.eawb_status)) {
+				frm.add_custom_button(__('Submit e-AWB'), () => run_method(frm, 'submit_eawb'), __('e-AWB'));
+			}
+		}
+		if (frm.doc.tact_rate_lookup || frm.doc.eawb_enabled) {
+			frm.add_custom_button(__('Lookup TACT Rate'), () => run_method(frm, 'lookup_tact_rate'), __('Integrations'));
+		}
+		if (frm.doc.cass_participant_code) {
+			frm.add_custom_button(__('Submit CASS Settlement'), () => run_method(frm, 'submit_cass_settlement'), __('Integrations'));
+		}
+		frm.add_custom_button(__('Validate DG (AutoCheck)'), () => run_method(frm, 'validate_dg_autocheck'), __('Integrations'));
+	},
+});
+
+function run_method(frm, method) {
+	frm.call(method).then((r) => {
+		if (!r.exc) {
+			frm.reload_doc();
+		}
+	});
+}

--- a/logistics/air_freight/doctype/air_shipment_iata_transaction/air_shipment_iata_transaction.py
+++ b/logistics/air_freight/doctype/air_shipment_iata_transaction/air_shipment_iata_transaction.py
@@ -75,6 +75,7 @@ class AirShipmentIATATransaction(Document):
 	def lookup_tact_rate(self):
 		try:
 			from logistics.air_freight.utils.iata_settings_utils import get_settings
+			from logistics.air_freight.iata_cargo_xml.integrations.tact_client import lookup_tact_rate
 
 			company = frappe.db.get_value("Air Shipment", self.air_shipment, "company")
 			iata_settings = get_settings(company=company, air_shipment=self.air_shipment)
@@ -84,23 +85,49 @@ class AirShipmentIATATransaction(Document):
 						company or _("(unknown)")
 					)
 				)
-			if not iata_settings.tact_subscription:
-				frappe.throw(_("TACT subscription is not enabled in IATA Settings"))
-			if not iata_settings.tact_api_key:
-				frappe.throw(_("TACT API key is not configured in IATA Settings"))
+			result = lookup_tact_rate(self.air_shipment, iata_settings)
+			if not result.get("success"):
+				frappe.throw(result.get("error") or _("TACT lookup failed"))
 
-			# Future TACT API: load Air Shipment for origin/destination/weight/chargeable.
-			frappe.msgprint(
-				_("TACT rate lookup functionality requires TACT API integration. Please configure TACT API endpoint."),
-				indicator="blue",
-				title=_("TACT Integration"),
-			)
-			return {"status": "info", "message": "TACT rate lookup requires API integration"}
+			self.tact_rate_lookup = 1
+			self.tact_rate_reference = result.get("tact_rate_reference")
+			self.tact_rate_amount = result.get("tact_rate_amount")
+			self.tact_currency = result.get("tact_currency")
+			self.tact_rate_validity = result.get("tact_rate_validity")
+			self.save()
+			return {"status": "success", **result}
 		except (frappe.ValidationError, frappe.LinkValidationError, frappe.PermissionError):
 			raise
 		except Exception as e:
 			frappe.log_error(f"TACT rate lookup error: {str(e)}", "Air Shipment IATA Transaction - TACT")
 			frappe.throw(_("Error looking up TACT rate: {0}").format(str(e)))
+
+	@frappe.whitelist()
+	def submit_cass_settlement(self):
+		from logistics.air_freight.utils.iata_settings_utils import get_settings
+		from logistics.air_freight.iata_cargo_xml.integrations.cass_client import submit_cass_settlement
+
+		company = frappe.db.get_value("Air Shipment", self.air_shipment, "company")
+		settings = get_settings(company=company, air_shipment=self.air_shipment)
+		result = submit_cass_settlement(self, settings)
+		if result.get("success"):
+			self.cass_settlement_status = "Submitted"
+			self.cass_settlement_date = today()
+			self.save()
+		else:
+			frappe.throw(result.get("error") or _("CASS submission failed"))
+		return result
+
+	@frappe.whitelist()
+	def validate_dg_autocheck(self):
+		from logistics.air_freight.utils.iata_settings_utils import get_settings
+		from logistics.air_freight.iata_cargo_xml.integrations.dg_autocheck_client import (
+			validate_dangerous_goods,
+		)
+
+		company = frappe.db.get_value("Air Shipment", self.air_shipment, "company")
+		settings = get_settings(company=company, air_shipment=self.air_shipment)
+		return validate_dangerous_goods(self.air_shipment, settings)
 
 	@frappe.whitelist()
 	def create_eawb(self):
@@ -150,3 +177,9 @@ class AirShipmentIATATransaction(Document):
 		except Exception as e:
 			frappe.log_error(f"e-AWB signing error: {str(e)}", "Air Shipment IATA Transaction - e-AWB")
 			frappe.throw(_("Error signing e-AWB: {0}").format(str(e)))
+
+	@frappe.whitelist()
+	def submit_eawb(self):
+		from logistics.air_freight.iata_cargo_xml.eawb_service import submit_house_eawb
+
+		return submit_house_eawb(self.name)

--- a/logistics/air_freight/doctype/airline/airline.json
+++ b/logistics/air_freight/doctype/airline/airline.json
@@ -50,6 +50,10 @@
   "supports_live_animals",
   "supports_refrigerated",
   "supports_oversized",
+  "ccs_routing_section",
+  "ccs_pima_code",
+  "eawb_enabled",
+  "eawb_message_types",
   "contact_section",
   "website",
   "phone",
@@ -303,6 +307,31 @@
    "fieldname": "supports_oversized",
    "fieldtype": "Check",
    "label": "Supports Oversized Cargo"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "ccs_routing_section",
+   "fieldtype": "Section Break",
+   "label": "CCS / e-AWB Routing"
+  },
+  {
+   "description": "Airline PIMA address used by CCS hubs (e.g. CHAMP TRAXON) to route Cargo-XML messages.",
+   "fieldname": "ccs_pima_code",
+   "fieldtype": "Data",
+   "label": "CCS PIMA Code"
+  },
+  {
+   "default": "0",
+   "fieldname": "eawb_enabled",
+   "fieldtype": "Check",
+   "label": "e-AWB Enabled with Carrier"
+  },
+  {
+   "default": "XFWB,FWB,FHL",
+   "description": "Comma-separated Cargo-XML / Cargo-IMP message types supported for this carrier.",
+   "fieldname": "eawb_message_types",
+   "fieldtype": "Small Text",
+   "label": "e-AWB Message Types"
   },
   {
    "collapsible": 1,

--- a/logistics/air_freight/doctype/airline/airline.json
+++ b/logistics/air_freight/doctype/airline/airline.json
@@ -54,6 +54,9 @@
   "ccs_pima_code",
   "eawb_enabled",
   "eawb_message_types",
+  "cargo_xml_endpoint",
+  "cargo_xml_test_endpoint",
+  "default_special_handling_codes",
   "contact_section",
   "website",
   "phone",
@@ -332,6 +335,25 @@
    "fieldname": "eawb_message_types",
    "fieldtype": "Small Text",
    "label": "e-AWB Message Types"
+  },
+  {
+   "depends_on": "eawb_enabled",
+   "description": "Direct Cargo-XML endpoint for this carrier (overrides company IATA Settings in Direct mode).",
+   "fieldname": "cargo_xml_endpoint",
+   "fieldtype": "Data",
+   "label": "Cargo-XML Endpoint URL"
+  },
+  {
+   "depends_on": "eawb_enabled",
+   "fieldname": "cargo_xml_test_endpoint",
+   "fieldtype": "Data",
+   "label": "Cargo-XML Test Endpoint URL"
+  },
+  {
+   "depends_on": "eawb_enabled",
+   "fieldname": "default_special_handling_codes",
+   "fieldtype": "Small Text",
+   "label": "Default Special Handling Codes"
   },
   {
    "collapsible": 1,

--- a/logistics/air_freight/doctype/ccs_provider/__init__.py
+++ b/logistics/air_freight/doctype/ccs_provider/__init__.py
@@ -1,0 +1,1 @@
+# CCS Provider

--- a/logistics/air_freight/doctype/ccs_provider/ccs_provider.json
+++ b/logistics/air_freight/doctype/ccs_provider/ccs_provider.json
@@ -1,0 +1,139 @@
+{
+ "actions": [],
+ "allow_import": 1,
+ "allow_rename": 1,
+ "autoname": "field:provider_code",
+ "creation": "2026-07-05 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "provider_code",
+  "provider_name",
+  "column_break_main",
+  "connector_type",
+  "is_active",
+  "description_section",
+  "description",
+  "endpoints_section",
+  "default_endpoint",
+  "test_endpoint",
+  "column_break_endpoints",
+  "protocol",
+  "requires_pima_routing",
+  "documentation_url"
+ ],
+ "fields": [
+  {
+   "fieldname": "provider_code",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Provider Code",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "provider_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Provider Name",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_main",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "generic",
+   "fieldname": "connector_type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Connector Type",
+   "options": "champ_traxon\ngeneric\nwise\ndescartes\nccnhub",
+   "reqd": 1
+  },
+  {
+   "default": "1",
+   "fieldname": "is_active",
+   "fieldtype": "Check",
+   "label": "Is Active"
+  },
+  {
+   "fieldname": "description_section",
+   "fieldtype": "Section Break",
+   "label": "Details"
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Small Text",
+   "label": "Description"
+  },
+  {
+   "fieldname": "endpoints_section",
+   "fieldtype": "Section Break",
+   "label": "Endpoints"
+  },
+  {
+   "description": "Production Cargo-XML / messaging hub URL supplied by the CCS provider.",
+   "fieldname": "default_endpoint",
+   "fieldtype": "Data",
+   "label": "Default Endpoint URL"
+  },
+  {
+   "description": "Sandbox or UAT hub URL for testing.",
+   "fieldname": "test_endpoint",
+   "fieldtype": "Data",
+   "label": "Test Endpoint URL"
+  },
+  {
+   "fieldname": "column_break_endpoints",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "HTTP REST",
+   "fieldname": "protocol",
+   "fieldtype": "Select",
+   "label": "Protocol",
+   "options": "HTTP REST\nSOAP\nSFTP"
+  },
+  {
+   "default": "1",
+   "description": "When enabled, outbound messages are addressed to the airline PIMA code via CCS routing headers.",
+   "fieldname": "requires_pima_routing",
+   "fieldtype": "Check",
+   "label": "Requires PIMA Routing"
+  },
+  {
+   "fieldname": "documentation_url",
+   "fieldtype": "Data",
+   "label": "Documentation URL",
+   "options": "URL"
+  }
+ ],
+ "icon": "fa fa-exchange",
+ "links": [],
+ "modified": "2026-07-05 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Air Freight",
+ "name": "CCS Provider",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "provider_name",
+ "track_changes": 1
+}

--- a/logistics/air_freight/doctype/ccs_provider/ccs_provider.py
+++ b/logistics/air_freight/doctype/ccs_provider/ccs_provider.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2026, www.agilasoft.com and contributors
+# See license.txt
+
+from __future__ import unicode_literals
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+from frappe.utils import validate_url
+
+
+class CCSProvider(Document):
+	def validate(self):
+		if self.default_endpoint:
+			validate_url(self.default_endpoint, throw=True, fieldname="default_endpoint")
+		if self.test_endpoint:
+			validate_url(self.test_endpoint, throw=True, fieldname="test_endpoint")

--- a/logistics/air_freight/doctype/iata_message_queue/iata_message_queue.json
+++ b/logistics/air_freight/doctype/iata_message_queue/iata_message_queue.json
@@ -37,7 +37,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Message Type",
-   "options": "FWB\nFSU\nFMA\nFHL\nXFWB\nXFHL\nXSDG"
+   "options": "FWB\nFSU\nFMA\nFHL\nXFWB\nXFHL\nXFZB\nXSDG\nXFNM\nXFSU"
   },
   {
    "fieldname": "direction",

--- a/logistics/air_freight/doctype/iata_message_queue/iata_message_queue.py
+++ b/logistics/air_freight/doctype/iata_message_queue/iata_message_queue.py
@@ -40,6 +40,22 @@ class IATAMessageQueue(Document):
             message_builder.send_fsu_message(self.reference_name)
         elif self.message_type == "FMA":
             message_builder.send_fma_message(self.reference_name)
+        elif self.message_type == "XFWB":
+            frappe.get_doc("Master Air Waybill", self.reference_name).submit_eawb()
+        elif self.message_type == "XFHL":
+            mawb = frappe.db.get_value("Air Shipment", self.reference_name, "master_awb")
+            if mawb:
+                xml = message_builder.build_xfhl_message(mawb, self.reference_name)
+                airline = frappe.db.get_value("Master Air Waybill", mawb, "airline")
+                message_builder.send_message(
+                    "XFHL",
+                    xml,
+                    reference_doctype="Air Shipment",
+                    reference_name=self.reference_name,
+                    airline=airline,
+                )
+        elif self.message_type == "XFZB":
+            message_builder.send_house_eawb_message(self.reference_name)
     
     def _process_inbound_message(self):
         """Process inbound message"""

--- a/logistics/air_freight/doctype/iata_settings/iata_settings.js
+++ b/logistics/air_freight/doctype/iata_settings/iata_settings.js
@@ -1,0 +1,16 @@
+frappe.ui.form.on('IATA Settings', {
+	connection_mode(frm) {
+		_toggle_connection_fields(frm);
+	},
+	cargo_xml_enabled(frm) {
+		_toggle_connection_fields(frm);
+	},
+});
+
+function _toggle_connection_fields(frm) {
+	const enabled = frm.doc.cargo_xml_enabled;
+	const is_ccs = enabled && frm.doc.connection_mode === 'CCS Hub';
+	frm.toggle_reqd('cargo_xml_endpoint', enabled && frm.doc.connection_mode === 'Direct' && !frm.doc.test_mode);
+	frm.toggle_reqd('ccs_provider', is_ccs && !frm.doc.test_mode);
+	frm.toggle_reqd('ccs_participant_code', is_ccs && !frm.doc.test_mode);
+}

--- a/logistics/air_freight/doctype/iata_settings/iata_settings.json
+++ b/logistics/air_freight/doctype/iata_settings/iata_settings.json
@@ -10,9 +10,18 @@
   "company",
   "cargo_xml_section",
   "cargo_xml_enabled",
+  "connection_mode",
   "cargo_xml_endpoint",
   "cargo_xml_username",
   "cargo_xml_password",
+  "ccs_section",
+  "ccs_provider",
+  "ccs_participant_code",
+  "ccs_endpoint",
+  "ccs_username",
+  "ccs_password",
+  "column_break_ccs",
+  "ccs_test_endpoint",
   "column_break_1",
   "dg_autocheck_enabled",
   "dg_autocheck_api_key",
@@ -58,19 +67,84 @@
    "label": "Enable Cargo-XML"
   },
   {
+   "default": "Direct",
+   "depends_on": "cargo_xml_enabled",
+   "fieldname": "connection_mode",
+   "fieldtype": "Select",
+   "label": "Connection Mode",
+   "options": "Direct\nCCS Hub",
+   "description": "Direct posts Cargo-XML to an airline or handler endpoint. CCS Hub routes messages through a Cargo Community System (e.g. CHAMP TRAXON) using PIMA addressing."
+  },
+  {
+   "depends_on": "eval:doc.cargo_xml_enabled && doc.connection_mode=='Direct'",
    "fieldname": "cargo_xml_endpoint",
    "fieldtype": "Data",
    "label": "Cargo-XML Endpoint URL"
   },
   {
+   "depends_on": "eval:doc.cargo_xml_enabled && (doc.connection_mode=='Direct' || doc.connection_mode=='CCS Hub')",
    "fieldname": "cargo_xml_username",
    "fieldtype": "Data",
    "label": "Username"
   },
   {
+   "depends_on": "eval:doc.cargo_xml_enabled && (doc.connection_mode=='Direct' || doc.connection_mode=='CCS Hub')",
    "fieldname": "cargo_xml_password",
    "fieldtype": "Password",
    "label": "Password"
+  },
+  {
+   "collapsible": 1,
+   "depends_on": "eval:doc.cargo_xml_enabled && doc.connection_mode=='CCS Hub'",
+   "fieldname": "ccs_section",
+   "fieldtype": "Section Break",
+   "label": "CCS Hub Configuration"
+  },
+  {
+   "depends_on": "eval:doc.cargo_xml_enabled && doc.connection_mode=='CCS Hub'",
+   "fieldname": "ccs_provider",
+   "fieldtype": "Link",
+   "label": "CCS Provider",
+   "options": "CCS Provider",
+   "link_filters": "[[\"CCS Provider\", \"is_active\", \"=\", 1]]"
+  },
+  {
+   "depends_on": "eval:doc.cargo_xml_enabled && doc.connection_mode=='CCS Hub'",
+   "description": "Forwarder PIMA / participant mailbox code assigned by the CCS provider.",
+   "fieldname": "ccs_participant_code",
+   "fieldtype": "Data",
+   "label": "CCS Participant Code (PIMA)"
+  },
+  {
+   "depends_on": "eval:doc.cargo_xml_enabled && doc.connection_mode=='CCS Hub'",
+   "description": "Optional override of the CCS Provider default hub URL.",
+   "fieldname": "ccs_endpoint",
+   "fieldtype": "Data",
+   "label": "CCS Endpoint URL Override"
+  },
+  {
+   "depends_on": "eval:doc.cargo_xml_enabled && doc.connection_mode=='CCS Hub'",
+   "description": "Optional CCS-specific credentials. When blank, Cargo-XML username/password are used.",
+   "fieldname": "ccs_username",
+   "fieldtype": "Data",
+   "label": "CCS Username"
+  },
+  {
+   "depends_on": "eval:doc.cargo_xml_enabled && doc.connection_mode=='CCS Hub'",
+   "fieldname": "ccs_password",
+   "fieldtype": "Password",
+   "label": "CCS Password"
+  },
+  {
+   "fieldname": "column_break_ccs",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval:doc.cargo_xml_enabled && doc.connection_mode=='CCS Hub'",
+   "description": "Optional CCS sandbox hub URL used when Test Mode is enabled.",
+   "fieldname": "ccs_test_endpoint",
+   "fieldtype": "Data",
+   "label": "CCS Test Endpoint URL"
   },
   {
    "fieldname": "column_break_1",

--- a/logistics/air_freight/doctype/iata_settings/iata_settings.json
+++ b/logistics/air_freight/doctype/iata_settings/iata_settings.json
@@ -42,7 +42,9 @@
   "testing_section",
   "test_mode",
   "test_endpoint",
-  "debug_logging"
+  "debug_logging",
+  "webhook_api_key",
+  "cargo_xml_autocheck_url"
  ],
  "fields": [
   {
@@ -258,6 +260,18 @@
    "fieldname": "debug_logging",
    "fieldtype": "Check",
    "label": "Enable Debug Logging"
+  },
+  {
+   "fieldname": "webhook_api_key",
+   "fieldtype": "Password",
+   "label": "Inbound Webhook API Key",
+   "description": "Required for unauthenticated Cargo-XML webhook posts. Send as X-IATA-Webhook-Key header."
+  },
+  {
+   "fieldname": "cargo_xml_autocheck_url",
+   "fieldtype": "Data",
+   "label": "Cargo-XML AutoCheck URL",
+   "description": "Optional remote validation endpoint (IATA Cargo-XML AutoCheck or equivalent) called before outbound submit."
   }
  ],
  "icon": "fa fa-plane",

--- a/logistics/air_freight/doctype/iata_settings/iata_settings.py
+++ b/logistics/air_freight/doctype/iata_settings/iata_settings.py
@@ -36,13 +36,69 @@ class IATASettings(Document):
 				fieldname="test_endpoint",
 			)
 
-		if self.cargo_xml_enabled and not self.test_mode:
+		if self.test_mode and self.ccs_test_endpoint:
+			validate_url(
+				self.ccs_test_endpoint,
+				throw=True,
+				fieldname="ccs_test_endpoint",
+			)
+
+		if not self.cargo_xml_enabled:
+			return
+
+		connection_mode = self.connection_mode or "Direct"
+
+		if connection_mode == "Direct" and not self.test_mode:
 			if not self.cargo_xml_endpoint:
-				frappe.throw(_("Cargo-XML Endpoint URL is required when Cargo-XML is enabled"))
+				frappe.throw(_("Cargo-XML Endpoint URL is required when using Direct connection mode"))
 			if not self.cargo_xml_username:
 				frappe.throw(_("Username is required when Cargo-XML is enabled"))
 			if not self.cargo_xml_password and not self.get_password("cargo_xml_password"):
 				frappe.throw(_("Password is required when Cargo-XML is enabled"))
+
+		if connection_mode == "CCS Hub" and not self.test_mode:
+			self._validate_ccs_hub_settings()
+
+		if connection_mode == "CCS Hub" and self.test_mode and not self.test_endpoint and not self.ccs_test_endpoint:
+			provider_test_endpoint = None
+			if self.ccs_provider:
+				provider_test_endpoint = frappe.db.get_value(
+					"CCS Provider", self.ccs_provider, "test_endpoint"
+				)
+			if not provider_test_endpoint:
+				# Sandbox mock is still allowed without a CCS test endpoint.
+				pass
+
+	def _validate_ccs_hub_settings(self):
+		if not self.ccs_provider:
+			frappe.throw(_("CCS Provider is required when Connection Mode is CCS Hub"))
+		if not frappe.db.exists("CCS Provider", self.ccs_provider):
+			frappe.throw(_("CCS Provider {0} does not exist").format(self.ccs_provider))
+
+		provider_endpoint = frappe.db.get_value(
+			"CCS Provider", self.ccs_provider, "default_endpoint"
+		)
+		if not self.ccs_endpoint and not provider_endpoint:
+			frappe.throw(
+				_(
+					"CCS Endpoint URL is required. Set CCS Endpoint URL Override in IATA Settings "
+					"or Default Endpoint URL on CCS Provider {0}."
+				).format(self.ccs_provider)
+			)
+
+		if not self.ccs_participant_code:
+			frappe.throw(_("CCS Participant Code (PIMA) is required when Connection Mode is CCS Hub"))
+
+		ccs_password = self.get_password("ccs_password", raise_exception=False)
+		cargo_password = self.get_password("cargo_xml_password", raise_exception=False)
+		username = self.ccs_username or self.cargo_xml_username
+		if not username:
+			frappe.throw(_("CCS Username or Cargo-XML Username is required for CCS Hub connectivity"))
+		if not ccs_password and not cargo_password:
+			frappe.throw(_("CCS Password or Cargo-XML Password is required for CCS Hub connectivity"))
+
+		if self.ccs_endpoint:
+			validate_url(self.ccs_endpoint, throw=True, fieldname="ccs_endpoint")
 
 		if self.dg_autocheck_enabled and not self.dg_autocheck_api_key:
 			frappe.throw(_("DG AutoCheck API Key is required when DG AutoCheck is enabled"))

--- a/logistics/air_freight/doctype/master_air_waybill/master_air_waybill.js
+++ b/logistics/air_freight/doctype/master_air_waybill/master_air_waybill.js
@@ -14,6 +14,19 @@ frappe.ui.form.on("Master Air Waybill", {
 			frm.add_custom_button(__("Submit eAWB"), function () {
 				submit_mawb_eawb(frm);
 			}, __("Action"));
+			frm.add_custom_button(__("Submit Consolidated e-AWB"), function () {
+				frappe.call({
+					method: "submit_consolidated_eawb",
+					doc: frm.doc,
+					freeze: true,
+					freeze_message: __("Submitting master and house manifests..."),
+					callback: function (r) {
+						if (!r.exc) {
+							frm.reload_doc();
+						}
+					},
+				});
+			}, __("Action"));
 		}
 
 		if (!frm._iata_sandbox_checked) {

--- a/logistics/air_freight/doctype/master_air_waybill/master_air_waybill.json
+++ b/logistics/air_freight/doctype/master_air_waybill/master_air_waybill.json
@@ -26,6 +26,9 @@
   "flight_date",
   "manifest_sent",
   "manifest_sent_date",
+  "send_awb_to_airline",
+  "special_handling_codes",
+  "paper_awb_required",
   "eawb_status",
   "eawb_submitted_date",
   "column_break_eawb",
@@ -206,6 +209,25 @@
    "fieldtype": "Datetime",
    "label": "Manifest Sent Date",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "description": "When enabled, e-AWB and house manifests are sent automatically after MAWB issue or consolidation update.",
+   "fieldname": "send_awb_to_airline",
+   "fieldtype": "Check",
+   "label": "Send AWB to Airline"
+  },
+  {
+   "description": "Comma-separated IATA SHC codes (e.g. ECC, ECP, PER). Leave blank for automatic ECC/ECP.",
+   "fieldname": "special_handling_codes",
+   "fieldtype": "Small Text",
+   "label": "Special Handling Codes"
+  },
+  {
+   "default": "0",
+   "fieldname": "paper_awb_required",
+   "fieldtype": "Check",
+   "label": "Paper AWB Required (ECP)"
   },
   {
    "default": "Not Submitted",

--- a/logistics/air_freight/doctype/master_air_waybill/master_air_waybill.py
+++ b/logistics/air_freight/doctype/master_air_waybill/master_air_waybill.py
@@ -68,6 +68,27 @@ class MasterAirWaybill(Document):
 			"message_queue": result.get("message_queue"),
 		}
 
+	@frappe.whitelist()
+	def submit_consolidated_eawb(self, include_house_manifest=1, include_house_awbs=0):
+		from logistics.air_freight.iata_cargo_xml.eawb_service import submit_consolidated_eawb
+
+		self.check_permission("write")
+		return submit_consolidated_eawb(
+			self.name,
+			include_house_manifest=bool(int(include_house_manifest)),
+			include_house_awbs=bool(int(include_house_awbs)),
+		)
+
+	def on_update(self):
+		if getattr(self, "send_awb_to_airline", 0) and self.eawb_status in (None, "", "Not Submitted"):
+			if getattr(self.flags, "auto_send_eawb", 0):
+				try:
+					from logistics.air_freight.iata_cargo_xml.eawb_service import auto_send_eawb_for_mawb
+
+					auto_send_eawb_for_mawb(self.name)
+				except Exception:
+					frappe.log_error(frappe.get_traceback(), "MAWB auto-send e-AWB")
+
 	def validate_eawb_submission(self):
 		if self.eawb_status == "Accepted":
 			frappe.throw(

--- a/logistics/air_freight/iata_cargo_xml/base_connector.py
+++ b/logistics/air_freight/iata_cargo_xml/base_connector.py
@@ -33,6 +33,11 @@ class IATAConnector:
 			cargo_xml_enabled=0,
 			cargo_xml_endpoint=None,
 			cargo_xml_username=None,
+			connection_mode="Direct",
+			ccs_provider=None,
+			ccs_participant_code=None,
+			ccs_endpoint=None,
+			ccs_test_endpoint=None,
 			debug_logging=0,
 		)
 
@@ -41,18 +46,49 @@ class IATAConnector:
 			return None
 		return self.settings.get_password("cargo_xml_password", raise_exception=False)
 
+	def _get_ccs_password(self):
+		if isinstance(self.settings, frappe._dict) or not hasattr(self.settings, "get_password"):
+			return None
+		return self.settings.get_password("ccs_password", raise_exception=False)
+
 	def get_sandbox_mode(self) -> str:
 		"""Return sandbox_mock, sandbox_endpoint, or production."""
 		if self.settings.test_mode:
-			if self.settings.test_endpoint:
+			if self._has_test_endpoint():
 				return "sandbox_endpoint"
 			return "sandbox_mock"
 		return "production"
+
+	def uses_ccs_hub(self) -> bool:
+		from logistics.air_freight.iata_cargo_xml.ccs.factory import uses_ccs_hub
+
+		return uses_ccs_hub(self.settings)
+
+	def _has_test_endpoint(self) -> bool:
+		if self.settings.test_endpoint:
+			return True
+		if self.uses_ccs_hub():
+			if getattr(self.settings, "ccs_test_endpoint", None):
+				return True
+			provider = getattr(self.settings, "ccs_provider", None)
+			if provider and frappe.db.get_value("CCS Provider", provider, "test_endpoint"):
+				return True
+		return False
 
 	def _resolve_endpoint(self, endpoint_override: Optional[str] = None) -> Tuple[Optional[str], str]:
 		mode = self.get_sandbox_mode()
 		if mode == "sandbox_mock":
 			return None, mode
+
+		if self.uses_ccs_hub():
+			from logistics.air_freight.iata_cargo_xml.ccs.factory import resolve_ccs_endpoint
+
+			test_mode = mode == "sandbox_endpoint"
+			endpoint, route_mode = resolve_ccs_endpoint(self.settings, test_mode=test_mode)
+			if endpoint_override:
+				endpoint = endpoint_override
+			return endpoint, route_mode if not test_mode else f"{route_mode}_test"
+
 		if mode == "sandbox_endpoint":
 			return endpoint_override or self.settings.test_endpoint, mode
 		return endpoint_override or self.settings.cargo_xml_endpoint, mode
@@ -65,6 +101,20 @@ class IATAConnector:
 				password = self._get_cargo_xml_password()
 				if self.settings.cargo_xml_username and password:
 					self.session.auth = (self.settings.cargo_xml_username, password)
+				ccs_password = self._get_ccs_password()
+				ccs_username = getattr(self.settings, "ccs_username", None)
+				if ccs_username and ccs_password:
+					self.session.auth = (ccs_username, ccs_password)
+				return True
+
+			if self.uses_ccs_hub():
+				ccs_password = self._get_ccs_password()
+				ccs_username = getattr(self.settings, "ccs_username", None) or getattr(
+					self.settings, "cargo_xml_username", None
+				)
+				password = ccs_password or self._get_cargo_xml_password()
+				if ccs_username and password:
+					self.session.auth = (ccs_username, password)
 				return True
 
 			if not self.settings.cargo_xml_enabled:
@@ -116,9 +166,15 @@ class IATAConnector:
 		endpoint: Optional[str] = None,
 		reference_doctype: Optional[str] = None,
 		reference_name: Optional[str] = None,
+		airline: Optional[str] = None,
 	) -> Dict[str, Any]:
-		"""Send message to IATA platform (production, sandbox endpoint, or in-app mock)."""
+		"""Send message to IATA platform (production, sandbox endpoint, CCS hub, or in-app mock)."""
 		try:
+			from logistics.air_freight.iata_cargo_xml.ccs.routing import (
+				build_routing_context,
+				resolve_airline_from_reference,
+			)
+
 			resolved_endpoint, mode = self._resolve_endpoint(endpoint)
 			self._debug_log(f"send_message mode={mode} type={message_type} ref={reference_name}")
 
@@ -141,6 +197,39 @@ class IATAConnector:
 
 			if not resolved_endpoint:
 				raise Exception("No endpoint configured")
+
+			routing_airline = airline or resolve_airline_from_reference(
+				reference_doctype, reference_name
+			)
+			routing_context = build_routing_context(
+				airline=routing_airline,
+				reference_doctype=reference_doctype,
+				reference_name=reference_name,
+				awb_number=self._extract_awb_from_content(content),
+			)
+
+			if self.uses_ccs_hub() and mode not in ("sandbox_mock",):
+				from logistics.air_freight.iata_cargo_xml.ccs.factory import get_ccs_connector
+
+				ccs_result = get_ccs_connector(self.settings).send(
+					message_type=message_type,
+					content=content,
+					session=self.session,
+					routing_context=routing_context,
+					validation=validation,
+					test_mode=mode.endswith("_test") or mode == "sandbox_endpoint",
+				)
+				self.log_transaction({
+					"message_type": message_type,
+					"direction": "outbound",
+					"status": "Sent" if ccs_result.get("success") else "Failed",
+					"message_content": content[:5000],
+					"response_content": (ccs_result.get("response") or "")[:1000],
+					"reference_doctype": reference_doctype,
+					"reference_name": reference_name,
+					"timestamp": datetime.now().isoformat(),
+				})
+				return ccs_result
 
 			response = self.session.post(resolved_endpoint, data=content, timeout=30)
 

--- a/logistics/air_freight/iata_cargo_xml/base_connector.py
+++ b/logistics/air_freight/iata_cargo_xml/base_connector.py
@@ -75,7 +75,13 @@ class IATAConnector:
 				return True
 		return False
 
-	def _resolve_endpoint(self, endpoint_override: Optional[str] = None) -> Tuple[Optional[str], str]:
+	def _resolve_endpoint(
+		self,
+		endpoint_override: Optional[str] = None,
+		airline: Optional[str] = None,
+	) -> Tuple[Optional[str], str]:
+		from logistics.air_freight.iata_cargo_xml.eawb_utils import resolve_airline_endpoint
+
 		mode = self.get_sandbox_mode()
 		if mode == "sandbox_mock":
 			return None, mode
@@ -90,8 +96,11 @@ class IATAConnector:
 			return endpoint, route_mode if not test_mode else f"{route_mode}_test"
 
 		if mode == "sandbox_endpoint":
-			return endpoint_override or self.settings.test_endpoint, mode
-		return endpoint_override or self.settings.cargo_xml_endpoint, mode
+			airline_endpoint = resolve_airline_endpoint(self.settings, airline, test_mode=True) if airline else None
+			return endpoint_override or airline_endpoint or self.settings.test_endpoint, mode
+
+		airline_endpoint = resolve_airline_endpoint(self.settings, airline, test_mode=False) if airline else None
+		return endpoint_override or airline_endpoint or self.settings.cargo_xml_endpoint, mode
 
 	def authenticate(self, sandbox_mode: Optional[str] = None) -> bool:
 		"""Handle IATA API authentication."""
@@ -142,6 +151,8 @@ class IATAConnector:
 				return self._validate_fsu_message(root)
 			if schema_type == "FMA":
 				return self._validate_fma_message(root)
+			if schema_type in ("XFHL", "XFZB"):
+				return self._validate_xfhl_message(root)
 
 			return {"valid": True, "errors": [], "warnings": []}
 
@@ -175,7 +186,7 @@ class IATAConnector:
 				resolve_airline_from_reference,
 			)
 
-			resolved_endpoint, mode = self._resolve_endpoint(endpoint)
+			resolved_endpoint, mode = self._resolve_endpoint(endpoint, airline=airline)
 			self._debug_log(f"send_message mode={mode} type={message_type} ref={reference_name}")
 
 			if mode != "sandbox_mock":
@@ -431,6 +442,14 @@ class IATAConnector:
 		for element in required_elements:
 			if self._find_element(root, element) is None:
 				errors.append(f"Missing required element: {element}")
+		return {"valid": len(errors) == 0, "errors": errors, "warnings": []}
+
+	def _validate_xfhl_message(self, root: ET.Element) -> Dict[str, Any]:
+		errors = []
+		if self._find_element(root, "MessageHeader") is None:
+			errors.append("Missing required element: MessageHeader")
+		if self._find_element(root, "MasterAirWaybill") is None and self._find_element(root, "HouseWaybill") is None:
+			errors.append("Missing MasterAirWaybill or HouseWaybill")
 		return {"valid": len(errors) == 0, "errors": errors, "warnings": []}
 
 	def _extract_message_data(self, root: ET.Element, message_type: str) -> Dict[str, Any]:

--- a/logistics/air_freight/iata_cargo_xml/ccs/__init__.py
+++ b/logistics/air_freight/iata_cargo_xml/ccs/__init__.py
@@ -1,0 +1,1 @@
+# IATA Cargo Community System (CCS) connectors

--- a/logistics/air_freight/iata_cargo_xml/ccs/base.py
+++ b/logistics/air_freight/iata_cargo_xml/ccs/base.py
@@ -1,0 +1,220 @@
+# Copyright (c) 2026, www.agilasoft.com and contributors
+# See license.txt
+
+from __future__ import unicode_literals
+
+import xml.etree.ElementTree as ET
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import Any, Dict, Optional, Tuple
+
+import frappe
+
+
+class BaseCCSConnector(ABC):
+	"""Base class for Cargo Community System outbound connectors."""
+
+	provider_code = "GENERIC"
+
+	def __init__(self, settings, provider_doc):
+		self.settings = settings
+		self.provider = provider_doc
+
+	def send(
+		self,
+		message_type: str,
+		content: str,
+		session,
+		routing_context: Optional[Dict[str, Any]] = None,
+		validation: Optional[Dict[str, Any]] = None,
+		test_mode: bool = False,
+	) -> Dict[str, Any]:
+		routing_context = routing_context or {}
+		endpoint, route_mode = self.resolve_endpoint(test_mode=test_mode)
+		if not endpoint:
+			raise frappe.ValidationError(
+				frappe._("No CCS endpoint configured. Set Default Endpoint on the CCS Provider or override it in IATA Settings.")
+			)
+
+		payload = self.prepare_payload(message_type, content, routing_context)
+		headers = self.build_headers(message_type, payload, routing_context)
+		auth = self.get_auth()
+
+		if auth:
+			session.auth = auth
+
+		response = session.post(endpoint, data=payload, headers=headers, timeout=30)
+
+		accepted = response.status_code == 200 and self.response_indicates_acceptance(response.text)
+		return {
+			"success": response.status_code == 200,
+			"accepted": accepted,
+			"status_code": response.status_code,
+			"response": response.text,
+			"validation": validation or {},
+			"sandbox_mode": route_mode,
+			"ccs_provider": self.provider.provider_code,
+			"ccs_endpoint": endpoint,
+			"routing": {
+				"sender_pima": self.get_sender_pima(),
+				"recipient_pima": routing_context.get("airline_pima"),
+				"airline": routing_context.get("airline"),
+			},
+		}
+
+	def resolve_endpoint(self, test_mode: bool = False) -> Tuple[Optional[str], str]:
+		if test_mode:
+			endpoint = (
+				getattr(self.settings, "ccs_test_endpoint", None)
+				or getattr(self.settings, "test_endpoint", None)
+				or getattr(self.provider, "test_endpoint", None)
+			)
+			return endpoint, "ccs_sandbox_endpoint"
+
+		endpoint = getattr(self.settings, "ccs_endpoint", None) or getattr(
+			self.provider, "default_endpoint", None
+		)
+		return endpoint, "ccs_production"
+
+	def get_sender_pima(self) -> Optional[str]:
+		code = getattr(self.settings, "ccs_participant_code", None)
+		return str(code).strip().upper() if code else None
+
+	def get_auth(self) -> Optional[Tuple[str, str]]:
+		username = getattr(self.settings, "ccs_username", None) or getattr(
+			self.settings, "cargo_xml_username", None
+		)
+		password = self._get_password("ccs_password") or self._get_password("cargo_xml_password")
+		if username and password:
+			return username, password
+		return None
+
+	def _get_password(self, fieldname: str) -> Optional[str]:
+		if hasattr(self.settings, "get_password"):
+			return self.settings.get_password(fieldname, raise_exception=False)
+		return None
+
+	def prepare_payload(
+		self,
+		message_type: str,
+		content: str,
+		routing_context: Dict[str, Any],
+	) -> str:
+		if not getattr(self.provider, "requires_pima_routing", 1):
+			return content
+		return self._inject_message_routing(content, message_type, routing_context)
+
+	def _inject_message_routing(
+		self,
+		content: str,
+		message_type: str,
+		routing_context: Dict[str, Any],
+	) -> str:
+		try:
+			root = ET.fromstring(content)
+		except ET.ParseError:
+			return content
+
+		header = self._find_element(root, "MessageHeader")
+		if header is None:
+			header = ET.SubElement(root, "MessageHeader")
+
+		sender_pima = self.get_sender_pima()
+		recipient_pima = routing_context.get("airline_pima")
+		if sender_pima:
+			header.set("SenderId", sender_pima)
+		if recipient_pima:
+			header.set("RecipientId", recipient_pima)
+		if not header.get("Timestamp"):
+			header.set("Timestamp", datetime.now().isoformat())
+		if not header.get("MessageType"):
+			header.set("MessageType", message_type)
+
+		return ET.tostring(root, encoding="unicode", method="xml")
+
+	def build_headers(
+		self,
+		message_type: str,
+		payload: str,
+		routing_context: Dict[str, Any],
+	) -> Dict[str, str]:
+		headers = {
+			"Content-Type": "application/xml",
+			"Accept": "application/xml",
+			"X-Message-Type": message_type,
+		}
+		sender_pima = self.get_sender_pima()
+		recipient_pima = routing_context.get("airline_pima")
+		if sender_pima:
+			headers["X-Sender-PIMA"] = sender_pima
+		if recipient_pima:
+			headers["X-Recipient-PIMA"] = recipient_pima
+		awb_number = routing_context.get("awb_number")
+		if awb_number:
+			headers["X-AWB-No"] = awb_number
+		return headers
+
+	@staticmethod
+	def response_indicates_acceptance(response_text: str) -> bool:
+		if not response_text:
+			return True
+		lower = response_text.lower()
+		if "rejected" in lower or "error" in lower:
+			return False
+		return True
+
+	@staticmethod
+	def _find_element(root: ET.Element, local_name: str) -> Optional[ET.Element]:
+		found = root.find(local_name)
+		if found is not None:
+			return found
+		for elem in root.iter():
+			if elem.tag.split("}")[-1] == local_name:
+				return elem
+		return None
+
+	@abstractmethod
+	def connector_label(self) -> str:
+		pass
+
+
+class ChampTraxonConnector(BaseCCSConnector):
+	provider_code = "CHAMP_TRAXON"
+
+	def connector_label(self) -> str:
+		return "CHAMP TRAXON cargoHUB"
+
+	def build_headers(
+		self,
+		message_type: str,
+		payload: str,
+		routing_context: Dict[str, Any],
+	) -> Dict[str, str]:
+		headers = super().build_headers(message_type, payload, routing_context)
+		headers["X-CHAMP-Provider"] = "TRAXON"
+		headers["X-CHAMP-Message-Format"] = "Cargo-XML"
+		return headers
+
+
+class WiseConnector(BaseCCSConnector):
+	provider_code = "WISE"
+
+	def connector_label(self) -> str:
+		return "WiseTech CCS"
+
+	def build_headers(
+		self,
+		message_type: str,
+		payload: str,
+		routing_context: Dict[str, Any],
+	) -> Dict[str, str]:
+		headers = super().build_headers(message_type, payload, routing_context)
+		headers["X-CCS-Provider"] = "WISE"
+		return headers
+
+
+class GenericCCSConnector(BaseCCSConnector):
+	provider_code = "GENERIC"
+
+	def connector_label(self) -> str:
+		return self.provider.provider_name or "Custom CCS"

--- a/logistics/air_freight/iata_cargo_xml/ccs/factory.py
+++ b/logistics/air_freight/iata_cargo_xml/ccs/factory.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2026, www.agilasoft.com and contributors
+# See license.txt
+
+from __future__ import unicode_literals
+
+from typing import Optional, Tuple
+
+import frappe
+
+from .base import BaseCCSConnector, ChampTraxonConnector, GenericCCSConnector, WiseConnector
+
+CONNECTOR_MAP = {
+	"champ_traxon": ChampTraxonConnector,
+	"generic": GenericCCSConnector,
+	"wise": WiseConnector,
+	"descartes": GenericCCSConnector,
+	"ccnhub": GenericCCSConnector,
+}
+
+
+def get_ccs_provider_doc(provider_name: str):
+	if not provider_name:
+		return None
+	if not frappe.db.exists("CCS Provider", provider_name):
+		return None
+	return frappe.get_doc("CCS Provider", provider_name)
+
+
+def get_ccs_connector(settings) -> BaseCCSConnector:
+	provider_name = getattr(settings, "ccs_provider", None)
+	provider_doc = get_ccs_provider_doc(provider_name)
+	if not provider_doc:
+		frappe.throw(frappe._("CCS Provider {0} was not found.").format(provider_name or ""))
+
+	connector_type = provider_doc.connector_type or "generic"
+	connector_cls = CONNECTOR_MAP.get(connector_type, GenericCCSConnector)
+	return connector_cls(settings, provider_doc)
+
+
+def resolve_ccs_endpoint(settings, test_mode: bool = False) -> Tuple[Optional[str], str]:
+	connector = get_ccs_connector(settings)
+	return connector.resolve_endpoint(test_mode=test_mode)
+
+
+def uses_ccs_hub(settings) -> bool:
+	return (
+		getattr(settings, "connection_mode", None) == "CCS Hub"
+		and getattr(settings, "ccs_provider", None)
+		and getattr(settings, "cargo_xml_enabled", 0)
+	)

--- a/logistics/air_freight/iata_cargo_xml/ccs/routing.py
+++ b/logistics/air_freight/iata_cargo_xml/ccs/routing.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2026, www.agilasoft.com and contributors
+# See license.txt
+
+from __future__ import unicode_literals
+
+from typing import Any, Dict, Optional
+
+import frappe
+
+
+def resolve_airline_pima(airline: Optional[str]) -> Optional[str]:
+	"""Return the CCS PIMA routing code for an airline."""
+	if not airline:
+		return None
+
+	pima = frappe.db.get_value("Airline", airline, "ccs_pima_code")
+	if pima:
+		return str(pima).strip().upper()
+
+	# Fall back to IATA 2-letter code when PIMA is not configured.
+	return frappe.db.get_value("Airline", airline, "two_character_code") or airline
+
+
+def build_routing_context(
+	*,
+	airline: Optional[str] = None,
+	reference_doctype: Optional[str] = None,
+	reference_name: Optional[str] = None,
+	awb_number: Optional[str] = None,
+) -> Dict[str, Any]:
+	return {
+		"airline": airline,
+		"airline_pima": resolve_airline_pima(airline),
+		"reference_doctype": reference_doctype,
+		"reference_name": reference_name,
+		"awb_number": awb_number,
+	}
+
+
+def resolve_airline_from_reference(
+	reference_doctype: Optional[str],
+	reference_name: Optional[str],
+) -> Optional[str]:
+	if not reference_doctype or not reference_name:
+		return None
+
+	if reference_doctype == "Master Air Waybill":
+		return frappe.db.get_value("Master Air Waybill", reference_name, "airline")
+	if reference_doctype == "Air Shipment":
+		return frappe.db.get_value("Air Shipment", reference_name, "airline")
+	return None

--- a/logistics/air_freight/iata_cargo_xml/eawb_service.py
+++ b/logistics/air_freight/iata_cargo_xml/eawb_service.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2026, www.agilasoft.com and contributors
+# See license.txt
+
+from __future__ import unicode_literals
+
+from typing import Any, Dict, List
+
+import frappe
+from frappe import _
+from frappe.utils import now_datetime
+
+from logistics.air_freight.iata_cargo_xml.message_builder import MessageBuilder
+from logistics.air_freight.utils.iata_settings_utils import resolve_company
+
+
+def submit_house_eawb(iata_transaction_name: str) -> Dict[str, Any]:
+	tx = frappe.get_doc("Air Shipment IATA Transaction", iata_transaction_name)
+	tx.check_permission("write")
+
+	if not tx.eawb_enabled:
+		frappe.throw(_("e-AWB is not enabled for this record"))
+	if tx.eawb_status not in ("Signed", "Created"):
+		frappe.throw(_("e-AWB must be signed before submission"))
+
+	company = frappe.db.get_value("Air Shipment", tx.air_shipment, "company")
+	builder = MessageBuilder(company=company)
+	result = builder.send_house_eawb_message(tx.air_shipment)
+
+	tx.eawb_status = "Submitted"
+	if result.get("accepted"):
+		tx.eawb_status = "Accepted"
+	elif not result.get("success"):
+		tx.eawb_status = "Rejected"
+
+	if result.get("message_id"):
+		tx.iata_message_id = result.get("message_id")
+	tx.last_status_update = now_datetime()
+	tx.flags.ignore_permissions = True
+	tx.save(ignore_permissions=True)
+	frappe.db.commit()
+
+	return {
+		"success": result.get("success"),
+		"eawb_status": tx.eawb_status,
+		"message_id": tx.iata_message_id,
+		"result": result,
+	}
+
+
+def submit_consolidated_eawb(
+	master_awb_name: str,
+	*,
+	include_house_manifest: bool = True,
+	include_house_awbs: bool = False,
+) -> Dict[str, Any]:
+	"""Submit master XFWB and optional XFHL/FWB messages for all linked house shipments."""
+	mawb = frappe.get_doc("Master Air Waybill", master_awb_name)
+	mawb.check_permission("write")
+
+	company = resolve_company(master_awb=master_awb_name)
+	builder = MessageBuilder(company=company)
+
+	results = {"master": None, "house_manifests": [], "house_awbs": []}
+
+	master_result = mawb.submit_eawb()
+	results["master"] = master_result
+
+	if include_house_manifest:
+		manifest_results = builder.send_xfhl_for_mawb(master_awb_name)
+		results["house_manifests"] = manifest_results
+
+	if include_house_awbs:
+		for ship_name in frappe.get_all(
+			"Air Shipment", filters={"master_awb": master_awb_name}, pluck="name"
+		):
+			tx_name = frappe.db.get_value(
+				"Air Shipment IATA Transaction", {"air_shipment": ship_name}, "name"
+			)
+			if not tx_name:
+				continue
+			tx = frappe.get_doc("Air Shipment IATA Transaction", tx_name)
+			if not tx.eawb_enabled:
+				continue
+			if tx.eawb_status in ("Signed", "Created"):
+				results["house_awbs"].append(submit_house_eawb(tx_name))
+
+	if master_awb_name:
+		frappe.db.set_value(
+			"Master Air Waybill",
+			master_awb_name,
+			{
+				"manifest_sent": 1,
+				"manifest_sent_date": now_datetime(),
+			},
+		)
+
+	return results
+
+
+def auto_send_eawb_for_mawb(master_awb_name: str) -> Dict[str, Any]:
+	"""Send e-AWB when auto-send is enabled on MAWB or Air Freight Settings."""
+	mawb = frappe.get_doc("Master Air Waybill", master_awb_name)
+	if not getattr(mawb, "send_awb_to_airline", 0):
+		company = resolve_company(master_awb=master_awb_name)
+		settings_name = frappe.db.get_value("Air Freight Settings", {"company": company}, "name")
+		if settings_name:
+			default_auto = frappe.db.get_value(
+				"Air Freight Settings", settings_name, "auto_send_eawb_default"
+			)
+			if not default_auto:
+				return {"skipped": True, "reason": "Auto-send disabled"}
+		else:
+			return {"skipped": True, "reason": "Auto-send disabled"}
+
+	return submit_consolidated_eawb(master_awb_name)
+
+
+def auto_send_eawb_for_consolidation(consolidation_name: str) -> Dict[str, Any]:
+	consol = frappe.get_doc("Air Consolidation", consolidation_name)
+	if not getattr(consol, "auto_send_eawb", 0) or not consol.master_awb:
+		return {"skipped": True, "reason": "Auto-send disabled or MAWB missing"}
+	return submit_consolidated_eawb(consol.master_awb)

--- a/logistics/air_freight/iata_cargo_xml/eawb_utils.py
+++ b/logistics/air_freight/iata_cargo_xml/eawb_utils.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2026, www.agilasoft.com and contributors
+# See license.txt
+
+from __future__ import unicode_literals
+
+from typing import Any, Dict, List, Optional
+
+import frappe
+from frappe.utils import flt
+
+FSU_STATUS_MAP = {
+	"ACC": "Accepted",
+	"RCS": "Ready for Carriage",
+	"FOH": "Freight on Hand",
+	"DEP": "Departed",
+	"ARR": "Arrived",
+	"DLV": "Delivered",
+	"RCF": "Ready for Collection",
+	"CCO": "Customs Cleared",
+	"NFD": "Notified for Delivery",
+	"BKD": "Booked",
+	"MAN": "Manifested",
+	"DIS": "Discrepancy",
+	"SPL": "Split Arrival",
+}
+
+SPLIT_FSU_CODES = {"SPL", "DIS"}
+
+
+def map_fsu_status(status_code: str, status_description: str = "") -> str:
+	code = (status_code or "").strip().upper()
+	return FSU_STATUS_MAP.get(code, status_description or code or "Exception")
+
+
+def resolve_special_handling_codes(
+	*,
+	airline: Optional[str] = None,
+	direction: Optional[str] = None,
+	paper_awb_required: bool = False,
+	manual_codes: Optional[str] = None,
+) -> List[str]:
+	"""Return IATA SHC list for e-AWB (ECC electronic contract / ECP paper companion)."""
+	if manual_codes:
+		return [c.strip().upper() for c in manual_codes.split(",") if c.strip()]
+
+	codes = ["ECC"] if not paper_awb_required else ["ECP"]
+	if airline:
+		extra = frappe.db.get_value("Airline", airline, "default_special_handling_codes")
+		if extra:
+			for code in extra.split(","):
+				code = code.strip().upper()
+				if code and code not in codes:
+					codes.append(code)
+	if direction == "Import":
+		for code in ("IMP",):
+			if code not in codes:
+				codes.append(code)
+	return codes
+
+
+def resolve_airline_endpoint(
+	settings,
+	airline: Optional[str] = None,
+	test_mode: bool = False,
+) -> Optional[str]:
+	"""Per-airline Cargo-XML endpoint override (Direct mode only)."""
+	if not airline or test_mode:
+		return None
+
+	if test_mode:
+		return frappe.db.get_value("Airline", airline, "cargo_xml_test_endpoint")
+
+	return frappe.db.get_value("Airline", airline, "cargo_xml_endpoint")
+
+
+def get_linked_shipments(master_awb_name: str) -> List[frappe.Document]:
+	names = frappe.get_all(
+		"Air Shipment",
+		filters={"master_awb": master_awb_name},
+		pluck="name",
+	)
+	return [frappe.get_doc("Air Shipment", name) for name in names]
+
+
+def aggregate_mawb_totals(master_awb_name: str) -> Dict[str, Any]:
+	shipments = get_linked_shipments(master_awb_name)
+	total_weight = 0.0
+	total_volume = 0.0
+	total_chargeable = 0.0
+	total_pieces = 0
+	primary_shipment = shipments[0] if shipments else None
+
+	for ship in shipments:
+		total_weight += flt(ship.weight)
+		total_volume += flt(ship.volume)
+		total_chargeable += flt(ship.chargeable or ship.weight)
+		if ship.packages:
+			for pkg in ship.packages:
+				total_pieces += int(pkg.no_of_packs or 1)
+
+	return {
+		"shipments": shipments,
+		"primary_shipment": primary_shipment,
+		"total_weight": total_weight,
+		"total_volume": total_volume,
+		"total_chargeable": total_chargeable or flt(
+			frappe.db.get_value("Master Air Waybill", master_awb_name, "booked_weight_kg")
+		),
+		"total_pieces": total_pieces,
+	}
+
+
+def collect_packages_for_security(shipments: List[frappe.Document]) -> List[Any]:
+	packages = []
+	for ship in shipments:
+		for pkg in ship.get("packages") or []:
+			packages.append(pkg)
+	return packages

--- a/logistics/air_freight/iata_cargo_xml/integrations/__init__.py
+++ b/logistics/air_freight/iata_cargo_xml/integrations/__init__.py
@@ -1,0 +1,1 @@
+# External IATA integration clients (CASS, TACT, DG AutoCheck)

--- a/logistics/air_freight/iata_cargo_xml/integrations/cass_client.py
+++ b/logistics/air_freight/iata_cargo_xml/integrations/cass_client.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2026, www.agilasoft.com and contributors
+# See license.txt
+
+from __future__ import unicode_literals
+
+from typing import Any, Dict
+
+import frappe
+import requests
+
+
+def submit_cass_settlement(tx, settings) -> Dict[str, Any]:
+	"""Submit CASS settlement request when CASSLink is enabled."""
+	if not settings or not settings.cass_enabled:
+		return {"success": False, "error": "CASSLink is not enabled"}
+
+	endpoint = settings.cass_api_endpoint
+	if not endpoint:
+		return {"success": False, "error": "CASS API endpoint is not configured"}
+
+	payload = {
+		"participant_code": tx.cass_participant_code or settings.cass_participant_code,
+		"air_shipment": tx.air_shipment,
+		"billing_reference": tx.cass_billing_reference,
+		"settlement_amount": tx.cass_settlement_amount,
+		"currency": tx.tact_currency,
+	}
+
+	response = requests.post(
+		endpoint,
+		json=payload,
+		timeout=30,
+		auth=_cass_auth(settings),
+	)
+	success = response.status_code in (200, 201, 202)
+	result = {"success": success, "status_code": response.status_code, "response": response.text[:1000]}
+	if not success:
+		result["error"] = response.text[:500]
+	return result
+
+
+def _cass_auth(settings):
+	user = getattr(settings, "cass_username", None) or settings.cargo_xml_username
+	password = None
+	if hasattr(settings, "get_password"):
+		password = settings.get_password("cass_password", raise_exception=False)
+		password = password or settings.get_password("cargo_xml_password", raise_exception=False)
+	if user and password:
+		return user, password
+	return None

--- a/logistics/air_freight/iata_cargo_xml/integrations/dg_autocheck_client.py
+++ b/logistics/air_freight/iata_cargo_xml/integrations/dg_autocheck_client.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2026, www.agilasoft.com and contributors
+# See license.txt
+
+from __future__ import unicode_literals
+
+from typing import Any, Dict, List
+
+import frappe
+import requests
+
+
+def validate_dangerous_goods(air_shipment: str, settings) -> Dict[str, Any]:
+	if not settings or not settings.dg_autocheck_enabled:
+		return {"success": False, "error": "DG AutoCheck is not enabled"}
+
+	api_key = settings.get_password("dg_autocheck_api_key", raise_exception=False) if hasattr(settings, "get_password") else None
+	if not api_key:
+		return {"success": False, "error": "DG AutoCheck API key is not configured"}
+
+	ship = frappe.get_doc("Air Shipment", air_shipment)
+	dg_lines: List[Dict[str, str]] = []
+	for pkg in ship.get("packages") or []:
+		if not pkg.dg_substance and not getattr(pkg, "un_number", None):
+			continue
+		dg_lines.append(
+			{
+				"un_number": getattr(pkg, "un_number", None) or pkg.dg_substance,
+				"dg_class": pkg.dg_class,
+				"packing_group": getattr(pkg, "packing_group", None),
+				"proper_shipping_name": getattr(pkg, "proper_shipping_name", None),
+			}
+		)
+
+	if not dg_lines:
+		return {"success": True, "message": "No dangerous goods on shipment", "validated": []}
+
+	endpoint = frappe.conf.get("iata_dg_autocheck_url") or "https://www.iata.org/api/dg-autocheck/validate"
+	response = requests.post(
+		endpoint,
+		json={"shipment": air_shipment, "items": dg_lines},
+		headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+		timeout=30,
+	)
+	success = response.status_code == 200
+	return {
+		"success": success,
+		"validated": dg_lines,
+		"response": response.text[:1000],
+		"error": None if success else response.text[:500],
+	}

--- a/logistics/air_freight/iata_cargo_xml/integrations/tact_client.py
+++ b/logistics/air_freight/iata_cargo_xml/integrations/tact_client.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2026, www.agilasoft.com and contributors
+# See license.txt
+
+from __future__ import unicode_literals
+
+from typing import Any, Dict
+
+import frappe
+import requests
+from frappe.utils import flt
+
+
+def lookup_tact_rate(air_shipment: str, settings) -> Dict[str, Any]:
+	if not settings or not settings.tact_subscription:
+		return {"success": False, "error": "TACT subscription is not enabled"}
+
+	endpoint = settings.tact_endpoint
+	api_key = settings.get_password("tact_api_key", raise_exception=False) if hasattr(settings, "get_password") else None
+	if not endpoint or not api_key:
+		return {"success": False, "error": "TACT endpoint or API key is not configured"}
+
+	ship = frappe.get_doc("Air Shipment", air_shipment)
+	payload = {
+		"origin": ship.origin_port,
+		"destination": ship.destination_port,
+		"chargeable_weight": flt(ship.chargeable or ship.weight),
+		"airline": ship.airline,
+	}
+
+	response = requests.post(
+		endpoint,
+		json=payload,
+		headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+		timeout=30,
+	)
+	if response.status_code != 200:
+		return {"success": False, "error": response.text[:500], "status_code": response.status_code}
+
+	data = response.json() if response.text else {}
+	return {
+		"success": True,
+		"tact_rate_reference": data.get("reference") or data.get("rate_id"),
+		"tact_rate_amount": flt(data.get("amount") or data.get("rate")),
+		"tact_currency": data.get("currency"),
+		"tact_rate_validity": data.get("valid_until"),
+		"raw": data,
+	}

--- a/logistics/air_freight/iata_cargo_xml/message_builder.py
+++ b/logistics/air_freight/iata_cargo_xml/message_builder.py
@@ -167,7 +167,14 @@ class MessageBuilder(IATAConnector):
                 resolve_company(air_shipment=air_freight_job_name)
             )
             xml_content = self.build_fwb_message(air_freight_job_name)
-            result = self.send_message("FWB", xml_content)
+            job = frappe.get_doc("Air Shipment", air_freight_job_name)
+            result = self.send_message(
+                "FWB",
+                xml_content,
+                reference_doctype="Air Shipment",
+                reference_name=air_freight_job_name,
+                airline=job.airline,
+            )
             
             # Queue message for tracking
             self._queue_message("FWB", "outbound", air_freight_job_name, xml_content)
@@ -187,7 +194,14 @@ class MessageBuilder(IATAConnector):
                 resolve_company(air_shipment=air_freight_job_name)
             )
             xml_content = self.build_fsu_message(air_freight_job_name, status_code, status_description)
-            result = self.send_message("FSU", xml_content)
+            job = frappe.get_doc("Air Shipment", air_freight_job_name)
+            result = self.send_message(
+                "FSU",
+                xml_content,
+                reference_doctype="Air Shipment",
+                reference_name=air_freight_job_name,
+                airline=job.airline,
+            )
             
             # Queue message for tracking
             self._queue_message("FSU", "outbound", air_freight_job_name, xml_content)
@@ -259,11 +273,13 @@ class MessageBuilder(IATAConnector):
 
             self._apply_company(resolve_company(master_awb=master_awb_name))
             xml_content = self.build_mawb_eawb_message(master_awb_name)
+            mawb = frappe.get_doc("Master Air Waybill", master_awb_name)
             result = self.send_message(
                 "XFWB",
                 xml_content,
                 reference_doctype="Master Air Waybill",
                 reference_name=master_awb_name,
+                airline=mawb.airline,
             )
 
             self._queue_message("XFWB", "outbound", master_awb_name, xml_content)

--- a/logistics/air_freight/iata_cargo_xml/message_builder.py
+++ b/logistics/air_freight/iata_cargo_xml/message_builder.py
@@ -7,9 +7,20 @@ import frappe
 from frappe import _
 import xml.etree.ElementTree as ET
 from datetime import datetime
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, List
 from .base_connector import IATAConnector
 from logistics.air_freight.utils.iata_airport import resolve_unloco_iata_code
+from logistics.air_freight.iata_cargo_xml.eawb_utils import (
+    aggregate_mawb_totals,
+    collect_packages_for_security,
+    resolve_special_handling_codes,
+)
+from logistics.air_freight.iata_cargo_xml.xml_helpers import (
+    add_charges,
+    add_oci_security,
+    add_special_handling_codes,
+)
+from logistics.air_freight.iata_cargo_xml.validation import validate_before_submit
 
 
 class MessageBuilder(IATAConnector):
@@ -249,6 +260,27 @@ class MessageBuilder(IATAConnector):
             self._add_flight_info(root, mawb)
             self._add_mawb_agents(root, mawb)
 
+            agg = aggregate_mawb_totals(master_awb_name)
+            primary = agg.get("primary_shipment")
+            if primary:
+                self._add_shipper_consignee(root, primary)
+            cargo = ET.SubElement(root, "Cargo")
+            cargo.set("TotalWeight", str(agg.get("total_weight") or 0))
+            cargo.set("TotalVolume", str(agg.get("total_volume") or 0))
+            cargo.set("ChargeableWeight", str(agg.get("total_chargeable") or 0))
+            cargo.set("TotalPieces", str(agg.get("total_pieces") or 0))
+
+            if primary and primary.get("charges"):
+                add_charges(root, primary.charges)
+
+            shc_codes = resolve_special_handling_codes(
+                airline=mawb.airline,
+                paper_awb_required=getattr(mawb, "paper_awb_required", 0),
+                manual_codes=getattr(mawb, "special_handling_codes", None),
+            )
+            add_special_handling_codes(root, shc_codes)
+            add_oci_security(root, collect_packages_for_security(agg.get("shipments") or []))
+
             xml_str = ET.tostring(root, encoding="unicode", method="xml")
 
             self.log_transaction({
@@ -273,6 +305,11 @@ class MessageBuilder(IATAConnector):
 
             self._apply_company(resolve_company(master_awb=master_awb_name))
             xml_content = self.build_mawb_eawb_message(master_awb_name)
+            validation = validate_before_submit(xml_content, "XFWB", self.settings, self)
+            if not validation.get("valid"):
+                raise frappe.ValidationError(
+                    _("Master e-AWB validation failed: {0}").format(validation.get("errors"))
+                )
             mawb = frappe.get_doc("Master Air Waybill", master_awb_name)
             result = self.send_message(
                 "XFWB",
@@ -281,6 +318,7 @@ class MessageBuilder(IATAConnector):
                 reference_name=master_awb_name,
                 airline=mawb.airline,
             )
+            result["validation"] = validation
 
             self._queue_message("XFWB", "outbound", master_awb_name, xml_content)
 
@@ -289,6 +327,99 @@ class MessageBuilder(IATAConnector):
         except Exception as e:
             frappe.log_error(f"Send XFWB error: {str(e)}")
             raise
+
+    def build_house_eawb_message(self, air_shipment_name: str) -> str:
+        """Build XFZB (House e-AWB) Cargo-XML message."""
+        job = frappe.get_doc("Air Shipment", air_shipment_name)
+        root = ET.Element("XFZB")
+        root.set("xmlns", self.namespace)
+        self._add_message_header(root, "XFZB", job.name)
+        self._add_air_waybill_info(root, job)
+        awb = root.find("AirWaybill")
+        if awb is not None and job.house_awb_no:
+            awb.set("AWBNo", str(job.house_awb_no).replace("-", "").replace(" ", ""))
+            awb.set("AWBType", "H")
+        self._add_origin_destination(root, job)
+        self._add_shipper_consignee(root, job)
+        self._add_cargo_details(root, job)
+        self._add_routing_info(root, job)
+        self._add_handling_info(root, job)
+        if job.get("charges"):
+            add_charges(root, job.charges)
+        shc_codes = resolve_special_handling_codes(
+            airline=job.airline,
+            direction=job.direction,
+            manual_codes=getattr(job, "special_handling_codes", None),
+        )
+        add_special_handling_codes(root, shc_codes)
+        add_oci_security(root, list(job.get("packages") or []))
+        return ET.tostring(root, encoding="unicode", method="xml")
+
+    def send_house_eawb_message(self, air_shipment_name: str) -> Dict[str, Any]:
+        from logistics.air_freight.utils.iata_settings_utils import resolve_company
+
+        self._apply_company(resolve_company(air_shipment=air_shipment_name))
+        xml_content = self.build_house_eawb_message(air_shipment_name)
+        job = frappe.get_doc("Air Shipment", air_shipment_name)
+        validation = validate_before_submit(xml_content, "XFZB", self.settings, self)
+        if not validation.get("valid"):
+            raise frappe.ValidationError(_("House e-AWB validation failed: {0}").format(validation.get("errors")))
+
+        result = self.send_message(
+            "XFZB",
+            xml_content,
+            reference_doctype="Air Shipment",
+            reference_name=air_shipment_name,
+            airline=job.airline,
+        )
+        result["validation"] = validation
+        self._queue_message("XFZB", "outbound", air_shipment_name, xml_content)
+        return result
+
+    def build_xfhl_message(self, master_awb_name: str, air_shipment_name: str) -> str:
+        """Build XFHL house manifest line for a shipment under a MAWB."""
+        mawb = frappe.get_doc("Master Air Waybill", master_awb_name)
+        job = frappe.get_doc("Air Shipment", air_shipment_name)
+        root = ET.Element("XFHL")
+        root.set("xmlns", self.namespace)
+        self._add_message_header(root, "XFHL", f"{mawb.name}_{job.name}")
+        master_ref = ET.SubElement(root, "MasterAirWaybill")
+        master_ref.set("AWBNo", (mawb.master_awb_no or "").replace("-", "").replace(" ", ""))
+        house = ET.SubElement(root, "HouseWaybill")
+        house.set("AWBNo", (job.house_awb_no or job.name).replace("-", "").replace(" ", ""))
+        house.set("Pieces", str(job.packs or 0))
+        house.set("Weight", str(job.weight or 0))
+        if job.shipper:
+            shipper_doc = frappe.get_doc("Shipper", job.shipper)
+            house.set("ShipperName", shipper_doc.shipper_name or "")
+        if job.consignee:
+            consignee_doc = frappe.get_doc("Consignee", job.consignee)
+            house.set("ConsigneeName", consignee_doc.consignee_name or "")
+        return ET.tostring(root, encoding="unicode", method="xml")
+
+    def send_xfhl_for_mawb(self, master_awb_name: str) -> List[Dict[str, Any]]:
+        from logistics.air_freight.utils.iata_settings_utils import resolve_company
+
+        self._apply_company(resolve_company(master_awb=master_awb_name))
+        mawb = frappe.get_doc("Master Air Waybill", master_awb_name)
+        results = []
+        for ship_name in frappe.get_all(
+            "Air Shipment", filters={"master_awb": master_awb_name}, pluck="name"
+        ):
+            xml_content = self.build_xfhl_message(master_awb_name, ship_name)
+            validation = validate_before_submit(xml_content, "XFHL", self.settings, self)
+            result = self.send_message(
+                "XFHL",
+                xml_content,
+                reference_doctype="Air Shipment",
+                reference_name=ship_name,
+                airline=mawb.airline,
+            )
+            result["validation"] = validation
+            result["air_shipment"] = ship_name
+            self._queue_message("XFHL", "outbound", ship_name, xml_content)
+            results.append(result)
+        return results
 
     def _add_mawb_air_waybill_info(self, root: ET.Element, mawb):
         awb = ET.SubElement(root, "AirWaybill")

--- a/logistics/air_freight/iata_cargo_xml/message_parser.py
+++ b/logistics/air_freight/iata_cargo_xml/message_parser.py
@@ -9,311 +9,399 @@ from datetime import datetime
 from typing import Any, Dict, Optional
 
 from .base_connector import IATAConnector
+from logistics.air_freight.iata_cargo_xml.eawb_utils import (
+	SPLIT_FSU_CODES,
+	map_fsu_status,
+)
 
 
 class MessageParser(IATAConnector):
-    """Parses incoming IATA Cargo-XML messages"""
-    
-    def __init__(self):
-        super().__init__()
-        self.namespace = "http://www.iata.org/IATA/CargoXML/1.0"
-    
-    def process_incoming_message(self, xml_content: str, message_type: str) -> Dict[str, Any]:
-        """Process incoming XML message"""
-        try:
-            # Parse XML
-            root = ET.fromstring(xml_content)
-            
-            # Extract message data
-            message_data = self._extract_message_data(root, message_type)
-            
-            # Process based on message type
-            if message_type == "FSU":
-                result = self._process_fsu_message(message_data)
-            elif message_type == "FMA":
-                result = self._process_fma_message(message_data)
-            elif message_type == "FWB":
-                result = self._process_fwb_message(message_data)
-            else:
-                result = {"success": False, "error": f"Unsupported message type: {message_type}"}
-            
-            # Log processing
-            self.log_transaction({
-                "message_type": message_type,
-                "direction": "inbound",
-                "status": "processed" if result["success"] else "failed",
-                "message_data": message_data,
-                "response_content": str(result)
-            })
-            
-            return result
-            
-        except Exception as e:
-            frappe.log_error(f"Message parsing error: {str(e)}")
-            return {"success": False, "error": str(e)}
-    
-    def _process_fsu_message(self, message_data: Dict[str, Any]) -> Dict[str, Any]:
-        """Process FSU (Freight Status Update) message"""
-        try:
-            awb_number = message_data.get("awb_number")
-            status_code = message_data.get("status_code")
-            status_description = message_data.get("status_description")
-            
-            if not awb_number:
-                return {"success": False, "error": "AWB number not found in FSU message"}
-            
-            # Find air freight job by AWB number
-            job = self._find_job_by_awb(awb_number)
-            if not job:
-                return {"success": False, "error": f"No job found for AWB: {awb_number}"}
-            
-            # Update job status based on FSU status
-            self._update_job_status(job, status_code, status_description)
-            
-            # Create milestone entry
-            self._create_milestone(job.name, status_code, status_description)
-            
-            return {
-                "success": True,
-                "job_updated": job.name,
-                "status_code": status_code,
-                "status_description": status_description
-            }
-            
-        except Exception as e:
-            frappe.log_error(f"FSU processing error: {str(e)}")
-            return {"success": False, "error": str(e)}
-    
-    def _process_fma_message(self, message_data: Dict[str, Any]) -> Dict[str, Any]:
-        """Process FMA (Freight Movement Advice) message"""
-        try:
-            flight_number = message_data.get("flight_number")
-            flight_date = message_data.get("flight_date")
-            
-            if not flight_number:
-                return {"success": False, "error": "Flight number not found in FMA message"}
-            
-            # Find master AWB by flight number
-            mawb = self._find_mawb_by_flight(flight_number, flight_date)
-            if not mawb:
-                return {"success": False, "error": f"No MAWB found for flight: {flight_number}"}
-            
-            # Update flight information
-            mawb.flight_no = flight_number
-            if flight_date:
-                mawb.origin_receipt_requested = datetime.strptime(flight_date, "%Y-%m-%d").date()
-            mawb.save()
-            
-            return {
-                "success": True,
-                "mawb_updated": mawb.name,
-                "flight_number": flight_number,
-                "flight_date": flight_date
-            }
-            
-        except Exception as e:
-            frappe.log_error(f"FMA processing error: {str(e)}")
-            return {"success": False, "error": str(e)}
-    
-    def _process_fwb_message(self, message_data: Dict[str, Any]) -> Dict[str, Any]:
-        """Process FWB (Freight Waybill) message - typically for confirmation"""
-        try:
-            awb_number = message_data.get("awb_number")
-            origin_airport = message_data.get("origin_airport")
-            destination_airport = message_data.get("destination_airport")
-            
-            if not awb_number:
-                return {"success": False, "error": "AWB number not found in FWB message"}
-            
-            # Find or create air freight job
-            job = self._find_job_by_awb(awb_number)
-            if not job:
-                # Create new job from FWB data
-                job = self._create_job_from_fwb(message_data)
-            else:
-                # Update existing job
-                self._update_job_from_fwb(job, message_data)
-            
-            return {
-                "success": True,
-                "job_processed": job.name,
-                "action": "created" if not job.get("__islocal") else "updated"
-            }
-            
-        except Exception as e:
-            frappe.log_error(f"FWB processing error: {str(e)}")
-            return {"success": False, "error": str(e)}
-    
-    def _find_job_by_awb(self, awb_number: str) -> Optional[frappe.Document]:
-        """Find air freight job by AWB number"""
-        try:
-            # First try to find by master AWB
-            jobs = frappe.get_all("Air Shipment",
-                                filters={"master_awb": awb_number},
-                                limit=1)
-            
-            if jobs:
-                return frappe.get_doc("Air Shipment", jobs[0].name)
-            
-            # Then try to find by job name (if AWB matches job name)
-            try:
-                return frappe.get_doc("Air Shipment", awb_number)
-            except Exception:
-                pass
-            
-            # Try to find in master AWB
-            mawbs = frappe.get_all("Master Air Waybill",
-                                 filters={"master_awb_no": awb_number},
-                                 limit=1)
-            
-            if mawbs:
-                # Find jobs linked to this MAWB
-                jobs = frappe.get_all("Air Shipment",
-                                    filters={"master_awb": mawbs[0].name},
-                                    limit=1)
-                if jobs:
-                    return frappe.get_doc("Air Shipment", jobs[0].name)
-            
-            return None
-            
-        except Exception as e:
-            frappe.log_error(f"Find job by AWB error: {str(e)}")
-            return None
-    
-    def _find_mawb_by_flight(self, flight_number: str, flight_date: str = None) -> Optional[frappe.Document]:
-        """Find master AWB by flight number"""
-        try:
-            filters = {"flight_no": flight_number}
-            if flight_date:
-                filters["origin_receipt_requested"] = datetime.strptime(flight_date, "%Y-%m-%d").date()
-            
-            mawbs = frappe.get_all("Master Air Waybill",
-                                 filters=filters,
-                                 limit=1)
-            
-            if mawbs:
-                return frappe.get_doc("Master Air Waybill", mawbs[0].name)
-            
-            return None
-            
-        except Exception as e:
-            frappe.log_error(f"Find MAWB by flight error: {str(e)}")
-            return None
-    
-    def _get_or_create_iata_tx(self, job):
-        """1:1 IATA / e-AWB / CASS / TACT document for this Air Shipment (child stores `air_shipment` link)."""
-        name = frappe.db.get_value("Air Shipment IATA Transaction", {"air_shipment": job.name}, "name")
-        if name:
-            return frappe.get_doc("Air Shipment IATA Transaction", name)
-        tx = frappe.get_doc({"doctype": "Air Shipment IATA Transaction", "air_shipment": job.name})
-        tx.flags.ignore_permissions = True
-        tx.insert()
-        return tx
+	"""Parses incoming IATA Cargo-XML messages"""
 
-    def _update_job_status(self, job: frappe.Document, status_code: str, status_description: str):
-        """Update job status based on FSU status"""
-        try:
-            # Map IATA status codes to internal status
-            status_mapping = {
-                "ACC": "Accepted",  # Cargo accepted
-                "DEP": "Departed",  # Departed
-                "ARR": "Arrived",   # Arrived
-                "DLV": "Delivered", # Delivered
-                "RCF": "Ready for Collection", # Ready for collection
-                "CCO": "Customs Cleared" # Customs cleared
-            }
-            
-            new_status = status_mapping.get(status_code, status_description)
-            tx = self._get_or_create_iata_tx(job)
-            tx.iata_status = new_status
-            tx.last_status_update = datetime.now()
-            tx.flags.ignore_permissions = True
-            tx.save()
-            
-        except Exception as e:
-            frappe.log_error(f"Update job status error: {str(e)}")
-    
-    def _create_milestone(self, job_name: str, status_code: str, status_description: str):
-        """Create milestone entry for status update"""
-        try:
-            milestone = frappe.get_doc({
-                "doctype": "Job Milestone",
-                "parent": job_name,
-                "parenttype": "Air Shipment",
-                "parentfield": "milestones",
-                "milestone": status_description,
-                "status": "Completed",
-                "expected_date": datetime.now().date(),
-                "actual_date": datetime.now().date()
-            })
-            milestone.insert(ignore_permissions=True)
-            
-        except Exception as e:
-            frappe.log_error(f"Create milestone error: {str(e)}")
-    
-    def _create_job_from_fwb(self, message_data: Dict[str, Any]) -> frappe.Document:
-        """Create new air freight job from FWB data"""
-        try:
-            job = frappe.get_doc({
-                "doctype": "Air Shipment",
-                "master_awb": message_data.get("awb_number"),
-                "direction": "Export",  # Default, should be determined from context
-                "origin_port": self._find_location_by_iata(message_data.get("origin_airport")),
-                "destination_port": self._find_location_by_iata(message_data.get("destination_airport")),
-                "booking_date": datetime.now().date(),
-            })
-            
-            job.insert(ignore_permissions=True)
-            tx = self._get_or_create_iata_tx(job)
-            tx.iata_status = "Received from IATA"
-            if message_data.get("message_id"):
-                tx.iata_message_id = message_data.get("message_id")
-            tx.last_status_update = datetime.now()
-            tx.flags.ignore_permissions = True
-            tx.save()
-            return job
-            
-        except Exception as e:
-            frappe.log_error(f"Create job from FWB error: {str(e)}")
-            raise
-    
-    def _update_job_from_fwb(self, job: frappe.Document, message_data: Dict[str, Any]):
-        """Update existing job from FWB data"""
-        try:
-            # Update relevant fields
-            if message_data.get("origin_airport"):
-                job.origin_port = self._find_location_by_iata(message_data.get("origin_airport"))
-            
-            if message_data.get("destination_airport"):
-                job.destination_port = self._find_location_by_iata(message_data.get("destination_airport"))
-            
-            tx = self._get_or_create_iata_tx(job)
-            tx.iata_status = "Confirmed via IATA"
-            if message_data.get("message_id"):
-                tx.iata_message_id = message_data.get("message_id")
-            tx.last_status_update = datetime.now()
-            tx.flags.ignore_permissions = True
-            tx.save()
-            job.save()
-            
-        except Exception as e:
-            frappe.log_error(f"Update job from FWB error: {str(e)}")
-    
-    def _find_location_by_iata(self, iata_code: str) -> Optional[str]:
-        """Find location by IATA code"""
-        try:
-            if not iata_code:
-                return None
-            
-            locations = frappe.get_all("Location",
-                                     filters={"custom_iata_code": iata_code},
-                                     limit=1)
-            
-            if locations:
-                return locations[0].name
-            
-            return None
-            
-        except Exception as e:
-            frappe.log_error(f"Find location by IATA error: {str(e)}")
-            return None
+	def __init__(self):
+		super().__init__()
+		self.namespace = "http://www.iata.org/IATA/CargoXML/1.0"
+
+	def process_incoming_message(self, xml_content: str, message_type: str) -> Dict[str, Any]:
+		"""Process incoming XML message"""
+		try:
+			root = ET.fromstring(xml_content)
+			message_data = self._extract_message_data(root, message_type)
+			message_data = self._augment_inbound_data(root, message_type, message_data, xml_content)
+
+			if message_type in ("FSU", "XFSU"):
+				result = self._process_fsu_message(message_data)
+			elif message_type in ("FMA", "XFMA"):
+				result = self._process_fma_message(message_data)
+			elif message_type in ("FWB", "XFWB"):
+				result = self._process_fwb_message(message_data)
+			elif message_type in ("XFNM", "FNA"):
+				result = self._process_xfnm_message(message_data, xml_content)
+			elif message_type in ("XFHL", "FHL"):
+				result = self._process_xfhl_message(message_data)
+			else:
+				result = {"success": False, "error": f"Unsupported message type: {message_type}"}
+
+			self.log_transaction({
+				"message_type": message_type,
+				"direction": "inbound",
+				"status": "processed" if result.get("success") else "failed",
+				"message_data": message_data,
+				"response_content": str(result),
+			})
+			return result
+
+		except Exception as e:
+			frappe.log_error(f"Message parsing error: {str(e)}")
+			return {"success": False, "error": str(e)}
+
+	def _process_fsu_message(self, message_data: Dict[str, Any]) -> Dict[str, Any]:
+		try:
+			awb_number = message_data.get("awb_number")
+			status_code = (message_data.get("status_code") or "").upper()
+			status_description = message_data.get("status_description")
+
+			if not awb_number:
+				return {"success": False, "error": "AWB number not found in FSU message"}
+
+			job = self._find_job_by_awb(awb_number)
+			mawb = None
+			if not job:
+				mawb = self._find_mawb_by_awb_no(awb_number)
+				if mawb:
+					job = self._find_primary_shipment_for_mawb(mawb.name)
+
+			if not job and not mawb:
+				return {"success": False, "error": f"No job found for AWB: {awb_number}"}
+
+			if status_code in SPLIT_FSU_CODES:
+				self._handle_split_arrival(job, message_data)
+
+			if job:
+				self._update_job_status(job, status_code, status_description)
+				self._create_milestone(job.name, status_code, status_description)
+
+			if mawb and status_code == "RCS":
+				mawb.eawb_status = "Accepted"
+				mawb.flags.ignore_permissions = True
+				mawb.save(ignore_permissions=True)
+
+			return {
+				"success": True,
+				"job_updated": job.name if job else None,
+				"mawb_updated": mawb.name if mawb else None,
+				"status_code": status_code,
+				"status_description": status_description,
+			}
+
+		except Exception as e:
+			frappe.log_error(f"FSU processing error: {str(e)}")
+			return {"success": False, "error": str(e)}
+
+	def _process_xfnm_message(self, message_data: Dict[str, Any], xml_content: str) -> Dict[str, Any]:
+		"""Process negative acknowledgement / error messages."""
+		awb_number = message_data.get("awb_number")
+		error_text = message_data.get("error_text") or xml_content[:500]
+		target = None
+
+		if awb_number:
+			mawb = self._find_mawb_by_awb_no(awb_number)
+			if mawb:
+				mawb.eawb_status = "Rejected"
+				mawb.flags.ignore_permissions = True
+				mawb.save(ignore_permissions=True)
+				target = mawb.name
+			else:
+				job = self._find_job_by_awb(awb_number)
+				if job:
+					tx = self._get_or_create_iata_tx(job)
+					tx.eawb_status = "Rejected"
+					tx.iata_message_id = message_data.get("message_id")
+					tx.last_status_update = datetime.now()
+					tx.flags.ignore_permissions = True
+					tx.save(ignore_permissions=True)
+					target = job.name
+
+		return {
+			"success": True,
+			"rejected": True,
+			"target": target,
+			"error": error_text,
+		}
+
+	def _process_xfhl_message(self, message_data: Dict[str, Any]) -> Dict[str, Any]:
+		awb_number = message_data.get("awb_number")
+		if not awb_number:
+			return {"success": False, "error": "House AWB number missing in XFHL"}
+		job = self._find_job_by_awb(awb_number)
+		if not job:
+			return {"success": False, "error": f"No shipment for house AWB {awb_number}"}
+		tx = self._get_or_create_iata_tx(job)
+		tx.iata_status = "Manifest Confirmed"
+		tx.last_status_update = datetime.now()
+		tx.flags.ignore_permissions = True
+		tx.save(ignore_permissions=True)
+		return {"success": True, "job_updated": job.name}
+
+	def _handle_split_arrival(self, job: Optional[frappe.Document], message_data: Dict[str, Any]):
+		if not job:
+			return
+		split_qty = message_data.get("split_pieces") or message_data.get("pieces")
+		frappe.get_doc({
+			"doctype": "Comment",
+			"comment_type": "Info",
+			"reference_doctype": "Air Shipment",
+			"reference_name": job.name,
+			"content": f"Split arrival reported by carrier. Pieces: {split_qty or 'unknown'}",
+		}).insert(ignore_permissions=True)
+		tx = self._get_or_create_iata_tx(job)
+		tx.iata_status = "Split Arrival"
+		tx.last_status_update = datetime.now()
+		tx.flags.ignore_permissions = True
+		tx.save(ignore_permissions=True)
+
+	def _find_mawb_by_awb_no(self, awb_number: str) -> Optional[frappe.Document]:
+		clean = (awb_number or "").replace("-", "").replace(" ", "")
+		name = frappe.db.get_value("Master Air Waybill", {"master_awb_no": clean}, "name")
+		if not name:
+			name = frappe.db.get_value("Master Air Waybill", {"master_awb_no": awb_number}, "name")
+		return frappe.get_doc("Master Air Waybill", name) if name else None
+
+	def _find_primary_shipment_for_mawb(self, mawb_name: str) -> Optional[frappe.Document]:
+		ship_name = frappe.db.get_value("Air Shipment", {"master_awb": mawb_name}, "name")
+		return frappe.get_doc("Air Shipment", ship_name) if ship_name else None
+
+	def _process_fma_message(self, message_data: Dict[str, Any]) -> Dict[str, Any]:
+		try:
+			flight_number = message_data.get("flight_number")
+			flight_date = message_data.get("flight_date")
+
+			if not flight_number:
+				return {"success": False, "error": "Flight number not found in FMA message"}
+
+			mawb = self._find_mawb_by_flight(flight_number, flight_date)
+			if not mawb:
+				return {"success": False, "error": f"No MAWB found for flight: {flight_number}"}
+
+			mawb.flight_no = flight_number
+			if flight_date:
+				mawb.origin_receipt_requested = datetime.strptime(flight_date, "%Y-%m-%d").date()
+			mawb.save()
+
+			return {
+				"success": True,
+				"mawb_updated": mawb.name,
+				"flight_number": flight_number,
+				"flight_date": flight_date,
+			}
+
+		except Exception as e:
+			frappe.log_error(f"FMA processing error: {str(e)}")
+			return {"success": False, "error": str(e)}
+
+	def _process_fwb_message(self, message_data: Dict[str, Any]) -> Dict[str, Any]:
+		try:
+			awb_number = message_data.get("awb_number")
+			origin_airport = message_data.get("origin_airport")
+			destination_airport = message_data.get("destination_airport")
+
+			if not awb_number:
+				return {"success": False, "error": "AWB number not found in FWB message"}
+
+			job = self._find_job_by_awb(awb_number)
+			if not job:
+				job = self._create_job_from_fwb(message_data)
+			else:
+				self._update_job_from_fwb(job, message_data)
+
+			return {
+				"success": True,
+				"job_processed": job.name,
+				"action": "created" if not job.get("__islocal") else "updated",
+			}
+
+		except Exception as e:
+			frappe.log_error(f"FWB processing error: {str(e)}")
+			return {"success": False, "error": str(e)}
+
+	def _find_job_by_awb(self, awb_number: str) -> Optional[frappe.Document]:
+		try:
+			jobs = frappe.get_all(
+				"Air Shipment",
+				filters={"master_awb": awb_number},
+				limit=1,
+			)
+			if jobs:
+				return frappe.get_doc("Air Shipment", jobs[0].name)
+
+			jobs = frappe.get_all(
+				"Air Shipment",
+				filters={"house_awb_no": awb_number},
+				limit=1,
+			)
+			if jobs:
+				return frappe.get_doc("Air Shipment", jobs[0].name)
+
+			try:
+				return frappe.get_doc("Air Shipment", awb_number)
+			except Exception:
+				pass
+
+			mawbs = frappe.get_all(
+				"Master Air Waybill",
+				filters={"master_awb_no": awb_number},
+				limit=1,
+			)
+			if mawbs:
+				jobs = frappe.get_all(
+					"Air Shipment",
+					filters={"master_awb": mawbs[0].name},
+					limit=1,
+				)
+				if jobs:
+					return frappe.get_doc("Air Shipment", jobs[0].name)
+
+			return None
+
+		except Exception as e:
+			frappe.log_error(f"Find job by AWB error: {str(e)}")
+			return None
+
+	def _find_mawb_by_flight(self, flight_number: str, flight_date: str = None) -> Optional[frappe.Document]:
+		try:
+			filters = {"flight_no": flight_number}
+			if flight_date:
+				filters["origin_receipt_requested"] = datetime.strptime(flight_date, "%Y-%m-%d").date()
+
+			mawbs = frappe.get_all("Master Air Waybill", filters=filters, limit=1)
+			if mawbs:
+				return frappe.get_doc("Master Air Waybill", mawbs[0].name)
+			return None
+
+		except Exception as e:
+			frappe.log_error(f"Find MAWB by flight error: {str(e)}")
+			return None
+
+	def _get_or_create_iata_tx(self, job):
+		name = frappe.db.get_value("Air Shipment IATA Transaction", {"air_shipment": job.name}, "name")
+		if name:
+			return frappe.get_doc("Air Shipment IATA Transaction", name)
+		tx = frappe.get_doc({"doctype": "Air Shipment IATA Transaction", "air_shipment": job.name})
+		tx.flags.ignore_permissions = True
+		tx.insert()
+		return tx
+
+	def _update_job_status(self, job: frappe.Document, status_code: str, status_description: str):
+		try:
+			new_status = map_fsu_status(status_code, status_description)
+			tx = self._get_or_create_iata_tx(job)
+			tx.iata_status = new_status
+			tx.last_status_update = datetime.now()
+			if status_code == "RCS":
+				tx.eawb_status = "Accepted"
+			tx.flags.ignore_permissions = True
+			tx.save()
+		except Exception as e:
+			frappe.log_error(f"Update job status error: {str(e)}")
+
+	def _create_milestone(self, job_name: str, status_code: str, status_description: str):
+		try:
+			label = map_fsu_status(status_code, status_description)
+			milestone = frappe.get_doc({
+				"doctype": "Job Milestone",
+				"parent": job_name,
+				"parenttype": "Air Shipment",
+				"parentfield": "milestones",
+				"milestone": label,
+				"status": "Completed",
+				"expected_date": datetime.now().date(),
+				"actual_date": datetime.now().date(),
+			})
+			milestone.insert(ignore_permissions=True)
+		except Exception as e:
+			frappe.log_error(f"Create milestone error: {str(e)}")
+
+	def _create_job_from_fwb(self, message_data: Dict[str, Any]) -> frappe.Document:
+		try:
+			job = frappe.get_doc({
+				"doctype": "Air Shipment",
+				"master_awb": message_data.get("awb_number"),
+				"direction": "Export",
+				"origin_port": self._find_location_by_iata(message_data.get("origin_airport")),
+				"destination_port": self._find_location_by_iata(message_data.get("destination_airport")),
+				"booking_date": datetime.now().date(),
+			})
+			job.insert(ignore_permissions=True)
+			tx = self._get_or_create_iata_tx(job)
+			tx.iata_status = "Received from IATA"
+			if message_data.get("message_id"):
+				tx.iata_message_id = message_data.get("message_id")
+			tx.last_status_update = datetime.now()
+			tx.flags.ignore_permissions = True
+			tx.save()
+			return job
+		except Exception as e:
+			frappe.log_error(f"Create job from FWB error: {str(e)}")
+			raise
+
+	def _update_job_from_fwb(self, job: frappe.Document, message_data: Dict[str, Any]):
+		try:
+			if message_data.get("origin_airport"):
+				job.origin_port = self._find_location_by_iata(message_data.get("origin_airport"))
+			if message_data.get("destination_airport"):
+				job.destination_port = self._find_location_by_iata(message_data.get("destination_airport"))
+
+			tx = self._get_or_create_iata_tx(job)
+			tx.iata_status = "Confirmed via IATA"
+			if message_data.get("message_id"):
+				tx.iata_message_id = message_data.get("message_id")
+			tx.last_status_update = datetime.now()
+			tx.flags.ignore_permissions = True
+			tx.save()
+			job.save()
+		except Exception as e:
+			frappe.log_error(f"Update job from FWB error: {str(e)}")
+
+	def _find_location_by_iata(self, iata_code: str) -> Optional[str]:
+		try:
+			if not iata_code:
+				return None
+			locations = frappe.get_all("Location", filters={"custom_iata_code": iata_code}, limit=1)
+			if locations:
+				return locations[0].name
+			return None
+		except Exception as e:
+			frappe.log_error(f"Find location by IATA error: {str(e)}")
+			return None
+
+	def _augment_inbound_data(
+		self,
+		root: ET.Element,
+		message_type: str,
+		message_data: Dict[str, Any],
+		xml_content: str,
+	) -> Dict[str, Any]:
+		message_data = dict(message_data or {})
+		if message_type in ("FSU", "XFSU"):
+			status = self._find_element(root, "StatusUpdate")
+			if status is not None:
+				message_data.setdefault("status_code", status.get("StatusCode"))
+				message_data.setdefault("status_description", status.get("StatusDescription"))
+				if status.get("Pieces"):
+					message_data["split_pieces"] = status.get("Pieces")
+		if message_type in ("XFNM", "FNA"):
+			message_data["error_text"] = xml_content[:1000]
+			for elem in root.iter():
+				tag = elem.tag.split("}")[-1]
+				if tag in ("Error", "Reason", "Remarks") and elem.text:
+					message_data["error_text"] = elem.text
+		return message_data
+
+	def _find_element(self, root: ET.Element, local_name: str):
+		found = root.find(local_name)
+		if found is not None:
+			return found
+		for elem in root.iter():
+			if elem.tag.split("}")[-1] == local_name:
+				return elem
+		return None

--- a/logistics/air_freight/iata_cargo_xml/validation.py
+++ b/logistics/air_freight/iata_cargo_xml/validation.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026, www.agilasoft.com and contributors
+# See license.txt
+
+from __future__ import unicode_literals
+
+from typing import Any, Dict, Optional
+
+import frappe
+import requests
+
+
+def validate_before_submit(
+	content: str,
+	message_type: str,
+	settings=None,
+	connector=None,
+) -> Dict[str, Any]:
+	"""Local schema checks plus optional remote IATA Cargo-XML AutoCheck validation."""
+	from logistics.air_freight.iata_cargo_xml.base_connector import IATAConnector
+
+	connector = connector or IATAConnector()
+	local = connector.validate_message(content, message_type)
+	if not local.get("valid"):
+		return local
+
+	autocheck_url = None
+	if settings:
+		autocheck_url = getattr(settings, "cargo_xml_autocheck_url", None)
+
+	if not autocheck_url:
+		return local
+
+	try:
+		response = requests.post(
+			autocheck_url,
+			data=content,
+			headers={"Content-Type": "application/xml", "Accept": "application/json"},
+			timeout=30,
+		)
+		if response.status_code != 200:
+			local.setdefault("warnings", []).append(
+				f"AutoCheck HTTP {response.status_code}: {response.text[:200]}"
+			)
+			return local
+
+		payload = response.json() if "json" in (response.headers.get("Content-Type") or "") else {}
+		if payload.get("valid") is False:
+			errors = payload.get("errors") or [payload.get("message") or "AutoCheck rejected message"]
+			return {"valid": False, "errors": errors, "warnings": local.get("warnings", [])}
+
+		local.setdefault("warnings", []).append("Passed remote Cargo-XML AutoCheck")
+		return local
+	except Exception as exc:
+		frappe.log_error(f"Cargo-XML AutoCheck error: {exc}")
+		local.setdefault("warnings", []).append(f"AutoCheck unavailable: {exc}")
+		return local

--- a/logistics/air_freight/iata_cargo_xml/webhook_auth.py
+++ b/logistics/air_freight/iata_cargo_xml/webhook_auth.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2026, www.agilasoft.com and contributors
+# See license.txt
+
+from __future__ import unicode_literals
+
+import frappe
+from frappe import _
+
+
+def verify_inbound_webhook(company: str = None) -> bool:
+	"""Validate inbound Cargo-XML webhook using API key or logged-in system user."""
+	from logistics.air_freight.utils.iata_settings_utils import get_settings
+
+	if frappe.session.user and frappe.session.user != "Guest":
+		return True
+
+	settings = get_settings(company=company)
+	if not settings:
+		frappe.throw(_("IATA Settings not found"), frappe.AuthenticationError)
+
+	expected_key = settings.get_password("webhook_api_key", raise_exception=False)
+	header_key = frappe.get_request_header("X-IATA-Webhook-Key")
+	if expected_key:
+		if header_key and header_key == expected_key:
+			return True
+		frappe.throw(_("Invalid webhook API key"), frappe.AuthenticationError)
+
+	# No key configured — require Authorization bearer matching site config fallback.
+	auth_header = frappe.get_request_header("Authorization") or ""
+	site_key = frappe.conf.get("iata_webhook_api_key")
+	if site_key and auth_header == f"Bearer {site_key}":
+		return True
+
+	frappe.throw(
+		_("Inbound IATA webhook requires authentication. Configure Webhook API Key in IATA Settings."),
+		frappe.AuthenticationError,
+	)

--- a/logistics/air_freight/iata_cargo_xml/xml_helpers.py
+++ b/logistics/air_freight/iata_cargo_xml/xml_helpers.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2026, www.agilasoft.com and contributors
+# See license.txt
+
+from __future__ import unicode_literals
+
+import xml.etree.ElementTree as ET
+from typing import Any, Iterable, List, Optional
+
+
+def add_special_handling_codes(parent: ET.Element, codes: Iterable[str]) -> None:
+	shc_parent = ET.SubElement(parent, "SpecialHandlingCodes")
+	for code in codes:
+		code = (code or "").strip().upper()
+		if code:
+			item = ET.SubElement(shc_parent, "SpecialHandlingCode")
+			item.set("Code", code)
+
+
+def add_oci_security(parent: ET.Element, packages: List[Any]) -> None:
+	"""Add e-CSD / OCI security declaration entries from package DG/security fields."""
+	oci = ET.SubElement(parent, "OtherCustomsInformation")
+	for pkg in packages:
+		if not getattr(pkg, "dg_substance", None) and not getattr(pkg, "un_number", None):
+			continue
+		entry = ET.SubElement(oci, "OCIEntry")
+		entry.set("CountryCode", "XX")
+		entry.set("InformationIdentifier", "CSD")
+		entry.set("ControlInformation", "SECURITY")
+		if getattr(pkg, "un_number", None):
+			entry.set("SupplementaryInformation", str(pkg.un_number))
+		if getattr(pkg, "dg_class", None):
+			entry.set("Note", f"Class {pkg.dg_class}")
+
+
+def add_charges(parent: ET.Element, charges: List[Any]) -> None:
+	if not charges:
+		return
+	charges_elem = ET.SubElement(parent, "Charges")
+	total = 0.0
+	for charge in charges:
+		amount = float(getattr(charge, "base_amount", None) or getattr(charge, "amount", 0) or 0)
+		if not amount:
+			continue
+		row = ET.SubElement(charges_elem, "Charge")
+		row.set("Code", getattr(charge, "charge_code", None) or getattr(charge, "item_code", None) or "FREIGHT")
+		row.set("Amount", str(amount))
+		row.set("Currency", getattr(charge, "currency", None) or "USD")
+		total += amount
+	charges_elem.set("TotalAmount", str(total))

--- a/logistics/air_freight/tests/test_ccs_connector.py
+++ b/logistics/air_freight/tests/test_ccs_connector.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2026, www.agilasoft.com and contributors
+# See license.txt
+
+import random
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import today
+
+from logistics.air_freight.iata_cargo_xml.base_connector import IATAConnector
+from logistics.air_freight.iata_cargo_xml.ccs.base import ChampTraxonConnector
+from logistics.air_freight.iata_cargo_xml.ccs.factory import get_ccs_connector, uses_ccs_hub
+from logistics.air_freight.iata_cargo_xml.ccs.routing import resolve_airline_pima
+from logistics.air_freight.iata_cargo_xml.message_builder import MessageBuilder
+from logistics.air_freight.tests.test_helpers import create_test_airline
+
+
+class TestCCSConnector(FrappeTestCase):
+	def setUp(self):
+		create_test_airline("TA", "Test Airline")
+		frappe.db.set_value("Airline", "TA", "ccs_pima_code", "TAFFWD")
+		self._ensure_ccs_provider()
+		self._ensure_iata_settings_ccs()
+		self.mawb = self._create_mawb()
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def _ensure_ccs_provider(self):
+		if not frappe.db.exists("CCS Provider", "CHAMP_TRAXON"):
+			frappe.get_doc(
+				{
+					"doctype": "CCS Provider",
+					"provider_code": "CHAMP_TRAXON",
+					"provider_name": "CHAMP TRAXON cargoHUB",
+					"connector_type": "champ_traxon",
+					"default_endpoint": "https://ccs.example/champ",
+					"test_endpoint": "https://ccs-sandbox.example/champ",
+					"requires_pima_routing": 1,
+					"is_active": 1,
+				}
+			).insert(ignore_permissions=True)
+
+	def _ensure_iata_settings_ccs(self):
+		from logistics.air_freight.utils.iata_settings_utils import get_settings
+
+		company = frappe.defaults.get_user_default("Company") or frappe.db.get_single_value(
+			"Global Defaults", "default_company"
+		)
+		if not company:
+			company = frappe.db.get_value("Company", {}, "name")
+
+		settings = get_settings(company=company)
+		if not settings:
+			settings = frappe.new_doc("IATA Settings")
+			settings.company = company
+			settings.flags.ignore_permissions = True
+			settings.flags.ignore_validate = True
+			settings.insert(ignore_permissions=True)
+
+		settings.cargo_xml_enabled = 1
+		settings.connection_mode = "CCS Hub"
+		settings.ccs_provider = "CHAMP_TRAXON"
+		settings.ccs_participant_code = "FFWD01"
+		settings.ccs_username = "ccs-user"
+		settings.ccs_password = "ccs-pass"
+		settings.test_mode = 0
+		settings.flags.ignore_permissions = True
+		settings.flags.ignore_validate = True
+		settings.save(ignore_permissions=True)
+
+	def _create_mawb(self):
+		mawb_no = f"12345{random.randint(100000, 999999)}"
+		doc = frappe.get_doc(
+			{
+				"doctype": "Master Air Waybill",
+				"master_awb_no": mawb_no,
+				"airline": "TA",
+				"flight_no": "TA100",
+				"flight_date": today(),
+				"origin_airport_iata": "SIN",
+				"destination_airport_iata": "LHR",
+			}
+		)
+		doc.flags.ignore_permissions = True
+		doc.insert(ignore_permissions=True)
+		return doc
+
+	def test_resolve_airline_pima_prefers_ccs_code(self):
+		self.assertEqual(resolve_airline_pima("TA"), "TAFFWD")
+
+	def test_uses_ccs_hub(self):
+		from logistics.air_freight.utils.iata_settings_utils import get_settings
+
+		settings = get_settings(company=self.mawb.company if hasattr(self.mawb, "company") else None)
+		self.assertTrue(uses_ccs_hub(settings))
+
+	def test_ccs_connector_builds_pima_headers(self):
+		from logistics.air_freight.utils.iata_settings_utils import get_settings
+
+		settings = get_settings()
+		connector = get_ccs_connector(settings)
+		self.assertIsInstance(connector, ChampTraxonConnector)
+
+		headers = connector.build_headers(
+			"XFWB",
+			"<XFWB/>",
+			{"airline_pima": "TAFFWD", "awb_number": "12345678901"},
+		)
+		self.assertEqual(headers["X-Sender-PIMA"], "FFWD01")
+		self.assertEqual(headers["X-Recipient-PIMA"], "TAFFWD")
+		self.assertEqual(headers["X-CHAMP-Provider"], "TRAXON")
+
+	def test_send_message_routes_through_ccs_hub(self):
+		builder = MessageBuilder()
+		xml = builder.build_mawb_eawb_message(self.mawb.name)
+
+		mock_response = MagicMock()
+		mock_response.status_code = 200
+		mock_response.text = '<Acknowledgement Status="Accepted" />'
+
+		with patch.object(builder.session, "post", return_value=mock_response) as mock_post:
+			result = builder.send_message(
+				"XFWB",
+				xml,
+				reference_doctype="Master Air Waybill",
+				reference_name=self.mawb.name,
+				airline="TA",
+			)
+
+		self.assertTrue(result["success"])
+		self.assertEqual(result["ccs_provider"], "CHAMP_TRAXON")
+		self.assertEqual(mock_post.call_args[0][0], "https://ccs.example/champ")
+		headers = mock_post.call_args[1]["headers"]
+		self.assertEqual(headers["X-Recipient-PIMA"], "TAFFWD")
+
+	def test_ccs_test_endpoint_used_in_test_mode(self):
+		from logistics.air_freight.utils.iata_settings_utils import get_settings
+
+		settings = get_settings()
+		settings.test_mode = 1
+		settings.flags.ignore_validate = True
+		settings.save(ignore_permissions=True)
+
+		connector = IATAConnector(company=settings.company)
+		endpoint, mode = connector._resolve_endpoint()
+		self.assertEqual(endpoint, "https://ccs-sandbox.example/champ")
+		self.assertIn("ccs", mode)

--- a/logistics/air_freight/tests/test_eawb_phases.py
+++ b/logistics/air_freight/tests/test_eawb_phases.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2026, www.agilasoft.com and contributors
+# See license.txt
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from logistics.air_freight.iata_cargo_xml.eawb_utils import map_fsu_status, resolve_special_handling_codes
+
+
+class TestEAWBPhases(FrappeTestCase):
+	def test_fsu_status_mapping_includes_rcs_foh(self):
+		self.assertEqual(map_fsu_status("RCS"), "Ready for Carriage")
+		self.assertEqual(map_fsu_status("FOH"), "Freight on Hand")
+		self.assertEqual(map_fsu_status("SPL"), "Split Arrival")
+
+	def test_special_handling_codes_default_ecc(self):
+		codes = resolve_special_handling_codes()
+		self.assertIn("ECC", codes)
+
+	def test_special_handling_codes_paper_awb(self):
+		codes = resolve_special_handling_codes(paper_awb_required=True)
+		self.assertIn("ECP", codes)
+
+	def tearDown(self):
+		frappe.db.rollback()

--- a/logistics/air_freight/utils/iata_settings_utils.py
+++ b/logistics/air_freight/utils/iata_settings_utils.py
@@ -7,6 +7,8 @@ import frappe
 
 PUBLIC_SETTINGS_FIELDS = (
 	"cargo_xml_enabled",
+	"connection_mode",
+	"ccs_provider",
 	"dg_autocheck_enabled",
 	"cass_enabled",
 	"tact_subscription",
@@ -99,6 +101,11 @@ def default_settings():
 		cargo_xml_enabled=0,
 		cargo_xml_endpoint=None,
 		cargo_xml_username=None,
+		connection_mode="Direct",
+		ccs_provider=None,
+		ccs_participant_code=None,
+		ccs_endpoint=None,
+		ccs_test_endpoint=None,
 		dg_autocheck_enabled=0,
 		cass_enabled=0,
 		tact_subscription=0,

--- a/logistics/patches.txt
+++ b/logistics/patches.txt
@@ -242,6 +242,8 @@ logistics.patches.v3_0_fix_iata_settings_single
 # IATA Settings: one record per Company (migrate legacy singleton values)
 logistics.patches.v3_0_migrate_iata_settings_per_company
 logistics.patches.v3_0_ensure_iata_settings_company_records
+# CCS Provider master records for Cargo Community System connectivity
+logistics.patches.v3_0_seed_ccs_providers
 # Docket Internal Jobs: restore persisted Internal Job Detail rows after virtual-grid rollback
 logistics.patches.v3_0_restore_docket_internal_job_detail_rows
 # Cash Advance: backfill request total_liquidated / unliquidated from submitted liquidations

--- a/logistics/patches/v3_0_seed_ccs_providers.py
+++ b/logistics/patches/v3_0_seed_ccs_providers.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2026, www.agilasoft.com and contributors
+# See license.txt
+
+from __future__ import unicode_literals
+
+import frappe
+
+
+PROVIDERS = (
+	{
+		"provider_code": "CHAMP_TRAXON",
+		"provider_name": "CHAMP TRAXON cargoHUB",
+		"connector_type": "champ_traxon",
+		"description": "Global air cargo community hub for Cargo-XML and Cargo-IMP messaging.",
+		"protocol": "HTTP REST",
+		"requires_pima_routing": 1,
+		"documentation_url": "https://www.champ.aero/products/ecargo/traxon-cargohub",
+	},
+	{
+		"provider_code": "WISE",
+		"provider_name": "WiseTech Global CCS",
+		"connector_type": "wise",
+		"description": "WiseTech cargo community connectivity for e-AWB and airline messaging.",
+		"protocol": "HTTP REST",
+		"requires_pima_routing": 1,
+	},
+	{
+		"provider_code": "DESCARTES",
+		"provider_name": "Descartes GLN",
+		"connector_type": "descartes",
+		"description": "Descartes Global Logistics Network for air cargo EDI.",
+		"protocol": "HTTP REST",
+		"requires_pima_routing": 1,
+	},
+	{
+		"provider_code": "CCNHUB",
+		"provider_name": "CCNhub",
+		"connector_type": "ccnhub",
+		"description": "IATA-sponsored cargo community hub for e-freight participants.",
+		"protocol": "HTTP REST",
+		"requires_pima_routing": 1,
+	},
+	{
+		"provider_code": "CUSTOM",
+		"provider_name": "Custom CCS Provider",
+		"connector_type": "generic",
+		"description": "Generic connector for a private or regional Cargo Community System.",
+		"protocol": "HTTP REST",
+		"requires_pima_routing": 1,
+	},
+)
+
+
+def execute():
+	if not frappe.db.exists("DocType", "CCS Provider"):
+		return
+
+	for row in PROVIDERS:
+		if frappe.db.exists("CCS Provider", row["provider_code"]):
+			doc = frappe.get_doc("CCS Provider", row["provider_code"])
+			for key, value in row.items():
+				setattr(doc, key, value)
+			doc.is_active = 1
+			doc.flags.ignore_permissions = True
+			doc.save(ignore_permissions=True)
+			continue
+
+		doc = frappe.get_doc({"doctype": "CCS Provider", **row, "is_active": 1})
+		doc.flags.ignore_permissions = True
+		doc.insert(ignore_permissions=True)
+
+	frappe.db.commit()
+	print("Seeded CCS Provider master records.")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements full e-AWB parity across three phases plus CCS provider connectivity.

### Phase 1 — Minimum viable live e-AWB
- Enriched **XFWB** with aggregated cargo, charges, **SHC codes** (ECC/ECP), and **e-CSD OCI** security data
- **House e-AWB (XFZB)** create → sign → **submit** workflow with UI buttons on IATA Transaction
- Inbound **RCS / FOH** and expanded FSU status mapping
- **Per-airline Cargo-XML endpoint** routing (Direct mode)
- Optional **Cargo-XML AutoCheck** pre-submit validation
- **Secured inbound webhook** via `X-IATA-Webhook-Key` or site bearer token

### Phase 2 — Consolidation parity
- **XFHL** house manifest builder and send for all houses on a MAWB
- **Submit Consolidated e-AWB** (master XFWB + all XFHL) from MAWB
- **Auto-send e-AWB** on Air Consolidation and MAWB (`send_awb_to_airline`)
- **XFNM** rejection parsing updates e-AWB status
- **Split arrival** FSU handling

### Phase 3 — Network & integrations
- **CCS Provider** hub connectivity (CHAMP TRAXON, Wise, Descartes, CCNhub, Custom) with PIMA routing
- Live **CASS**, **TACT**, and **DG AutoCheck** HTTP client integrations
- Airline **CCS PIMA**, direct endpoints, and default SHC codes

## Configure

1. **IATA Settings** — enable Cargo-XML, choose Direct or CCS Hub, set credentials
2. **Airline** — set CCS PIMA code and optional direct endpoint
3. **Air Consolidation** — enable **Auto-send e-AWB** when MAWB is assigned
4. **Master AWB** — use **Submit eAWB** or **Submit Consolidated e-AWB**
5. **Air Shipment** → **Integrations → IATA / e-AWB** — create, sign, submit house e-AWB

## Testing

- `test_ccs_connector.py`, `test_eawb_phases.py`, `test_mawb_eawb_sandbox.py`
- Python syntax checks pass (Frappe bench required for full test run)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23a9938c-c03d-40fa-b289-087730468a93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23a9938c-c03d-40fa-b289-087730468a93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

