### PR TITLE
Require Job Number on Cash Advance Liquidation when request is linked

### DIFF
--- a/logistics/cash_advance/doctype/cash_advance_liquidation/cash_advance_liquidation.js
+++ b/logistics/cash_advance/doctype/cash_advance_liquidation/cash_advance_liquidation.js
@@ -1,6 +1,9 @@
 frappe.ui.form.on('Cash Advance Liquidation', {
 	refresh: function(frm) {
-		logistics_cash_advance_liquidation_set_item_query(frm);
+		logistics_cash_advance_liquidation_load_request_fund_type(frm).then(function() {
+			logistics_cash_advance_liquidation_set_item_query(frm);
+			logistics_cash_advance_liquidation_toggle_item_job_number(frm);
+		});
 
 		frm.add_custom_button(__('Reload from Cash Advance'), function() {
 			logistics_cash_advance_liquidation_pull_from_request(frm, false);
@@ -13,6 +16,12 @@ frappe.ui.form.on('Cash Advance Liquidation', {
 
 	cash_advance_request: function(frm) {
 		logistics_cash_advance_liquidation_pull_from_request(frm, true);
+		logistics_cash_advance_liquidation_toggle_item_job_number(frm);
+	},
+
+	job_number: function(frm) {
+		logistics_cash_advance_liquidation_sync_item_job_numbers(frm);
+		logistics_cash_advance_liquidation_set_item_query(frm);
 	},
 
 	total_requested: function(frm) {
@@ -28,15 +37,79 @@ frappe.ui.form.on('Cash Advance Liquidation', {
 	}
 });
 
+function logistics_cash_advance_liquidation_load_request_fund_type(frm) {
+	if (!frm.doc.cash_advance_request) {
+		frm._cash_advance_request_fund_type = null;
+		return Promise.resolve();
+	}
+	return frappe.db.get_value(
+		'Cash Advance Request',
+		frm.doc.cash_advance_request,
+		'fund_type'
+	).then(function(r) {
+		frm._cash_advance_request_fund_type = (r && r.fund_type) || null;
+	});
+}
+
+function logistics_cash_advance_liquidation_get_fund_type(frm) {
+	return frm._cash_advance_request_fund_type || null;
+}
+
+function logistics_cash_advance_liquidation_resolve_item_job_number(frm, row) {
+	if (logistics_cash_advance_liquidation_get_fund_type(frm) === 'Revolving Fund') {
+		return row && row.job_number;
+	}
+	return frm.doc.job_number || (row && row.job_number);
+}
+
+function logistics_cash_advance_liquidation_toggle_item_job_number(frm) {
+	var has_request = !!frm.doc.cash_advance_request;
+	var revolving = logistics_cash_advance_liquidation_get_fund_type(frm) === 'Revolving Fund';
+	frm.toggle_reqd('job_number', has_request && !revolving);
+	frm.fields_dict.items.grid.update_docfield_property(
+		'job_number', 'reqd', has_request ? 1 : 0
+	);
+	frm.fields_dict.items.grid.update_docfield_property(
+		'job_number', 'hidden', has_request ? 0 : 1
+	);
+	frm.fields_dict.items.grid.update_docfield_property(
+		'job_number', 'read_only', revolving ? 0 : 1
+	);
+	frm.refresh_field('items');
+}
+
+function logistics_cash_advance_liquidation_sync_item_job_numbers(frm) {
+	if (logistics_cash_advance_liquidation_get_fund_type(frm) === 'Revolving Fund') {
+		return;
+	}
+	if (!frm.doc.job_number || !frm.doc.items || !frm.doc.items.length) {
+		return;
+	}
+	$.each(frm.doc.items, function(i, row) {
+		frappe.model.set_value(row.doctype, row.name, 'job_number', frm.doc.job_number);
+	});
+}
+
 function logistics_cash_advance_liquidation_set_item_query(frm) {
-	frm.set_query('item_code', 'items', function() {
-		var job_number = frm.doc.job_number;
+	frm.set_query('item_code', 'items', function(doc, cdt, cdn) {
+		var row = locals[cdt][cdn];
+		var job_number = logistics_cash_advance_liquidation_resolve_item_job_number(frm, row);
 		if (!job_number) {
 			return { filters: [['Item', 'name', '=', '__no_job_number__']] };
 		}
 		return {
 			query: 'logistics.cash_advance.job_charge_items.item_query',
 			filters: { job_number: job_number }
+		};
+	});
+	frm.set_query('job_number', 'items', function() {
+		if (!frm.doc.company) {
+			return {};
+		}
+		return {
+			filters: {
+				company: frm.doc.company
+			}
 		};
 	});
 }
@@ -49,12 +122,14 @@ function logistics_cash_advance_liquidation_pull_from_request(frm, silent) {
 		return;
 	}
 	return frappe.db.get_doc('Cash Advance Request', frm.doc.cash_advance_request).then(function(ca) {
+		frm._cash_advance_request_fund_type = ca.fund_type || null;
+		var revolving = ca.fund_type === 'Revolving Fund';
 		var p = Promise.resolve();
 		p = p.then(function() { return frm.set_value('company', ca.company); });
 		p = p.then(function() { return frm.set_value('branch', ca.branch); });
 		p = p.then(function() { return frm.set_value('cost_center', ca.cost_center); });
 		p = p.then(function() { return frm.set_value('profit_center', ca.profit_center); });
-		p = p.then(function() { return frm.set_value('job_number', ca.job_number); });
+		p = p.then(function() { return frm.set_value('job_number', revolving ? null : ca.job_number); });
 		p = p.then(function() { return frm.set_value('payee', ca.payee); });
 		p = p.then(function() { return frm.set_value('payee_name', ca.payee_name); });
 		p = p.then(function() { return frm.set_value('request_date', ca.date); });
@@ -67,9 +142,11 @@ function logistics_cash_advance_liquidation_pull_from_request(frm, silent) {
 				row.item_code = r.item_code;
 				row.description = r.description;
 				row.amount_requested = r.amount_requested;
+				row.job_number = revolving ? r.job_number : ca.job_number;
 			});
 			frm.refresh_field('items');
 			logistics_cash_advance_liquidation_set_item_query(frm);
+			logistics_cash_advance_liquidation_toggle_item_job_number(frm);
 			calculate_liquidation_totals(frm);
 		});
 	});
@@ -102,6 +179,10 @@ function calculate_liquidation_totals(frm) {
 frappe.ui.form.on('Cash Advance Liquidation Item', {
 	item_code: function(frm, cdt, cdn) {
 		calculate_liquidation_totals(frm);
+	},
+
+	job_number: function(frm, cdt, cdn) {
+		logistics_cash_advance_liquidation_set_item_query(frm);
 	},
 
 	amount_requested: function(frm, cdt, cdn) {

--- a/logistics/cash_advance/doctype/cash_advance_liquidation/cash_advance_liquidation.py
+++ b/logistics/cash_advance/doctype/cash_advance_liquidation/cash_advance_liquidation.py
@@ -20,6 +20,7 @@ from logistics.cash_advance.job_charge_items import get_item_codes_for_job_numbe
 class CashAdvanceLiquidation(Document):
 	def validate(self):
 		self._validate_linked_request()
+		self._validate_job_number_when_request_linked()
 		self._validate_items_against_job()
 
 		if self.total_requested and self.total_requested < 0:
@@ -61,7 +62,51 @@ class CashAdvanceLiquidation(Document):
 		if req_co and self.company and req_co != self.company:
 			frappe.throw(_("Company must match the linked Cash Advance Request."))
 
+	def _get_linked_request_fund_type(self):
+		if not self.cash_advance_request:
+			return None
+		return frappe.db.get_value("Cash Advance Request", self.cash_advance_request, "fund_type")
+
+	def _validate_job_number_when_request_linked(self):
+		if not self.cash_advance_request:
+			return
+
+		fund_type = self._get_linked_request_fund_type()
+		if fund_type == "Revolving Fund":
+			for idx, row in enumerate(self.items or [], start=1):
+				if not row.item_code:
+					continue
+				if not row.job_number:
+					frappe.throw(_("Row {0}: Job Number is required.").format(idx))
+			return
+
+		if not self.job_number:
+			frappe.throw(_("Job Number is required when a Cash Advance Request is linked."))
+
+		for idx, row in enumerate(self.items or [], start=1):
+			if not row.item_code:
+				continue
+			if not row.job_number:
+				row.job_number = self.job_number
+
 	def _validate_items_against_job(self):
+		fund_type = self._get_linked_request_fund_type()
+		if fund_type == "Revolving Fund":
+			for idx, row in enumerate(self.items or [], start=1):
+				if not row.item_code:
+					continue
+				job_number = row.job_number
+				if not job_number:
+					continue
+				allowed = set(get_item_codes_for_job_number(job_number))
+				if row.item_code not in allowed:
+					frappe.throw(
+						_("Row {0}: Charge Item {1} is not on the charges for Job Number {2}.").format(
+							idx, row.item_code, job_number
+						)
+					)
+			return
+
 		if not self.job_number:
 			if any(getattr(r, "item_code", None) for r in self.items or []):
 				frappe.throw(_("Job Number is required (load from Cash Advance Request)."))

--- a/logistics/cash_advance/doctype/cash_advance_liquidation_item/cash_advance_liquidation_item.json
+++ b/logistics/cash_advance/doctype/cash_advance_liquidation_item/cash_advance_liquidation_item.json
@@ -10,12 +10,12 @@
   "charge_section",
   "item_code",
   "description",
-  "job_number",
   "column_break_4",
   "amount_requested",
   "liquidation_entry_section",
   "date",
   "reference_no",
+  "job_number",
   "amount_liquidated",
   "attachment",
   "column_break_12",
@@ -97,9 +97,9 @@
   {
    "fieldname": "job_number",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Job Number",
-   "options": "Job Number",
-   "read_only": 1
+   "options": "Job Number"
   }
  ],
  "index_web_pages_for_search": 1,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes **Job Number** mandatory on Cash Advance Liquidation when a Cash Advance Request is selected.

## Changes

- **Server validation** (`cash_advance_liquidation.py`): throws if Job Number is missing when a request is linked. For standard funds, the parent Job Number is required and propagated to item rows. For Revolving Fund requests, each item row must have its own Job Number.
- **Client script** (`cash_advance_liquidation.js`): shows Job Number on item rows when a request is linked, marks it required, copies job numbers when loading from the request, and syncs parent job number to rows for non-revolving funds.
- **Child DocType** (`cash_advance_liquidation_item.json`): moves Job Number into the Liquidation section (between Reference No and Amount Liquidated) and removes the hard-coded read-only flag so revolving-fund rows can be edited.

## Test plan

- [ ] Create a Cash Advance Liquidation and select a submitted Cash Advance Request with a Job Number — item rows should auto-fill Job Number.
- [ ] Try saving without Job Number — form should block save with a validation error.
- [ ] Verify Revolving Fund requests require per-row Job Numbers on liquidation items.
- [ ] Confirm Job Number appears in the liquidation row modal between Reference No and Amount Liquidated.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-afafdb3b-440e-4431-a118-b65093376955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afafdb3b-440e-4431-a118-b65093376955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

