### PR TITLE
feat(cash-advance): virtual rollup fields and job-scoped charge filtering

### DIFF
--- a/logistics/cash_advance/doctype/cash_advance_liquidation/cash_advance_liquidation.js
+++ b/logistics/cash_advance/doctype/cash_advance_liquidation/cash_advance_liquidation.js
@@ -15,6 +15,11 @@ frappe.ui.form.on('Cash Advance Liquidation', {
 		logistics_cash_advance_liquidation_pull_from_request(frm, true);
 	},
 
+	job_number: function(frm) {
+		logistics_cash_advance_liquidation_set_item_query(frm);
+		logistics_cash_advance_liquidation_clear_invalid_items(frm);
+	},
+
 	total_requested: function(frm) {
 		calculate_liquidation_totals(frm);
 	},
@@ -38,6 +43,28 @@ function logistics_cash_advance_liquidation_set_item_query(frm) {
 			query: 'logistics.cash_advance.job_charge_items.item_query',
 			filters: { job_number: job_number }
 		};
+	});
+}
+
+function logistics_cash_advance_liquidation_clear_invalid_items(frm) {
+	if (!frm.doc.job_number || !frm.doc.items || !frm.doc.items.length) {
+		return;
+	}
+	frappe.call({
+		method: 'logistics.cash_advance.job_charge_items.get_charge_item_codes',
+		args: { job_number: frm.doc.job_number },
+		callback: function(r) {
+			var allowed = r.message || [];
+			var allowed_set = {};
+			allowed.forEach(function(name) { allowed_set[name] = 1; });
+			$.each(frm.doc.items || [], function(i, row) {
+				if (row.item_code && !allowed_set[row.item_code]) {
+					frappe.model.set_value(row.doctype, row.name, 'item_code', null);
+				}
+			});
+			frm.refresh_field('items');
+			calculate_liquidation_totals(frm);
+		}
 	});
 }
 

--- a/logistics/cash_advance/doctype/cash_advance_request/cash_advance_request.js
+++ b/logistics/cash_advance/doctype/cash_advance_request/cash_advance_request.js
@@ -46,6 +46,7 @@ frappe.ui.form.on('Cash Advance Request', {
 	fund_type: function(frm) {
 		logistics_cash_advance_toggle_item_job_number(frm);
 		logistics_cash_advance_set_item_query(frm);
+		logistics_cash_advance_clear_invalid_items(frm);
 	},
 
 	job_number: function(frm) {
@@ -160,6 +161,25 @@ function logistics_cash_advance_toggle_item_job_number(frm) {
 	frm.refresh_field('items');
 }
 
+function logistics_cash_advance_header_job_number_required(frm) {
+	return frm.doc.fund_type && frm.doc.fund_type !== 'Revolving Fund';
+}
+
+function logistics_cash_advance_row_job_number_required(frm) {
+	return frm.doc.fund_type === 'Revolving Fund';
+}
+
+function logistics_cash_advance_item_job_number_required(frm, row) {
+	if (logistics_cash_advance_row_job_number_required(frm)) {
+		return true;
+	}
+	return logistics_cash_advance_header_job_number_required(frm);
+}
+
+function logistics_cash_advance_no_charge_items_filter() {
+	return { filters: [['Item', 'name', '=', '__no_job_number__']] };
+}
+
 function logistics_cash_advance_resolve_item_job_number(frm, row) {
 	if (frm.doc.fund_type === 'Revolving Fund') {
 		return row && row.job_number;
@@ -172,10 +192,10 @@ function logistics_cash_advance_set_item_query(frm) {
 		var row = locals[cdt][cdn];
 		var job_number = logistics_cash_advance_resolve_item_job_number(frm, row);
 		if (!job_number) {
-			if (frm.doc.fund_type && frm.doc.fund_type !== 'Revolving Fund') {
-				return {};
+			if (logistics_cash_advance_item_job_number_required(frm, row)) {
+				return logistics_cash_advance_no_charge_items_filter();
 			}
-			return { filters: [['Item', 'name', '=', '__no_job_number__']] };
+			return {};
 		}
 		return {
 			query: 'logistics.cash_advance.job_charge_items.item_query',
@@ -220,17 +240,48 @@ function logistics_cash_advance_clear_invalid_items(frm) {
 	if (!frm.doc.items || !frm.doc.items.length) {
 		return;
 	}
-	if (frm.doc.fund_type === 'Revolving Fund') {
+	if (logistics_cash_advance_row_job_number_required(frm)) {
+		var tasks = [];
 		$.each(frm.doc.items || [], function(i, row) {
-			if (!row.job_number && row.item_code) {
-				frappe.model.set_value(row.doctype, row.name, 'item_code', null);
+			if (!row.job_number) {
+				if (row.item_code) {
+					frappe.model.set_value(row.doctype, row.name, 'item_code', null);
+				}
+				return;
 			}
+			if (!row.item_code) {
+				return;
+			}
+			tasks.push(new Promise(function(resolve) {
+				frappe.call({
+					method: 'logistics.cash_advance.job_charge_items.get_charge_item_codes',
+					args: { job_number: row.job_number },
+					callback: function(r) {
+						var allowed = r.message || [];
+						if (row.item_code && allowed.indexOf(row.item_code) === -1) {
+							frappe.model.set_value(row.doctype, row.name, 'item_code', null);
+						}
+						resolve();
+					}
+				});
+			}));
 		});
-		frm.refresh_field('items');
-		calculate_totals(frm);
+		Promise.all(tasks).then(function() {
+			frm.refresh_field('items');
+			calculate_totals(frm);
+		});
 		return;
 	}
 	if (!frm.doc.job_number) {
+		if (logistics_cash_advance_header_job_number_required(frm)) {
+			$.each(frm.doc.items || [], function(i, row) {
+				if (row.item_code) {
+					frappe.model.set_value(row.doctype, row.name, 'item_code', null);
+				}
+			});
+			frm.refresh_field('items');
+			calculate_totals(frm);
+		}
 		return;
 	}
 	frappe.call({
@@ -314,18 +365,28 @@ function calculate_totals(frm) {
 frappe.ui.form.on('Cash Advance Request Item', {
 	job_number: function(frm, cdt, cdn) {
 		var row = locals[cdt][cdn];
-		if (frm.doc.fund_type === 'Revolving Fund' && row.item_code) {
-			frappe.call({
-				method: 'logistics.cash_advance.job_charge_items.get_charge_item_codes',
-				args: { job_number: row.job_number },
-				callback: function(r) {
-					var allowed = r.message || [];
-					if (row.item_code && allowed.indexOf(row.item_code) === -1) {
-						frappe.model.set_value(cdt, cdn, 'item_code', null);
-					}
-				}
-			});
+		if (!logistics_cash_advance_row_job_number_required(frm)) {
+			return;
 		}
+		if (!row.job_number) {
+			if (row.item_code) {
+				frappe.model.set_value(cdt, cdn, 'item_code', null);
+			}
+			return;
+		}
+		if (!row.item_code) {
+			return;
+		}
+		frappe.call({
+			method: 'logistics.cash_advance.job_charge_items.get_charge_item_codes',
+			args: { job_number: row.job_number },
+			callback: function(r) {
+				var allowed = r.message || [];
+				if (row.item_code && allowed.indexOf(row.item_code) === -1) {
+					frappe.model.set_value(cdt, cdn, 'item_code', null);
+				}
+			}
+		});
 	},
 
 	item_code: function(frm, cdt, cdn) {

--- a/logistics/cash_advance/doctype/cash_advance_request/cash_advance_request.json
+++ b/logistics/cash_advance/doctype/cash_advance_request/cash_advance_request.json
@@ -76,6 +76,7 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Job Number",
+   "mandatory_depends_on": "eval:doc.fund_type && doc.fund_type != 'Revolving Fund'",
    "no_copy": 1,
    "options": "Job Number"
   },

--- a/logistics/cash_advance/doctype/cash_advance_request/cash_advance_request.py
+++ b/logistics/cash_advance/doctype/cash_advance_request/cash_advance_request.py
@@ -15,7 +15,11 @@ from logistics.cash_advance.accounting import (
 	create_advance_release_journal_entry,
 	ensure_payee_for_party_accounts,
 )
-from logistics.cash_advance.job_charge_items import get_item_codes_for_job_number
+from logistics.cash_advance.job_charge_items import (
+	get_item_codes_for_job_number,
+	header_job_number_required,
+	row_job_number_required,
+)
 from logistics.cash_advance.totals_sync import (
 	compute_unliquidated,
 	get_cash_advance_request_totals,
@@ -204,6 +208,8 @@ class CashAdvanceRequest(Document):
 			frappe.throw(_("Fund Source (Bank or Cash account) is required to submit."))
 		if not self.payee:
 			frappe.throw(_("Payee (Supplier) is required to submit (used as the party on the advance entry)."))
+		if header_job_number_required(self.fund_type) and not self.job_number:
+			frappe.throw(_("Job Number is required for {0} cash advances.").format(self.fund_type))
 		_validate_cash_bank_account(self.fund_source, self.company)
 		ensure_payee_for_party_accounts(self)
 		if flt(self.total_requested, 2) <= 0:
@@ -263,7 +269,7 @@ class CashAdvanceRequest(Document):
 			)
 
 	def _validate_items_against_job(self):
-		if self.fund_type == "Revolving Fund":
+		if row_job_number_required(self.fund_type):
 			for idx, row in enumerate(self.items or [], start=1):
 				if not row.item_code and not row.job_number:
 					continue
@@ -279,6 +285,11 @@ class CashAdvanceRequest(Document):
 							idx, row.item_code, row.job_number
 						)
 					)
+			return
+
+		if header_job_number_required(self.fund_type) and not self.job_number:
+			if any(getattr(row, "item_code", None) for row in self.items or []):
+				frappe.throw(_("Job Number is required to select charge items."))
 			return
 
 		if not self.job_number:

--- a/logistics/cash_advance/job_charge_items.py
+++ b/logistics/cash_advance/job_charge_items.py
@@ -48,6 +48,25 @@ def _item_code_from_charge_row(charge) -> Optional[str]:
 	)
 
 
+def header_job_number_required(fund_type: Optional[str]) -> bool:
+	"""Header Job Number is required for Bank and Petty Cash advances."""
+	return bool(fund_type) and fund_type != "Revolving Fund"
+
+
+def row_job_number_required(fund_type: Optional[str]) -> bool:
+	"""Each item row needs its own Job Number for Revolving Fund advances."""
+	return fund_type == "Revolving Fund"
+
+
+def resolve_item_job_number(
+	fund_type: Optional[str], header_job_number: Optional[str], row_job_number: Optional[str] = None
+) -> Optional[str]:
+	"""Job Number used to scope charge-item selection for a request/liquidation row."""
+	if row_job_number_required(fund_type):
+		return row_job_number
+	return header_job_number
+
+
 def get_item_codes_for_job_number(job_number: Optional[str]) -> List[str]:
 	"""Distinct Item codes from the operational job linked to this Job Number."""
 	if not job_number or not frappe.db.exists("Job Number", job_number):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Refactors **Cash Advance Request** rollup fields to be virtual and sourced from related cash-advance documents, reorganizes the form layout, and enforces job-scoped charge item filtering when a Job Number is required.

## Changes

### Virtual fields (Items tab)
- `total_liquidated` — summed from submitted **Cash Advance Liquidation**
- `refunded` — summed from submitted **Cash Acknowledgment** (Payment)
- `returned` — summed from submitted **Cash Acknowledgment** (Receipt)
- `advance_journal_entry` — looked up from submitted **Journal Entry** (`bill_no` = request name)
- `unliquidated` — `Total Requested - Total Liquidated + Refunded - Returned`

### Removed fields
- Refund/Return Date, Reference, From/To, Returns and Refunds tab

### Layout
Moved **Refunded**, **Returned**, and **Release Journal Entry** into the **Items** tab after **Total Liquidated**.

### Charge item filtering
- **Bank / Petty Cash**: header Job Number is required; Charge Item link is restricted to applicable charges on that job
- **Revolving Fund**: each item row Job Number is required; Charge Item is restricted to that row's job charges
- When Job Number is required but missing, no charge items are selectable
- Liquidation charge items are also cleared/refiltered when Job Number changes

### Supporting updates
- Release journal entries store `bill_no` on **Journal Entry** for lookup
- `totals_sync` no longer writes rollup values to the request table
- Number cards and dashboard charts use **Cash Advance Liquidation Aging** report data
- Migration patch backfills `bill_no` on existing release JEs and drops legacy stored columns

## Migration

Run `bench migrate` to apply `logistics.patches.v1_0_cash_advance_request_virtual_fields`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e35710e-388f-4c66-9417-159cf339ac7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e35710e-388f-4c66-9417-159cf339ac7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

