### PR TITLE
Require Job Number via Fund Source and Item checkboxes

### DIFF
--- a/logistics/cash_advance/doctype/cash_acknowledgment/cash_acknowledgment.js
+++ b/logistics/cash_advance/doctype/cash_acknowledgment/cash_acknowledgment.js
@@ -52,7 +52,6 @@ function logistics_cash_acknowledgment_pull_from_request(frm) {
 		p = p.then(function() { return frm.set_value('branch', ca.branch); });
 		p = p.then(function() { return frm.set_value('cost_center', ca.cost_center); });
 		p = p.then(function() { return frm.set_value('profit_center', ca.profit_center); });
-		p = p.then(function() { return frm.set_value('job_number', ca.job_number); });
 		p = p.then(function() { return frm.set_value('fund_source', ca.fund_source); });
 		p = p.then(function() { return frm.set_value('payee', ca.payee); });
 		p = p.then(function() { return frm.set_value('payee_name', ca.payee_name); });

--- a/logistics/cash_advance/doctype/cash_advance_liquidation/cash_advance_liquidation.js
+++ b/logistics/cash_advance/doctype/cash_advance_liquidation/cash_advance_liquidation.js
@@ -1,6 +1,9 @@
 frappe.ui.form.on('Cash Advance Liquidation', {
 	refresh: function(frm) {
-		logistics_cash_advance_liquidation_set_item_query(frm);
+		logistics_cash_advance_liquidation_load_request_fund_type(frm).then(function() {
+			logistics_cash_advance_liquidation_set_item_query(frm);
+			logistics_cash_advance_liquidation_toggle_item_job_number(frm);
+		});
 
 		frm.add_custom_button(__('Reload from Cash Advance'), function() {
 			logistics_cash_advance_liquidation_pull_from_request(frm, false);
@@ -13,6 +16,12 @@ frappe.ui.form.on('Cash Advance Liquidation', {
 
 	cash_advance_request: function(frm) {
 		logistics_cash_advance_liquidation_pull_from_request(frm, true);
+		logistics_cash_advance_liquidation_toggle_item_job_number(frm);
+	},
+
+	job_number: function(frm) {
+		logistics_cash_advance_liquidation_sync_item_job_numbers(frm);
+		logistics_cash_advance_liquidation_set_item_query(frm);
 	},
 
 	total_requested: function(frm) {
@@ -28,15 +37,79 @@ frappe.ui.form.on('Cash Advance Liquidation', {
 	}
 });
 
+function logistics_cash_advance_liquidation_load_request_fund_type(frm) {
+	if (!frm.doc.cash_advance_request) {
+		frm._cash_advance_request_fund_type = null;
+		return Promise.resolve();
+	}
+	return frappe.db.get_value(
+		'Cash Advance Request',
+		frm.doc.cash_advance_request,
+		'fund_type'
+	).then(function(r) {
+		frm._cash_advance_request_fund_type = (r && r.fund_type) || null;
+	});
+}
+
+function logistics_cash_advance_liquidation_get_fund_type(frm) {
+	return frm._cash_advance_request_fund_type || null;
+}
+
+function logistics_cash_advance_liquidation_resolve_item_job_number(frm, row) {
+	if (logistics_cash_advance_liquidation_get_fund_type(frm) === 'Revolving Fund') {
+		return row && row.job_number;
+	}
+	return frm.doc.job_number || (row && row.job_number);
+}
+
+function logistics_cash_advance_liquidation_toggle_item_job_number(frm) {
+	var has_request = !!frm.doc.cash_advance_request;
+	var revolving = logistics_cash_advance_liquidation_get_fund_type(frm) === 'Revolving Fund';
+	frm.toggle_reqd('job_number', has_request && !revolving);
+	frm.fields_dict.items.grid.update_docfield_property(
+		'job_number', 'reqd', has_request ? 1 : 0
+	);
+	frm.fields_dict.items.grid.update_docfield_property(
+		'job_number', 'hidden', has_request ? 0 : 1
+	);
+	frm.fields_dict.items.grid.update_docfield_property(
+		'job_number', 'read_only', revolving ? 0 : 1
+	);
+	frm.refresh_field('items');
+}
+
+function logistics_cash_advance_liquidation_sync_item_job_numbers(frm) {
+	if (logistics_cash_advance_liquidation_get_fund_type(frm) === 'Revolving Fund') {
+		return;
+	}
+	if (!frm.doc.job_number || !frm.doc.items || !frm.doc.items.length) {
+		return;
+	}
+	$.each(frm.doc.items, function(i, row) {
+		frappe.model.set_value(row.doctype, row.name, 'job_number', frm.doc.job_number);
+	});
+}
+
 function logistics_cash_advance_liquidation_set_item_query(frm) {
-	frm.set_query('item_code', 'items', function() {
-		var job_number = frm.doc.job_number;
+	frm.set_query('item_code', 'items', function(doc, cdt, cdn) {
+		var row = locals[cdt][cdn];
+		var job_number = logistics_cash_advance_liquidation_resolve_item_job_number(frm, row);
 		if (!job_number) {
 			return { filters: [['Item', 'name', '=', '__no_job_number__']] };
 		}
 		return {
 			query: 'logistics.cash_advance.job_charge_items.item_query',
 			filters: { job_number: job_number }
+		};
+	});
+	frm.set_query('job_number', 'items', function() {
+		if (!frm.doc.company) {
+			return {};
+		}
+		return {
+			filters: {
+				company: frm.doc.company
+			}
 		};
 	});
 }
@@ -49,12 +122,14 @@ function logistics_cash_advance_liquidation_pull_from_request(frm, silent) {
 		return;
 	}
 	return frappe.db.get_doc('Cash Advance Request', frm.doc.cash_advance_request).then(function(ca) {
+		frm._cash_advance_request_fund_type = ca.fund_type || null;
+		var revolving = ca.fund_type === 'Revolving Fund';
 		var p = Promise.resolve();
 		p = p.then(function() { return frm.set_value('company', ca.company); });
 		p = p.then(function() { return frm.set_value('branch', ca.branch); });
 		p = p.then(function() { return frm.set_value('cost_center', ca.cost_center); });
 		p = p.then(function() { return frm.set_value('profit_center', ca.profit_center); });
-		p = p.then(function() { return frm.set_value('job_number', ca.job_number); });
+		p = p.then(function() { return frm.set_value('job_number', revolving ? null : ca.job_number); });
 		p = p.then(function() { return frm.set_value('payee', ca.payee); });
 		p = p.then(function() { return frm.set_value('payee_name', ca.payee_name); });
 		p = p.then(function() { return frm.set_value('request_date', ca.date); });
@@ -67,9 +142,11 @@ function logistics_cash_advance_liquidation_pull_from_request(frm, silent) {
 				row.item_code = r.item_code;
 				row.description = r.description;
 				row.amount_requested = r.amount_requested;
+				row.job_number = revolving ? r.job_number : ca.job_number;
 			});
 			frm.refresh_field('items');
 			logistics_cash_advance_liquidation_set_item_query(frm);
+			logistics_cash_advance_liquidation_toggle_item_job_number(frm);
 			calculate_liquidation_totals(frm);
 		});
 	});
@@ -102,6 +179,10 @@ function calculate_liquidation_totals(frm) {
 frappe.ui.form.on('Cash Advance Liquidation Item', {
 	item_code: function(frm, cdt, cdn) {
 		calculate_liquidation_totals(frm);
+	},
+
+	job_number: function(frm, cdt, cdn) {
+		logistics_cash_advance_liquidation_set_item_query(frm);
 	},
 
 	amount_requested: function(frm, cdt, cdn) {

--- a/logistics/cash_advance/doctype/cash_advance_liquidation/cash_advance_liquidation.js
+++ b/logistics/cash_advance/doctype/cash_advance_liquidation/cash_advance_liquidation.js
@@ -1,8 +1,10 @@
 frappe.ui.form.on('Cash Advance Liquidation', {
 	refresh: function(frm) {
-		logistics_cash_advance_liquidation_load_request_fund_type(frm).then(function() {
-			logistics_cash_advance_liquidation_set_item_query(frm);
-			logistics_cash_advance_liquidation_toggle_item_job_number(frm);
+		logistics_cash_advance_liquidation_load_request_context(frm).then(function() {
+			logistics_cash_advance_liquidation_preload_item_require_job_number(frm).then(function() {
+				logistics_cash_advance_liquidation_set_item_query(frm);
+				logistics_cash_advance_liquidation_toggle_item_job_number(frm);
+			});
 		});
 
 		frm.add_custom_button(__('Reload from Cash Advance'), function() {
@@ -16,7 +18,6 @@ frappe.ui.form.on('Cash Advance Liquidation', {
 
 	cash_advance_request: function(frm) {
 		logistics_cash_advance_liquidation_pull_from_request(frm, true);
-		logistics_cash_advance_liquidation_toggle_item_job_number(frm);
 	},
 
 	job_number: function(frm) {
@@ -37,62 +38,87 @@ frappe.ui.form.on('Cash Advance Liquidation', {
 	}
 });
 
-function logistics_cash_advance_liquidation_load_request_fund_type(frm) {
+function logistics_cash_advance_liquidation_load_request_context(frm) {
 	if (!frm.doc.cash_advance_request) {
-		frm._cash_advance_request_fund_type = null;
+		frm._cash_advance_request_require_job_number = 0;
 		return Promise.resolve();
 	}
 	return frappe.db.get_value(
 		'Cash Advance Request',
 		frm.doc.cash_advance_request,
-		'fund_type'
+		'require_job_number'
 	).then(function(r) {
-		frm._cash_advance_request_fund_type = (r && r.fund_type) || null;
+		frm._cash_advance_request_require_job_number = (r && r.require_job_number) ? 1 : 0;
 	});
 }
 
-function logistics_cash_advance_liquidation_get_fund_type(frm) {
-	return frm._cash_advance_request_fund_type || null;
+function logistics_cash_advance_liquidation_get_require_job_number(frm) {
+	return frm._cash_advance_request_require_job_number ? 1 : 0;
+}
+
+function logistics_cash_advance_liquidation_preload_item_require_job_number(frm) {
+	var codes = (frm.doc.items || []).map(function(row) { return row.item_code; }).filter(Boolean);
+	if (!codes.length) {
+		return Promise.resolve();
+	}
+	return frappe.db.get_list('Item', {
+		filters: { name: ['in', codes] },
+		fields: ['name', 'require_job_number'],
+		limit_page_length: 0
+	}).then(function(rows) {
+		frm._cash_advance_item_require_job_number = frm._cash_advance_item_require_job_number || {};
+		rows.forEach(function(row) {
+			frm._cash_advance_item_require_job_number[row.name] = row.require_job_number ? 1 : 0;
+		});
+	});
+}
+
+function logistics_cash_advance_liquidation_row_requires_job_number(frm, row) {
+	if (!logistics_cash_advance_liquidation_get_require_job_number(frm) || !row || !row.item_code) {
+		return false;
+	}
+	var cache = frm._cash_advance_item_require_job_number || {};
+	return !!cache[row.item_code];
 }
 
 function logistics_cash_advance_liquidation_resolve_item_job_number(frm, row) {
-	if (logistics_cash_advance_liquidation_get_fund_type(frm) === 'Revolving Fund') {
-		return row && row.job_number;
+	if (row && row.job_number) {
+		return row.job_number;
 	}
-	return frm.doc.job_number || (row && row.job_number);
+	return frm.doc.job_number;
 }
 
 function logistics_cash_advance_liquidation_toggle_item_job_number(frm) {
-	var has_request = !!frm.doc.cash_advance_request;
-	var revolving = logistics_cash_advance_liquidation_get_fund_type(frm) === 'Revolving Fund';
-	frm.toggle_reqd('job_number', has_request && !revolving);
+	var show = !!frm.doc.cash_advance_request && logistics_cash_advance_liquidation_get_require_job_number(frm);
 	frm.fields_dict.items.grid.update_docfield_property(
-		'job_number', 'reqd', has_request ? 1 : 0
-	);
-	frm.fields_dict.items.grid.update_docfield_property(
-		'job_number', 'hidden', has_request ? 0 : 1
-	);
-	frm.fields_dict.items.grid.update_docfield_property(
-		'job_number', 'read_only', revolving ? 0 : 1
+		'job_number', 'hidden', show ? 0 : 1
 	);
 	frm.refresh_field('items');
 }
 
 function logistics_cash_advance_liquidation_sync_item_job_numbers(frm) {
-	if (logistics_cash_advance_liquidation_get_fund_type(frm) === 'Revolving Fund') {
+	if (!logistics_cash_advance_liquidation_get_require_job_number(frm) || !frm.doc.job_number) {
 		return;
 	}
-	if (!frm.doc.job_number || !frm.doc.items || !frm.doc.items.length) {
+	if (!frm.doc.items || !frm.doc.items.length) {
 		return;
 	}
-	$.each(frm.doc.items, function(i, row) {
-		frappe.model.set_value(row.doctype, row.name, 'job_number', frm.doc.job_number);
+	logistics_cash_advance_liquidation_preload_item_require_job_number(frm).then(function() {
+		$.each(frm.doc.items, function(i, row) {
+			if (!logistics_cash_advance_liquidation_row_requires_job_number(frm, row) || row.job_number) {
+				return;
+			}
+			frappe.model.set_value(row.doctype, row.name, 'job_number', frm.doc.job_number);
+		});
 	});
 }
 
 function logistics_cash_advance_liquidation_set_item_query(frm) {
 	frm.set_query('item_code', 'items', function(doc, cdt, cdn) {
 		var row = locals[cdt][cdn];
+		if (!logistics_cash_advance_liquidation_row_requires_job_number(frm, row)) {
+			return {};
+		}
 		var job_number = logistics_cash_advance_liquidation_resolve_item_job_number(frm, row);
 		if (!job_number) {
 			return { filters: [['Item', 'name', '=', '__no_job_number__']] };
@@ -122,14 +148,13 @@ function logistics_cash_advance_liquidation_pull_from_request(frm, silent) {
 		return;
 	}
 	return frappe.db.get_doc('Cash Advance Request', frm.doc.cash_advance_request).then(function(ca) {
-		frm._cash_advance_request_fund_type = ca.fund_type || null;
-		var revolving = ca.fund_type === 'Revolving Fund';
+		frm._cash_advance_request_require_job_number = ca.require_job_number ? 1 : 0;
 		var p = Promise.resolve();
 		p = p.then(function() { return frm.set_value('company', ca.company); });
 		p = p.then(function() { return frm.set_value('branch', ca.branch); });
 		p = p.then(function() { return frm.set_value('cost_center', ca.cost_center); });
 		p = p.then(function() { return frm.set_value('profit_center', ca.profit_center); });
-		p = p.then(function() { return frm.set_value('job_number', revolving ? null : ca.job_number); });
+		p = p.then(function() { return frm.set_value('job_number', ca.job_number); });
 		p = p.then(function() { return frm.set_value('payee', ca.payee); });
 		p = p.then(function() { return frm.set_value('payee_name', ca.payee_name); });
 		p = p.then(function() { return frm.set_value('request_date', ca.date); });
@@ -142,12 +167,14 @@ function logistics_cash_advance_liquidation_pull_from_request(frm, silent) {
 				row.item_code = r.item_code;
 				row.description = r.description;
 				row.amount_requested = r.amount_requested;
-				row.job_number = revolving ? r.job_number : ca.job_number;
+				row.job_number = r.job_number || ca.job_number;
 			});
 			frm.refresh_field('items');
-			logistics_cash_advance_liquidation_set_item_query(frm);
-			logistics_cash_advance_liquidation_toggle_item_job_number(frm);
-			calculate_liquidation_totals(frm);
+			return logistics_cash_advance_liquidation_preload_item_require_job_number(frm).then(function() {
+				logistics_cash_advance_liquidation_set_item_query(frm);
+				logistics_cash_advance_liquidation_toggle_item_job_number(frm);
+				calculate_liquidation_totals(frm);
+			});
 		});
 	});
 }
@@ -178,7 +205,17 @@ function calculate_liquidation_totals(frm) {
 
 frappe.ui.form.on('Cash Advance Liquidation Item', {
 	item_code: function(frm, cdt, cdn) {
-		calculate_liquidation_totals(frm);
+		var row = locals[cdt][cdn];
+		logistics_cash_advance_liquidation_preload_item_require_job_number(frm).then(function() {
+			if (
+				logistics_cash_advance_liquidation_row_requires_job_number(frm, row) &&
+				!row.job_number &&
+				frm.doc.job_number
+			) {
+				frappe.model.set_value(cdt, cdn, 'job_number', frm.doc.job_number);
+			}
+			calculate_liquidation_totals(frm);
+		});
 	},
 
 	job_number: function(frm, cdt, cdn) {

--- a/logistics/cash_advance/doctype/cash_advance_liquidation/cash_advance_liquidation.js
+++ b/logistics/cash_advance/doctype/cash_advance_liquidation/cash_advance_liquidation.js
@@ -154,7 +154,6 @@ function logistics_cash_advance_liquidation_pull_from_request(frm, silent) {
 		p = p.then(function() { return frm.set_value('branch', ca.branch); });
 		p = p.then(function() { return frm.set_value('cost_center', ca.cost_center); });
 		p = p.then(function() { return frm.set_value('profit_center', ca.profit_center); });
-		p = p.then(function() { return frm.set_value('job_number', ca.job_number); });
 		p = p.then(function() { return frm.set_value('payee', ca.payee); });
 		p = p.then(function() { return frm.set_value('payee_name', ca.payee_name); });
 		p = p.then(function() { return frm.set_value('request_date', ca.date); });
@@ -167,7 +166,7 @@ function logistics_cash_advance_liquidation_pull_from_request(frm, silent) {
 				row.item_code = r.item_code;
 				row.description = r.description;
 				row.amount_requested = r.amount_requested;
-				row.job_number = r.job_number || ca.job_number;
+				row.job_number = r.job_number;
 			});
 			frm.refresh_field('items');
 			return logistics_cash_advance_liquidation_preload_item_require_job_number(frm).then(function() {
@@ -205,15 +204,7 @@ function calculate_liquidation_totals(frm) {
 
 frappe.ui.form.on('Cash Advance Liquidation Item', {
 	item_code: function(frm, cdt, cdn) {
-		var row = locals[cdt][cdn];
 		logistics_cash_advance_liquidation_preload_item_require_job_number(frm).then(function() {
-			if (
-				logistics_cash_advance_liquidation_row_requires_job_number(frm, row) &&
-				!row.job_number &&
-				frm.doc.job_number
-			) {
-				frappe.model.set_value(cdt, cdn, 'job_number', frm.doc.job_number);
-			}
 			calculate_liquidation_totals(frm);
 		});
 	},

--- a/logistics/cash_advance/doctype/cash_advance_liquidation/cash_advance_liquidation.py
+++ b/logistics/cash_advance/doctype/cash_advance_liquidation/cash_advance_liquidation.py
@@ -20,6 +20,7 @@ from logistics.cash_advance.job_charge_items import get_item_codes_for_job_numbe
 class CashAdvanceLiquidation(Document):
 	def validate(self):
 		self._validate_linked_request()
+		self._validate_job_number_when_request_linked()
 		self._validate_items_against_job()
 
 		if self.total_requested and self.total_requested < 0:
@@ -61,7 +62,51 @@ class CashAdvanceLiquidation(Document):
 		if req_co and self.company and req_co != self.company:
 			frappe.throw(_("Company must match the linked Cash Advance Request."))
 
+	def _get_linked_request_fund_type(self):
+		if not self.cash_advance_request:
+			return None
+		return frappe.db.get_value("Cash Advance Request", self.cash_advance_request, "fund_type")
+
+	def _validate_job_number_when_request_linked(self):
+		if not self.cash_advance_request:
+			return
+
+		fund_type = self._get_linked_request_fund_type()
+		if fund_type == "Revolving Fund":
+			for idx, row in enumerate(self.items or [], start=1):
+				if not row.item_code:
+					continue
+				if not row.job_number:
+					frappe.throw(_("Row {0}: Job Number is required.").format(idx))
+			return
+
+		if not self.job_number:
+			frappe.throw(_("Job Number is required when a Cash Advance Request is linked."))
+
+		for idx, row in enumerate(self.items or [], start=1):
+			if not row.item_code:
+				continue
+			if not row.job_number:
+				row.job_number = self.job_number
+
 	def _validate_items_against_job(self):
+		fund_type = self._get_linked_request_fund_type()
+		if fund_type == "Revolving Fund":
+			for idx, row in enumerate(self.items or [], start=1):
+				if not row.item_code:
+					continue
+				job_number = row.job_number
+				if not job_number:
+					continue
+				allowed = set(get_item_codes_for_job_number(job_number))
+				if row.item_code not in allowed:
+					frappe.throw(
+						_("Row {0}: Charge Item {1} is not on the charges for Job Number {2}.").format(
+							idx, row.item_code, job_number
+						)
+					)
+			return
+
 		if not self.job_number:
 			if any(getattr(r, "item_code", None) for r in self.items or []):
 				frappe.throw(_("Job Number is required (load from Cash Advance Request)."))

--- a/logistics/cash_advance/doctype/cash_advance_liquidation/cash_advance_liquidation.py
+++ b/logistics/cash_advance/doctype/cash_advance_liquidation/cash_advance_liquidation.py
@@ -15,6 +15,10 @@ from logistics.cash_advance.accounting import (
 )
 from logistics.cash_advance.totals_sync import sync_cash_advance_request_liquidation_totals
 from logistics.cash_advance.job_charge_items import get_item_codes_for_job_number
+from logistics.cash_advance.job_number_rules import (
+	resolve_row_job_number,
+	row_requires_job_number,
+)
 
 
 class CashAdvanceLiquidation(Document):
@@ -62,64 +66,42 @@ class CashAdvanceLiquidation(Document):
 		if req_co and self.company and req_co != self.company:
 			frappe.throw(_("Company must match the linked Cash Advance Request."))
 
-	def _get_linked_request_fund_type(self):
+	def _get_linked_request_require_job_number(self):
 		if not self.cash_advance_request:
-			return None
-		return frappe.db.get_value("Cash Advance Request", self.cash_advance_request, "fund_type")
+			return 0
+		return frappe.db.get_value(
+			"Cash Advance Request", self.cash_advance_request, "require_job_number"
+		)
 
 	def _validate_job_number_when_request_linked(self):
 		if not self.cash_advance_request:
 			return
 
-		fund_type = self._get_linked_request_fund_type()
-		if fund_type == "Revolving Fund":
-			for idx, row in enumerate(self.items or [], start=1):
-				if not row.item_code:
-					continue
-				if not row.job_number:
-					frappe.throw(_("Row {0}: Job Number is required.").format(idx))
-			return
+		require_job_number = self._get_linked_request_require_job_number()
+		for idx, row in enumerate(self.items or [], start=1):
+			if not row_requires_job_number(require_job_number, row.item_code):
+				continue
+			job_number = resolve_row_job_number(self.job_number, row)
+			if not job_number:
+				frappe.throw(_("Row {0}: Job Number is required for this charge item.").format(idx))
+			if not row.job_number:
+				row.job_number = job_number
 
-		if not self.job_number:
-			frappe.throw(_("Job Number is required when a Cash Advance Request is linked."))
-
+	def _validate_items_against_job(self):
+		require_job_number = self._get_linked_request_require_job_number()
 		for idx, row in enumerate(self.items or [], start=1):
 			if not row.item_code:
 				continue
-			if not row.job_number:
-				row.job_number = self.job_number
-
-	def _validate_items_against_job(self):
-		fund_type = self._get_linked_request_fund_type()
-		if fund_type == "Revolving Fund":
-			for idx, row in enumerate(self.items or [], start=1):
-				if not row.item_code:
-					continue
-				job_number = row.job_number
-				if not job_number:
-					continue
-				allowed = set(get_item_codes_for_job_number(job_number))
-				if row.item_code not in allowed:
-					frappe.throw(
-						_("Row {0}: Charge Item {1} is not on the charges for Job Number {2}.").format(
-							idx, row.item_code, job_number
-						)
-					)
-			return
-
-		if not self.job_number:
-			if any(getattr(r, "item_code", None) for r in self.items or []):
-				frappe.throw(_("Job Number is required (load from Cash Advance Request)."))
-			return
-
-		allowed = set(get_item_codes_for_job_number(self.job_number))
-		for row in self.items or []:
-			if not row.item_code:
+			if not row_requires_job_number(require_job_number, row.item_code):
 				continue
+			job_number = resolve_row_job_number(self.job_number, row)
+			if not job_number:
+				continue
+			allowed = set(get_item_codes_for_job_number(job_number))
 			if row.item_code not in allowed:
 				frappe.throw(
-					_("Charge Item {0} is not on the charges for Job Number {1}.").format(
-						row.item_code, self.job_number
+					_("Row {0}: Charge Item {1} is not on the charges for Job Number {2}.").format(
+						idx, row.item_code, job_number
 					)
 				)
 

--- a/logistics/cash_advance/doctype/cash_advance_liquidation_item/cash_advance_liquidation_item.json
+++ b/logistics/cash_advance/doctype/cash_advance_liquidation_item/cash_advance_liquidation_item.json
@@ -10,12 +10,12 @@
   "charge_section",
   "item_code",
   "description",
-  "job_number",
   "column_break_4",
   "amount_requested",
   "liquidation_entry_section",
   "date",
   "reference_no",
+  "job_number",
   "amount_liquidated",
   "attachment",
   "column_break_12",
@@ -97,9 +97,9 @@
   {
    "fieldname": "job_number",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Job Number",
-   "options": "Job Number",
-   "read_only": 1
+   "options": "Job Number"
   }
  ],
  "index_web_pages_for_search": 1,

--- a/logistics/cash_advance/doctype/cash_advance_request/cash_advance_request.js
+++ b/logistics/cash_advance/doctype/cash_advance_request/cash_advance_request.js
@@ -4,7 +4,9 @@ frappe.ui.form.on('Cash Advance Request', {
 		logistics_cash_advance_set_employee_advance_query(frm);
 		logistics_cash_advance_set_dimension_queries(frm);
 		logistics_cash_advance_set_item_query(frm);
-		logistics_cash_advance_toggle_item_job_number(frm);
+		logistics_cash_advance_preload_item_require_job_number(frm).then(function() {
+			logistics_cash_advance_toggle_item_job_number(frm);
+		});
 
 		if (
 			!frm.is_new() &&
@@ -33,17 +35,26 @@ frappe.ui.form.on('Cash Advance Request', {
 	fund_source: function(frm) {
 		if (!frm.doc.fund_source) {
 			frm.set_value('fund_type', null);
+			frm.set_value('require_job_number', 0);
+			logistics_cash_advance_toggle_item_job_number(frm);
 			return;
 		}
-		frappe.db.get_value('Account', frm.doc.fund_source, ['fund_type', 'cash_advance_request_limit'], function(r) {
-			if (r) {
-				frm.set_value('fund_type', r.fund_type || null);
+		frappe.db.get_value(
+			'Account',
+			frm.doc.fund_source,
+			['fund_type', 'cash_advance_request_limit', 'require_job_number'],
+			function(r) {
+				if (r) {
+					frm.set_value('fund_type', r.fund_type || null);
+					frm.set_value('require_job_number', r.require_job_number ? 1 : 0);
+				}
+				logistics_cash_advance_toggle_item_job_number(frm);
 			}
-		});
+		);
 		logistics_cash_advance_set_item_query(frm);
 	},
 
-	fund_type: function(frm) {
+	require_job_number: function(frm) {
 		logistics_cash_advance_toggle_item_job_number(frm);
 		logistics_cash_advance_set_item_query(frm);
 	},
@@ -52,6 +63,7 @@ frappe.ui.form.on('Cash Advance Request', {
 		logistics_cash_advance_apply_job_number_dimensions(frm).then(function() {
 			logistics_cash_advance_set_item_query(frm);
 			logistics_cash_advance_clear_invalid_items(frm);
+			logistics_cash_advance_sync_item_job_numbers(frm);
 		});
 	},
 
@@ -127,6 +139,7 @@ function logistics_cash_advance_clear_mismatched_dimensions(frm) {
 			if (r && r.company && r.company !== company) {
 				frm.set_value('fund_source', null);
 				frm.set_value('fund_type', null);
+				frm.set_value('require_job_number', 0);
 			}
 		});
 	}
@@ -149,32 +162,66 @@ function logistics_cash_advance_set_fund_source_query(frm) {
 	});
 }
 
+function logistics_cash_advance_preload_item_require_job_number(frm) {
+	var codes = (frm.doc.items || []).map(function(row) { return row.item_code; }).filter(Boolean);
+	if (!codes.length) {
+		return Promise.resolve();
+	}
+	return frappe.db.get_list('Item', {
+		filters: { name: ['in', codes] },
+		fields: ['name', 'require_job_number'],
+		limit_page_length: 0
+	}).then(function(rows) {
+		frm._cash_advance_item_require_job_number = frm._cash_advance_item_require_job_number || {};
+		rows.forEach(function(row) {
+			frm._cash_advance_item_require_job_number[row.name] = row.require_job_number ? 1 : 0;
+		});
+	});
+}
+
+function logistics_cash_advance_row_requires_job_number(frm, row) {
+	if (!frm.doc.require_job_number || !row || !row.item_code) {
+		return false;
+	}
+	var cache = frm._cash_advance_item_require_job_number || {};
+	return !!cache[row.item_code];
+}
+
 function logistics_cash_advance_toggle_item_job_number(frm) {
-	var revolving = frm.doc.fund_type === 'Revolving Fund';
+	var show = !!frm.doc.require_job_number;
 	frm.fields_dict.items.grid.update_docfield_property(
-		'job_number', 'reqd', revolving ? 1 : 0
-	);
-	frm.fields_dict.items.grid.update_docfield_property(
-		'job_number', 'hidden', revolving ? 0 : 1
+		'job_number', 'hidden', show ? 0 : 1
 	);
 	frm.refresh_field('items');
 }
 
 function logistics_cash_advance_resolve_item_job_number(frm, row) {
-	if (frm.doc.fund_type === 'Revolving Fund') {
-		return row && row.job_number;
+	if (row && row.job_number) {
+		return row.job_number;
 	}
 	return frm.doc.job_number;
+}
+
+function logistics_cash_advance_sync_item_job_numbers(frm) {
+	if (!frm.doc.require_job_number || !frm.doc.job_number || !frm.doc.items || !frm.doc.items.length) {
+		return;
+	}
+	$.each(frm.doc.items, function(i, row) {
+		if (!logistics_cash_advance_row_requires_job_number(frm, row) || row.job_number) {
+			return;
+		}
+		frappe.model.set_value(row.doctype, row.name, 'job_number', frm.doc.job_number);
+	});
 }
 
 function logistics_cash_advance_set_item_query(frm) {
 	frm.set_query('item_code', 'items', function(doc, cdt, cdn) {
 		var row = locals[cdt][cdn];
+		if (!logistics_cash_advance_row_requires_job_number(frm, row)) {
+			return {};
+		}
 		var job_number = logistics_cash_advance_resolve_item_job_number(frm, row);
 		if (!job_number) {
-			if (frm.doc.fund_type && frm.doc.fund_type !== 'Revolving Fund') {
-				return {};
-			}
 			return { filters: [['Item', 'name', '=', '__no_job_number__']] };
 		}
 		return {
@@ -220,34 +267,32 @@ function logistics_cash_advance_clear_invalid_items(frm) {
 	if (!frm.doc.items || !frm.doc.items.length) {
 		return;
 	}
-	if (frm.doc.fund_type === 'Revolving Fund') {
+	logistics_cash_advance_preload_item_require_job_number(frm).then(function() {
 		$.each(frm.doc.items || [], function(i, row) {
-			if (!row.job_number && row.item_code) {
-				frappe.model.set_value(row.doctype, row.name, 'item_code', null);
+			if (!row.item_code) {
+				return;
 			}
+			if (!logistics_cash_advance_row_requires_job_number(frm, row)) {
+				return;
+			}
+			var job_number = logistics_cash_advance_resolve_item_job_number(frm, row);
+			if (!job_number) {
+				frappe.model.set_value(row.doctype, row.name, 'item_code', null);
+				return;
+			}
+			frappe.call({
+				method: 'logistics.cash_advance.job_charge_items.get_charge_item_codes',
+				args: { job_number: job_number },
+				callback: function(r) {
+					var allowed = r.message || [];
+					if (row.item_code && allowed.indexOf(row.item_code) === -1) {
+						frappe.model.set_value(row.doctype, row.name, 'item_code', null);
+					}
+				}
+			});
 		});
 		frm.refresh_field('items');
 		calculate_totals(frm);
-		return;
-	}
-	if (!frm.doc.job_number) {
-		return;
-	}
-	frappe.call({
-		method: 'logistics.cash_advance.job_charge_items.get_charge_item_codes',
-		args: { job_number: frm.doc.job_number },
-		callback: function(r) {
-			var allowed = r.message || [];
-			var set = {};
-			allowed.forEach(function(name) { set[name] = 1; });
-			$.each(frm.doc.items || [], function(i, row) {
-				if (row.item_code && !set[row.item_code]) {
-					frappe.model.set_value(row.doctype, row.name, 'item_code', null);
-				}
-			});
-			frm.refresh_field('items');
-			calculate_totals(frm);
-		}
 	});
 }
 
@@ -314,7 +359,7 @@ function calculate_totals(frm) {
 frappe.ui.form.on('Cash Advance Request Item', {
 	job_number: function(frm, cdt, cdn) {
 		var row = locals[cdt][cdn];
-		if (frm.doc.fund_type === 'Revolving Fund' && row.item_code) {
+		if (logistics_cash_advance_row_requires_job_number(frm, row) && row.item_code) {
 			frappe.call({
 				method: 'logistics.cash_advance.job_charge_items.get_charge_item_codes',
 				args: { job_number: row.job_number },
@@ -329,7 +374,18 @@ frappe.ui.form.on('Cash Advance Request Item', {
 	},
 
 	item_code: function(frm, cdt, cdn) {
-		calculate_totals(frm);
+		var row = locals[cdt][cdn];
+		logistics_cash_advance_preload_item_require_job_number(frm).then(function() {
+			if (
+				logistics_cash_advance_row_requires_job_number(frm, row) &&
+				!row.job_number &&
+				frm.doc.job_number
+			) {
+				frappe.model.set_value(cdt, cdn, 'job_number', frm.doc.job_number);
+			}
+			logistics_cash_advance_set_item_query(frm);
+			calculate_totals(frm);
+		});
 	},
 
 	amount_requested: function(frm, cdt, cdn) {

--- a/logistics/cash_advance/doctype/cash_advance_request/cash_advance_request.js
+++ b/logistics/cash_advance/doctype/cash_advance_request/cash_advance_request.js
@@ -59,14 +59,6 @@ frappe.ui.form.on('Cash Advance Request', {
 		logistics_cash_advance_set_item_query(frm);
 	},
 
-	job_number: function(frm) {
-		logistics_cash_advance_apply_job_number_dimensions(frm).then(function() {
-			logistics_cash_advance_set_item_query(frm);
-			logistics_cash_advance_clear_invalid_items(frm);
-			logistics_cash_advance_sync_item_job_numbers(frm);
-		});
-	},
-
 	total_requested: function(frm) {
 		calculate_totals(frm);
 	},
@@ -196,22 +188,7 @@ function logistics_cash_advance_toggle_item_job_number(frm) {
 }
 
 function logistics_cash_advance_resolve_item_job_number(frm, row) {
-	if (row && row.job_number) {
-		return row.job_number;
-	}
-	return frm.doc.job_number;
-}
-
-function logistics_cash_advance_sync_item_job_numbers(frm) {
-	if (!frm.doc.require_job_number || !frm.doc.job_number || !frm.doc.items || !frm.doc.items.length) {
-		return;
-	}
-	$.each(frm.doc.items, function(i, row) {
-		if (!logistics_cash_advance_row_requires_job_number(frm, row) || row.job_number) {
-			return;
-		}
-		frappe.model.set_value(row.doctype, row.name, 'job_number', frm.doc.job_number);
-	});
+	return row && row.job_number;
 }
 
 function logistics_cash_advance_set_item_query(frm) {
@@ -241,11 +218,11 @@ function logistics_cash_advance_set_item_query(frm) {
 	});
 }
 
-function logistics_cash_advance_apply_job_number_dimensions(frm) {
-	if (!frm.doc.job_number) {
+function logistics_cash_advance_apply_row_job_number_dimensions(frm, job_number) {
+	if (!job_number) {
 		return Promise.resolve();
 	}
-	return frappe.db.get_doc('Job Number', frm.doc.job_number).then(function(jn) {
+	return frappe.db.get_doc('Job Number', job_number).then(function(jn) {
 		var chain = Promise.resolve();
 		if (jn.company) {
 			chain = chain.then(function() { return frm.set_value('company', jn.company); });
@@ -359,30 +336,25 @@ function calculate_totals(frm) {
 frappe.ui.form.on('Cash Advance Request Item', {
 	job_number: function(frm, cdt, cdn) {
 		var row = locals[cdt][cdn];
-		if (logistics_cash_advance_row_requires_job_number(frm, row) && row.item_code) {
-			frappe.call({
-				method: 'logistics.cash_advance.job_charge_items.get_charge_item_codes',
-				args: { job_number: row.job_number },
-				callback: function(r) {
-					var allowed = r.message || [];
-					if (row.item_code && allowed.indexOf(row.item_code) === -1) {
-						frappe.model.set_value(cdt, cdn, 'item_code', null);
+		logistics_cash_advance_apply_row_job_number_dimensions(frm, row.job_number).then(function() {
+			if (logistics_cash_advance_row_requires_job_number(frm, row) && row.item_code) {
+				frappe.call({
+					method: 'logistics.cash_advance.job_charge_items.get_charge_item_codes',
+					args: { job_number: row.job_number },
+					callback: function(r) {
+						var allowed = r.message || [];
+						if (row.item_code && allowed.indexOf(row.item_code) === -1) {
+							frappe.model.set_value(cdt, cdn, 'item_code', null);
+						}
 					}
-				}
-			});
-		}
+				});
+			}
+			logistics_cash_advance_set_item_query(frm);
+		});
 	},
 
 	item_code: function(frm, cdt, cdn) {
-		var row = locals[cdt][cdn];
 		logistics_cash_advance_preload_item_require_job_number(frm).then(function() {
-			if (
-				logistics_cash_advance_row_requires_job_number(frm, row) &&
-				!row.job_number &&
-				frm.doc.job_number
-			) {
-				frappe.model.set_value(cdt, cdn, 'job_number', frm.doc.job_number);
-			}
 			logistics_cash_advance_set_item_query(frm);
 			calculate_totals(frm);
 		});

--- a/logistics/cash_advance/doctype/cash_advance_request/cash_advance_request.json
+++ b/logistics/cash_advance/doctype/cash_advance_request/cash_advance_request.json
@@ -12,6 +12,7 @@
   "date",
   "fund_source",
   "fund_type",
+  "require_job_number",
   "column_break_tuun",
   "payee",
   "payee_name",
@@ -102,6 +103,14 @@
    "fieldtype": "Select",
    "label": "Fund Type",
    "options": "\nBank\nPetty Cash\nRevolving Fund",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fetch_from": "fund_source.require_job_number",
+   "fieldname": "require_job_number",
+   "fieldtype": "Check",
+   "label": "Require Job Number",
    "read_only": 1
   },
   {

--- a/logistics/cash_advance/doctype/cash_advance_request/cash_advance_request.json
+++ b/logistics/cash_advance/doctype/cash_advance_request/cash_advance_request.json
@@ -16,7 +16,6 @@
   "column_break_tuun",
   "payee",
   "payee_name",
-  "job_number",
   "column_break_xblv",
   "company",
   "branch",
@@ -77,14 +76,6 @@
    "label": "Profit Center",
    "link_filters": "[[\"Profit Center\", \"company\", \"=\", \"eval:doc.company\"]]",
    "options": "Profit Center"
-  },
-  {
-   "fieldname": "job_number",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Job Number",
-   "no_copy": 1,
-   "options": "Job Number"
   },
   {
    "fieldname": "column_break_acct",

--- a/logistics/cash_advance/doctype/cash_advance_request/cash_advance_request.py
+++ b/logistics/cash_advance/doctype/cash_advance_request/cash_advance_request.py
@@ -16,6 +16,10 @@ from logistics.cash_advance.accounting import (
 	ensure_payee_for_party_accounts,
 )
 from logistics.cash_advance.job_charge_items import get_item_codes_for_job_number
+from logistics.cash_advance.job_number_rules import (
+	resolve_row_job_number,
+	row_requires_job_number,
+)
 from logistics.cash_advance.totals_sync import (
 	compute_unliquidated,
 	get_cash_advance_request_totals,
@@ -74,6 +78,7 @@ class CashAdvanceRequest(Document):
 		self._validate_accounting_dimensions()
 		self._validate_fund_source_company()
 		self._validate_fund_source_fund_type()
+		self._sync_require_job_number_from_fund_source()
 		self._validate_request_limit()
 		self._validate_items_against_job()
 
@@ -103,6 +108,13 @@ class CashAdvanceRequest(Document):
 			)
 		if self.fund_type and self.fund_type != fund_type:
 			self.fund_type = fund_type
+
+	def _sync_require_job_number_from_fund_source(self):
+		if not self.fund_source:
+			return
+		self.require_job_number = cint(
+			frappe.db.get_value("Account", self.fund_source, "require_job_number")
+		)
 
 	def _validate_request_limit(self):
 		if not self.fund_source:
@@ -263,35 +275,20 @@ class CashAdvanceRequest(Document):
 			)
 
 	def _validate_items_against_job(self):
-		if self.fund_type == "Revolving Fund":
-			for idx, row in enumerate(self.items or [], start=1):
-				if not row.item_code and not row.job_number:
-					continue
-				if not row.job_number:
-					frappe.throw(
-						_("Row {0}: Job Number is required for Revolving Fund items.").format(idx)
-					)
-				self._validate_item_job_number_company(row.job_number)
-				allowed = set(get_item_codes_for_job_number(row.job_number))
-				if row.item_code and row.item_code not in allowed:
-					frappe.throw(
-						_("Row {0}: Charge Item {1} is not on the charges for Job Number {2}.").format(
-							idx, row.item_code, row.job_number
-						)
-					)
-			return
-
-		if not self.job_number:
-			return
-
-		allowed = set(get_item_codes_for_job_number(self.job_number))
-		for row in self.items or []:
+		for idx, row in enumerate(self.items or [], start=1):
 			if not row.item_code:
 				continue
+			if not row_requires_job_number(self.require_job_number, row.item_code):
+				continue
+			job_number = resolve_row_job_number(self.job_number, row)
+			if not job_number:
+				frappe.throw(_("Row {0}: Job Number is required for this charge item.").format(idx))
+			self._validate_item_job_number_company(job_number)
+			allowed = set(get_item_codes_for_job_number(job_number))
 			if row.item_code not in allowed:
 				frappe.throw(
-					_("Charge Item {0} is not on the charges for Job Number {1}.").format(
-						row.item_code, self.job_number
+					_("Row {0}: Charge Item {1} is not on the charges for Job Number {2}.").format(
+						idx, row.item_code, job_number
 					)
 				)
 

--- a/logistics/cash_advance/doctype/cash_advance_request/cash_advance_request.py
+++ b/logistics/cash_advance/doctype/cash_advance_request/cash_advance_request.py
@@ -16,10 +16,7 @@ from logistics.cash_advance.accounting import (
 	ensure_payee_for_party_accounts,
 )
 from logistics.cash_advance.job_charge_items import get_item_codes_for_job_number
-from logistics.cash_advance.job_number_rules import (
-	resolve_row_job_number,
-	row_requires_job_number,
-)
+from logistics.cash_advance.job_number_rules import row_requires_job_number
 from logistics.cash_advance.totals_sync import (
 	compute_unliquidated,
 	get_cash_advance_request_totals,
@@ -74,7 +71,6 @@ class CashAdvanceRequest(Document):
 
 	def validate(self):
 		self._validate_no_overdue_advance_for_payee()
-		self._validate_job_number_company_alignment()
 		self._validate_accounting_dimensions()
 		self._validate_fund_source_company()
 		self._validate_fund_source_fund_type()
@@ -263,32 +259,20 @@ class CashAdvanceRequest(Document):
 					)
 				return
 
-	def _validate_job_number_company_alignment(self):
-		if not self.job_number:
-			return
-		jn = frappe.get_doc("Job Number", self.job_number)
-		if jn.company and self.company and jn.company != self.company:
-			frappe.throw(
-				_("Company {0} does not match Job Number {1} ({2}).").format(
-					self.company, self.job_number, jn.company
-				)
-			)
-
 	def _validate_items_against_job(self):
 		for idx, row in enumerate(self.items or [], start=1):
 			if not row.item_code:
 				continue
 			if not row_requires_job_number(self.require_job_number, row.item_code):
 				continue
-			job_number = resolve_row_job_number(self.job_number, row)
-			if not job_number:
+			if not row.job_number:
 				frappe.throw(_("Row {0}: Job Number is required for this charge item.").format(idx))
-			self._validate_item_job_number_company(job_number)
-			allowed = set(get_item_codes_for_job_number(job_number))
+			self._validate_item_job_number_company(row.job_number)
+			allowed = set(get_item_codes_for_job_number(row.job_number))
 			if row.item_code not in allowed:
 				frappe.throw(
 					_("Row {0}: Charge Item {1} is not on the charges for Job Number {2}.").format(
-						idx, row.item_code, job_number
+						idx, row.item_code, row.job_number
 					)
 				)
 

--- a/logistics/cash_advance/job_number_rules.py
+++ b/logistics/cash_advance/job_number_rules.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026, www.agilasoft.com and contributors
+
+from __future__ import unicode_literals
+
+from typing import Optional
+
+import frappe
+from frappe.utils import cint
+
+
+def get_item_require_job_number(item_code: Optional[str]) -> bool:
+	if not item_code:
+		return False
+	return bool(cint(frappe.db.get_value("Item", item_code, "require_job_number")))
+
+
+def row_requires_job_number(require_job_number_flag, item_code: Optional[str]) -> bool:
+	return bool(cint(require_job_number_flag)) and get_item_require_job_number(item_code)
+
+
+def resolve_row_job_number(parent_job_number: Optional[str], row) -> Optional[str]:
+	row_job_number = getattr(row, "job_number", None)
+	if row_job_number:
+		return row_job_number
+	return parent_job_number

--- a/logistics/cash_advance/report/cash_advance_liquidation_aging/cash_advance_liquidation_aging.py
+++ b/logistics/cash_advance/report/cash_advance_liquidation_aging/cash_advance_liquidation_aging.py
@@ -71,10 +71,19 @@ def _rows(filters, as_on):
 	else:
 		conditions.append("car.docstatus = 1")
 
-	for field in ("company", "branch", "cost_center", "profit_center", "job_number", "payee"):
+	for field in ("company", "branch", "cost_center", "profit_center", "payee"):
 		if filters.get(field):
 			conditions.append("car.`{0}` = %({0})s".format(field))
 			values[field] = filters[field]
+
+	if filters.get("job_number"):
+		conditions.append(
+			"""EXISTS (
+				SELECT 1 FROM `tabCash Advance Request Item` cari
+				WHERE cari.parent = car.name AND cari.job_number = %(job_number)s
+			)"""
+		)
+		values["job_number"] = filters["job_number"]
 
 	where = " AND ".join(conditions)
 
@@ -82,7 +91,12 @@ def _rows(filters, as_on):
 		"""
 		SELECT
 			car.name, car.date, car.release_date, car.liquidation_due_date,
-			car.payee, car.payee_name, car.job_number,
+			car.payee, car.payee_name,
+			(
+				SELECT MIN(cari.job_number)
+				FROM `tabCash Advance Request Item` cari
+				WHERE cari.parent = car.name AND IFNULL(cari.job_number, '') != ''
+			) AS job_number,
 			car.company, car.branch, car.cost_center, car.profit_center,
 			car.total_requested,
 			IFNULL(liq.total_liquidated, 0) AS total_liquidated,

--- a/logistics/cash_advance/report/cash_advance_request_job_number_portfolio_concentration/cash_advance_request_job_number_portfolio_concentration.py
+++ b/logistics/cash_advance/report/cash_advance_request_job_number_portfolio_concentration/cash_advance_request_job_number_portfolio_concentration.py
@@ -3,14 +3,53 @@
 # For license information, please see license.txt
 from __future__ import unicode_literals
 
-import json
+import frappe
+from frappe import _
+from frappe.utils import cint, flt
 
-from logistics.analytics_reports.management_reports import run_management_report
-
-REF_DOCTYPE = 'Cash Advance Request'
-HANDLER_ID = 'top_value'
-OPTIONS = json.loads('{"field":"job_number","limit":15}')
+from logistics.analytics_reports.management_reports import bar_top_numeric
 
 
 def execute(filters=None):
-	return run_management_report(REF_DOCTYPE, HANDLER_ID, filters, OPTIONS)
+	filters = frappe._dict(filters or {})
+	limit = cint(filters.get("limit")) or 15
+	conditions = ["car.docstatus = 1", "IFNULL(cari.job_number, '') != ''"]
+	values = {"limit": limit}
+
+	for field in ("company", "branch", "cost_center", "profit_center", "payee"):
+		if filters.get(field):
+			conditions.append(f"car.`{field}` = %({field})s")
+			values[field] = filters[field]
+
+	if filters.get("job_number"):
+		conditions.append("cari.job_number = %(job_number)s")
+		values["job_number"] = filters["job_number"]
+
+	where = " AND ".join(conditions)
+	columns = [
+		{"fieldname": "bucket", "label": _("Job Number"), "fieldtype": "Link", "options": "Job Number", "width": 220},
+		{"fieldname": "metric", "label": _("Value"), "fieldtype": "Currency", "width": 140},
+		{"fieldname": "share_pct", "label": _("Of total %"), "fieldtype": "Percent", "width": 100},
+	]
+
+	rows = frappe.db.sql(
+		f"""
+		SELECT cari.job_number AS bucket, COALESCE(SUM(car.total_requested), 0) AS metric
+		FROM `tabCash Advance Request Item` cari
+		INNER JOIN `tabCash Advance Request` car ON car.name = cari.parent
+		WHERE {where}
+		GROUP BY cari.job_number
+		ORDER BY metric DESC
+		LIMIT %(limit)s
+		""",
+		values,
+		as_dict=1,
+	)
+
+	total_metric = sum(flt(r.get("metric")) for r in rows) or 1
+	for row in rows:
+		row["share_pct"] = round(100.0 * flt(row.get("metric")) / total_metric, 2)
+
+	chart = bar_top_numeric(rows, "bucket", "metric", limit=limit, dataset_label=_("Value"))
+	summary = [{"label": _("Top slice total"), "value": flt(total_metric), "indicator": "green"}]
+	return columns, rows, None, chart, summary

--- a/logistics/cash_advance/report/cash_advance_request_unliquidated_aging_by_liquidation_due_date/cash_advance_request_unliquidated_aging_by_liquidation_due_date.py
+++ b/logistics/cash_advance/report/cash_advance_request_unliquidated_aging_by_liquidation_due_date/cash_advance_request_unliquidated_aging_by_liquidation_due_date.py
@@ -17,10 +17,18 @@ def execute(filters=None):
 	joins = unliquidated_join_sql(car)
 
 	where, values = ["car.docstatus = 1", "car.liquidation_due_date IS NOT NULL", f"({unliquidated_expr}) > 0"], {}
-	for field in ("company", "branch", "cost_center", "profit_center", "job_number", "payee"):
+	for field in ("company", "branch", "cost_center", "profit_center", "payee"):
 		if filters.get(field):
 			where.append(f"car.`{field}` = %({field})s")
 			values[field] = filters[field]
+	if filters.get("job_number"):
+		where.append(
+			"""EXISTS (
+				SELECT 1 FROM `tabCash Advance Request Item` cari
+				WHERE cari.parent = car.name AND cari.job_number = %(job_number)s
+			)"""
+		)
+		values["job_number"] = filters["job_number"]
 
 	columns = [
 		{"fieldname": "age_bucket", "label": _("Aging bucket"), "fieldtype": "Data", "width": 180},

--- a/logistics/logistics/custom/account.json
+++ b/logistics/logistics/custom/account.json
@@ -28,6 +28,15 @@
    "insert_after": "fund_type",
    "depends_on": "eval:!doc.is_group && ['Bank', 'Cash'].includes(doc.account_type) && doc.fund_type",
    "description": "Maximum total amount allowed per Cash Advance Request from this fund source."
+  },
+  {
+   "dt": "Account",
+   "fieldname": "require_job_number",
+   "fieldtype": "Check",
+   "label": "Require Job Number",
+   "insert_after": "cash_advance_request_limit",
+   "depends_on": "eval:!doc.is_group && ['Bank', 'Cash'].includes(doc.account_type) && doc.fund_type",
+   "description": "When enabled, cash advance lines for charge items marked Require Job Number must include a Job Number."
   }
  ],
  "custom_perms": [],

--- a/logistics/logistics/custom/item.json
+++ b/logistics/logistics/custom/item.json
@@ -1189,6 +1189,21 @@
    "width": null
   },
   {
+   "creation": "2026-07-07 00:00:00",
+   "default": "0",
+   "depends_on": "eval:doc.custom_logistics_charge_item",
+   "description": "When enabled, cash advance lines using this charge item must include a Job Number when the fund source requires it.",
+   "dt": "Item",
+   "fieldname": "require_job_number",
+   "fieldtype": "Check",
+   "insert_after": "custom_logistics_charge_item",
+   "label": "Require Job Number",
+   "modified": "2026-07-07 00:00:00",
+   "modified_by": "Administrator",
+   "name": "Item-require_job_number",
+   "owner": "Administrator"
+  },
+  {
    "_assign": null,
    "_comments": null,
    "_liked_by": null,

--- a/logistics/patches.txt
+++ b/logistics/patches.txt
@@ -315,3 +315,5 @@ logistics.patches.v3_0_add_charge_unit_breaks
 logistics.patches.v3_0_sync_special_project_service_financials
 # Cash Advance: backfill Require Job Number on Revolving Fund accounts
 logistics.patches.v3_0_backfill_account_require_job_number_for_revolving_fund
+# Cash Advance: drop header job_number from Cash Advance Request
+logistics.patches.v3_0_drop_cash_advance_request_job_number

--- a/logistics/patches.txt
+++ b/logistics/patches.txt
@@ -313,3 +313,5 @@ logistics.patches.v3_0_backfill_freight_agent_covered_unlocs_from_default
 logistics.patches.v3_0_add_charge_unit_breaks
 # Special Project: backfill service-row planned/actual from charges and linked jobs
 logistics.patches.v3_0_sync_special_project_service_financials
+# Cash Advance: backfill Require Job Number on Revolving Fund accounts
+logistics.patches.v3_0_backfill_account_require_job_number_for_revolving_fund

--- a/logistics/patches/v3_0_backfill_account_require_job_number_for_revolving_fund.py
+++ b/logistics/patches/v3_0_backfill_account_require_job_number_for_revolving_fund.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2026, Agilasoft and contributors
+
+import frappe
+
+
+def execute():
+	frappe.db.sql(
+		"""
+		UPDATE `tabAccount`
+		SET require_job_number = 1
+		WHERE fund_type = 'Revolving Fund'
+		  AND IFNULL(require_job_number, 0) = 0
+		"""
+	)

--- a/logistics/patches/v3_0_drop_cash_advance_request_job_number.py
+++ b/logistics/patches/v3_0_drop_cash_advance_request_job_number.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, Agilasoft and contributors
+
+import frappe
+
+
+def execute():
+	if not frappe.db.has_column("Cash Advance Request", "job_number"):
+		return
+	frappe.db.sql_ddl("ALTER TABLE `tabCash Advance Request` DROP COLUMN `job_number`")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces Fund Type–based Job Number validation with configurable checkboxes on **Fund Source**, **Cash Advance Request**, and **Item**. Job numbers live on **item rows only** (no Cash Advance Request header field).

## Merge with `develop`

Resolved conflicts from overlapping PRs already merged to `develop`:
- #1168 — filter charge items when job number is required (fund_type-based)
- #1170 — require job number on liquidation when request is linked (fund_type-based)

This branch supersedes both with the `require_job_number` checkbox design.

## Test plan

- [ ] Cash Advance Request has no header Job Number; row-level validation works
- [ ] Fund Source **Require Job Number** + Item **Require Job Number** gates validation
- [ ] Cash Advance Liquidation inherits row-level rules from linked request
- [ ] Run `bench migrate` for schema/custom field updates
- [ ] Job number reports still work from item rows
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-afafdb3b-440e-4431-a118-b65093376955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afafdb3b-440e-4431-a118-b65093376955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

