### PR TITLE
feat(air-freight): CCS provider connectivity and e-AWB parity phases 1–3

### DIFF
--- a/logistics/air_freight/doctype/ccs_provider/ccs_provider.py
+++ b/logistics/air_freight/doctype/ccs_provider/ccs_provider.py
@@ -12,6 +12,6 @@ from frappe.utils import validate_url
 class CCSProvider(Document):
 	def validate(self):
 		if self.default_endpoint:
-			validate_url(self.default_endpoint, throw=True, fieldname="default_endpoint")
+			validate_url(self.default_endpoint, throw=True)
 		if self.test_endpoint:
-			validate_url(self.test_endpoint, throw=True, fieldname="test_endpoint")
+			validate_url(self.test_endpoint, throw=True)

--- a/logistics/air_freight/doctype/iata_settings/iata_settings.py
+++ b/logistics/air_freight/doctype/iata_settings/iata_settings.py
@@ -30,18 +30,10 @@ class IATASettings(Document):
 			frappe.throw(_("Company is required"))
 
 		if self.test_mode and self.test_endpoint:
-			validate_url(
-				self.test_endpoint,
-				throw=True,
-				fieldname="test_endpoint",
-			)
+			validate_url(self.test_endpoint, throw=True)
 
 		if self.test_mode and self.ccs_test_endpoint:
-			validate_url(
-				self.ccs_test_endpoint,
-				throw=True,
-				fieldname="ccs_test_endpoint",
-			)
+			validate_url(self.ccs_test_endpoint, throw=True)
 
 		if not self.cargo_xml_enabled:
 			return
@@ -98,7 +90,7 @@ class IATASettings(Document):
 			frappe.throw(_("CCS Password or Cargo-XML Password is required for CCS Hub connectivity"))
 
 		if self.ccs_endpoint:
-			validate_url(self.ccs_endpoint, throw=True, fieldname="ccs_endpoint")
+			validate_url(self.ccs_endpoint, throw=True)
 
 		if self.dg_autocheck_enabled and not self.dg_autocheck_api_key:
 			frappe.throw(_("DG AutoCheck API Key is required when DG AutoCheck is enabled"))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds CCS provider connectivity and closes e-AWB parity gaps vs CargoWise across three phases:

### Phase 1 — MVP live e-AWB
- Enriched XFWB message builder (cargo, charges, SHC, e-CSD OCI)
- House e-AWB submit (XFZB) on Air Shipment IATA Transaction
- Inbound FSU parsing (RCS, FOH, SPL, etc.)
- Per-airline endpoint routing, AutoCheck validation, webhook API key auth
- IATA Transaction UI actions (Create / Sign / Submit / TACT / CASS / DG)

### Phase 2 — Consolidation parity
- XFHL house manifest builder/send
- Consolidated submit (`submit_consolidated_eawb`: XFWB + all XFHL)
- MAWB consolidated e-AWB button, Air Consolidation auto-send
- XFNM rejection parsing, split arrival handling

### Phase 3 — Integrations
- CASS, TACT, DG AutoCheck clients
- Airline cargo XML endpoint fields
- IATA Message Queue retry for XFWB/XFHL/XFZB/XFNM/XFSU

### CCS connectivity
- New **CCS Provider** DocType + seed patch (CHAMP_TRAXON, WISE, DESCARTES, CCNHUB, CUSTOM)
- **IATA Settings** connection mode: Direct / CCS Hub
- CCS connector module with provider-specific routing

## Testing

Local bench built and browser-tested on `cargonext.localhost:8000`:

| Flow | Result |
|------|--------|
| Login | ✅ |
| IATA Settings (Cargo-XML, Connection Mode, Test Mode) | ✅ |
| CCS Provider list (5 seeded providers) | ✅ |
| IATA Settings save with CCS Hub + CHAMP_TRAXON | ✅ |
| Master AWB list page | ✅ |

**Bug fix during testing:** Frappe v16 `validate_url()` no longer accepts `fieldname` — removed from IATA Settings and CCS Provider validation (`118a2cac`).

## Sandbox testing (no external deps)

IATA Settings → Enable Cargo-XML + **Test Mode** (blank test endpoint = in-app mock).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23a9938c-c03d-40fa-b289-087730468a93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23a9938c-c03d-40fa-b289-087730468a93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

