### PR TITLE
fix(outlook): seed Connected App before install init_singles

### DIFF
--- a/logistics/hooks.py
+++ b/logistics/hooks.py
@@ -328,7 +328,7 @@ doctype_js = {
 # Installation
 # ------------
 
-# before_install = "logistics.install.before_install"
+before_install = "logistics.integrations.outlook.install.before_install"
 # after_install = "logistics.install.after_install"
 
 # Desk Notifications

--- a/logistics/integrations/outlook/install.py
+++ b/logistics/integrations/outlook/install.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2026, Agilasoft and contributors
+# For license information, please see license.txt
+
+"""Outlook integration install helpers."""
+
+from __future__ import annotations
+
+import frappe
+
+from logistics.integrations.outlook.utils import OUTLOOK_PROVIDER_NAME
+
+OUTLOOK_SCOPES = [
+	"openid",
+	"profile",
+	"offline_access",
+	"User.Read",
+	"Calendars.ReadWrite",
+]
+
+
+def create_connected_app() -> str:
+	"""Create the Microsoft Outlook Connected App skeleton if missing."""
+	connected_app_name = OUTLOOK_PROVIDER_NAME
+	existing_name = frappe.db.get_value(
+		"Connected App", {"provider_name": connected_app_name}, "name"
+	)
+	if existing_name:
+		if existing_name != connected_app_name:
+			frappe.rename_doc("Connected App", existing_name, connected_app_name, force=True)
+		return connected_app_name
+
+	if frappe.db.exists("Connected App", connected_app_name):
+		return connected_app_name
+
+	doc = frappe.new_doc("Connected App")
+	doc.name = connected_app_name
+	doc.provider_name = connected_app_name
+	doc.client_id = ""
+	doc.authorization_uri = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
+	doc.token_uri = "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+	for scope in OUTLOOK_SCOPES:
+		doc.append("scopes", {"scope": scope})
+	doc.insert(ignore_permissions=True)
+	return connected_app_name
+
+
+def before_install():
+	"""Seed Connected App before singles init during fresh app install."""
+	create_connected_app()
+	frappe.db.commit()

--- a/logistics/integrations/outlook/test_task_sync.py
+++ b/logistics/integrations/outlook/test_task_sync.py
@@ -17,7 +17,7 @@ from logistics.integrations.outlook.task_sync import (
 	sync_task_for_user,
 	delete_task_for_user,
 )
-from logistics.patches.v3_0_outlook_calendar_setup import _create_connected_app
+from logistics.integrations.outlook.install import create_connected_app
 
 
 class TestOutlookTaskSync(IntegrationTestCase):
@@ -27,10 +27,10 @@ class TestOutlookTaskSync(IntegrationTestCase):
 		self.user = frappe.session.user
 
 	def _ensure_outlook_settings(self, enabled=True):
-		_create_connected_app()
+		create_connected_app()
 		settings = frappe.get_single("Outlook Calendar Settings")
 		settings.enable_sync = 1 if enabled else 0
-		settings.connected_app = _create_connected_app()
+		settings.connected_app = create_connected_app()
 		settings.azure_tenant_id = settings.azure_tenant_id or "common"
 		settings.mark_completed_tasks_as_free = 1
 		settings.delete_outlook_event_on_task_delete = 1

--- a/logistics/patches/v3_0_outlook_calendar_setup.py
+++ b/logistics/patches/v3_0_outlook_calendar_setup.py
@@ -8,48 +8,18 @@ from __future__ import unicode_literals
 import frappe
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 
+from logistics.integrations.outlook.install import create_connected_app
 from logistics.integrations.outlook.utils import OUTLOOK_PROVIDER_NAME
 
 CONNECTED_APP_NAME = OUTLOOK_PROVIDER_NAME
-OUTLOOK_SCOPES = [
-	"openid",
-	"profile",
-	"offline_access",
-	"User.Read",
-	"Calendars.ReadWrite",
-]
 
 
 def execute():
-	connected_app_name = _create_connected_app()
+	connected_app_name = create_connected_app()
 	_create_user_custom_fields()
 	_create_default_settings(connected_app_name)
 	frappe.clear_cache(doctype="User")
 	frappe.db.commit()
-
-
-def _create_connected_app() -> str:
-	existing_name = frappe.db.get_value(
-		"Connected App", {"provider_name": CONNECTED_APP_NAME}, "name"
-	)
-	if existing_name:
-		if existing_name != CONNECTED_APP_NAME:
-			frappe.rename_doc("Connected App", existing_name, CONNECTED_APP_NAME, force=True)
-		return CONNECTED_APP_NAME
-
-	if frappe.db.exists("Connected App", CONNECTED_APP_NAME):
-		return CONNECTED_APP_NAME
-
-	doc = frappe.new_doc("Connected App")
-	doc.name = CONNECTED_APP_NAME
-	doc.provider_name = CONNECTED_APP_NAME
-	doc.client_id = ""
-	doc.authorization_uri = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
-	doc.token_uri = "https://login.microsoftonline.com/common/oauth2/v2.0/token"
-	for scope in OUTLOOK_SCOPES:
-		doc.append("scopes", {"scope": scope})
-	doc.insert(ignore_permissions=True)
-	return CONNECTED_APP_NAME
 
 
 def _create_user_custom_fields():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes fresh-site `bench install-app logistics` failures with:

```
Could not find Connected App: Microsoft Outlook
```

## Root cause

`Outlook Calendar Settings` is a Single DocType with a required Link default of `Microsoft Outlook`. During install, Frappe runs `init_singles()` and validates links before migrate patches run. The Connected App was only created by `v3_0_outlook_calendar_setup`, so new installs failed at the final post-install step.

## Fix

- Add `logistics.integrations.outlook.install.before_install` and register it in `hooks.py`
- Create the Microsoft Outlook Connected App skeleton before singles initialization
- Share `create_connected_app()` between the install hook and the existing migrate patch

## Testing

- Updated Outlook task sync tests to import the shared helper
- Manual verification on affected site: reinstall or `bench install-app logistics --force` after deploying this change
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62e77ecd-2525-4c36-84e1-8790c5678d19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62e77ecd-2525-4c36-84e1-8790c5678d19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

