### PR TITLE
feat(cash-advance): Extend Due Date with reason codes and due date settings

### DIFF
--- a/logistics/cash_advance/doctype/cash_advance_reason_code/cash_advance_reason_code.js
+++ b/logistics/cash_advance/doctype/cash_advance_reason_code/cash_advance_reason_code.js
@@ -1,0 +1,1 @@
+// Copyright (c) 2026, www.agilasoft.com and contributors

--- a/logistics/cash_advance/doctype/cash_advance_reason_code/cash_advance_reason_code.json
+++ b/logistics/cash_advance/doctype/cash_advance_reason_code/cash_advance_reason_code.json
@@ -1,0 +1,86 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:reason_code",
+ "creation": "2026-07-07 08:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "reason_code",
+  "description",
+  "column_break_1",
+  "is_active"
+ ],
+ "fields": [
+  {
+   "fieldname": "reason_code",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Reason Code",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Small Text",
+   "in_list_view": 1,
+   "label": "Description"
+  },
+  {
+   "fieldname": "column_break_1",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "1",
+   "fieldname": "is_active",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Is Active"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-07-07 08:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Cash Advance",
+ "name": "Cash Advance Reason Code",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "read": 1,
+   "role": "Accounts User"
+  }
+ ],
+ "quick_entry": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/logistics/cash_advance/doctype/cash_advance_reason_code/cash_advance_reason_code.py
+++ b/logistics/cash_advance/doctype/cash_advance_reason_code/cash_advance_reason_code.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026, www.agilasoft.com and contributors
+
+from __future__ import unicode_literals
+
+from frappe.model.document import Document
+
+
+class CashAdvanceReasonCode(Document):
+	pass

--- a/logistics/cash_advance/doctype/cash_advance_request/cash_advance_request.js
+++ b/logistics/cash_advance/doctype/cash_advance_request/cash_advance_request.js
@@ -8,6 +8,10 @@ frappe.ui.form.on('Cash Advance Request', {
 			logistics_cash_advance_toggle_item_job_number(frm);
 		});
 
+		if (frm.doc.docstatus === 0 && frm.doc.date && frm.doc.company) {
+			logistics_cash_advance_set_default_liquidation_due_date(frm);
+		}
+
 		if (
 			!frm.is_new() &&
 			!frm.doc.__islocal &&
@@ -30,6 +34,11 @@ frappe.ui.form.on('Cash Advance Request', {
 		logistics_cash_advance_set_employee_advance_query(frm);
 		logistics_cash_advance_set_dimension_queries(frm);
 		logistics_cash_advance_clear_mismatched_dimensions(frm);
+		logistics_cash_advance_set_default_liquidation_due_date(frm);
+	},
+
+	date: function(frm) {
+		logistics_cash_advance_set_default_liquidation_due_date(frm);
 	},
 
 	fund_source: function(frm) {
@@ -273,49 +282,118 @@ function logistics_cash_advance_clear_invalid_items(frm) {
 	});
 }
 
+function logistics_cash_advance_set_default_liquidation_due_date(frm) {
+	if (!frm.doc || frm.doc.docstatus !== 0 || !frm.doc.date) {
+		return;
+	}
+
+	var set_with_offset = function(offsetDays) {
+		var base = frm.doc.date;
+		var days = (typeof offsetDays === 'number' && !isNaN(offsetDays)) ? offsetDays : 30;
+		frm.set_value('liquidation_due_date', frappe.datetime.add_days(base, days));
+	};
+
+	frm._cash_advance_due_date_cache = frm._cash_advance_due_date_cache || {};
+	if (frm._cash_advance_due_date_cache[frm.doc.company] != null) {
+		set_with_offset(frm._cash_advance_due_date_cache[frm.doc.company]);
+		return;
+	}
+
+	frappe.call({
+		method: 'logistics.cash_advance.doctype.cash_advance_settings.cash_advance_settings.get_due_date_settings',
+		args: { company: frm.doc.company },
+		callback: function(r) {
+			var days = (r && r.message && r.message.liquidation_due_date_offset_days != null)
+				? r.message.liquidation_due_date_offset_days
+				: 30;
+			frm._cash_advance_due_date_cache[frm.doc.company] = days;
+			set_with_offset(days);
+		}
+	});
+}
+
 function logistics_cash_advance_extend_due_date(frm) {
 	var base = frm.doc.liquidation_due_date || frappe.datetime.get_today();
 	var default_date = frappe.datetime.add_days(base, 30);
-	frappe.prompt(
-		[
-			{
-				fieldname: 'liquidation_due_date',
-				fieldtype: 'Date',
-				label: __('New Liquidation Due Date'),
-				reqd: 1,
-				default: default_date,
-				description: __('Must be after the current due date and not before today.')
-			},
-			{
-				fieldname: 'reason',
-				fieldtype: 'Small Text',
-				label: __('Reason')
-			}
-		],
-		function(values) {
-			frappe.call({
-				method: 'logistics.cash_advance.doctype.cash_advance_request.cash_advance_request.extend_liquidation_due_date',
-				args: {
-					cash_advance_request: frm.doc.name,
-					liquidation_due_date: values.liquidation_due_date,
-					reason: values.reason
+
+	var show_prompt = function(max_extension_days) {
+		var max_days = (typeof max_extension_days === 'number' && !isNaN(max_extension_days))
+			? max_extension_days
+			: 30;
+		var description = __('Must be after the current due date and not before today.');
+		if (max_days > 0) {
+			description += ' ' + __('Maximum extension: {0} day(s).', [max_days]);
+		}
+
+		frappe.prompt(
+			[
+				{
+					fieldname: 'liquidation_due_date',
+					fieldtype: 'Date',
+					label: __('New Liquidation Due Date'),
+					reqd: 1,
+					default: default_date,
+					description: description
 				},
-				freeze: true,
-				freeze_message: __('Extending due date...'),
-				callback: function(r) {
-					if (r.message && r.message.success) {
-						frm.reload_doc();
-						frappe.show_alert({
-							message: r.message.message || __('Due date updated.'),
-							indicator: 'green'
-						}, 5);
+				{
+					fieldname: 'reason_code',
+					fieldtype: 'Link',
+					label: __('Reason Code'),
+					options: 'Cash Advance Reason Code',
+					reqd: 1,
+					get_query: function() {
+						return {
+							filters: { is_active: 1 }
+						};
 					}
+				},
+				{
+					fieldname: 'reason_description',
+					fieldtype: 'Small Text',
+					label: __('Reason Description'),
+					reqd: 1
 				}
-			});
-		},
-		__('Extend Due Date'),
-		__('Update')
-	);
+			],
+			function(values) {
+				frappe.call({
+					method: 'logistics.cash_advance.doctype.cash_advance_request.cash_advance_request.extend_liquidation_due_date',
+					args: {
+						cash_advance_request: frm.doc.name,
+						liquidation_due_date: values.liquidation_due_date,
+						reason_code: values.reason_code,
+						reason_description: values.reason_description
+					},
+					freeze: true,
+					freeze_message: __('Extending due date...'),
+					callback: function(r) {
+						if (r.message && r.message.success) {
+							frm.reload_doc();
+							frappe.show_alert({
+								message: r.message.message || __('Due date updated.'),
+								indicator: 'green'
+							}, 5);
+						}
+					}
+				});
+			},
+			__('Extend Due Date'),
+			__('Update')
+		);
+	};
+
+	frappe.call({
+		method: 'logistics.cash_advance.doctype.cash_advance_settings.cash_advance_settings.get_due_date_settings',
+		args: { company: frm.doc.company },
+		callback: function(r) {
+			var max_extension_days = (r && r.message && r.message.max_due_date_extension_days != null)
+				? r.message.max_due_date_extension_days
+				: 30;
+			if (max_extension_days > 0) {
+				default_date = frappe.datetime.add_days(base, max_extension_days);
+			}
+			show_prompt(max_extension_days);
+		}
+	});
 }
 
 function calculate_totals(frm) {

--- a/logistics/cash_advance/doctype/cash_advance_request/cash_advance_request.py
+++ b/logistics/cash_advance/doctype/cash_advance_request/cash_advance_request.py
@@ -7,13 +7,16 @@ from __future__ import unicode_literals
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import cint, flt, fmt_money, formatdate, get_link_to_form, getdate, nowdate, today
+from frappe.utils import cint, date_diff, flt, fmt_money, formatdate, get_link_to_form, getdate, nowdate, today
 
 from logistics.cash_advance.accounting import (
 	_validate_cash_bank_account,
 	cancel_journal_entry,
 	create_advance_release_journal_entry,
 	ensure_payee_for_party_accounts,
+)
+from logistics.cash_advance.doctype.cash_advance_settings.cash_advance_settings import (
+	get_max_due_date_extension_days,
 )
 from logistics.cash_advance.job_charge_items import get_item_codes_for_job_number
 from logistics.cash_advance.job_number_rules import row_requires_job_number
@@ -308,11 +311,26 @@ class CashAdvanceRequest(Document):
 
 
 @frappe.whitelist()
-def extend_liquidation_due_date(cash_advance_request, liquidation_due_date, reason=None):
+def extend_liquidation_due_date(
+	cash_advance_request,
+	liquidation_due_date,
+	reason_code=None,
+	reason_description=None,
+):
 	"""Extend liquidation due date on a submitted cash advance with an outstanding balance."""
 	if not cash_advance_request:
 		frappe.throw(_("Cash Advance Request is required."))
 	frappe.has_permission("Cash Advance Request", "write", doc=cash_advance_request, throw=True)
+
+	if not reason_code:
+		frappe.throw(_("Reason Code is required."), title=_("Missing Reason Code"))
+	if not reason_description or not str(reason_description).strip():
+		frappe.throw(_("Reason Description is required."), title=_("Missing Reason Description"))
+
+	if not frappe.db.exists("Cash Advance Reason Code", reason_code):
+		frappe.throw(_("Reason Code {0} does not exist.").format(reason_code))
+	if not cint(frappe.db.get_value("Cash Advance Reason Code", reason_code, "is_active")):
+		frappe.throw(_("Reason Code {0} is not active.").format(reason_code))
 
 	doc = frappe.get_doc("Cash Advance Request", cash_advance_request)
 	if doc.docstatus != 1:
@@ -335,14 +353,40 @@ def extend_liquidation_due_date(cash_advance_request, liquidation_due_date, reas
 				),
 				title=_("Invalid Extension"),
 			)
+		extension_days = date_diff(new_due, old_d)
+	else:
+		extension_days = date_diff(new_due, today_d)
 
-	updates = {"liquidation_due_date": new_due}
-	if reason and str(reason).strip():
-		prefix = _("Due date extended to {0}: ").format(formatdate(new_due))
-		existing = (doc.status_reason or "").strip()
-		updates["status_reason"] = (existing + "\n" + prefix + str(reason).strip()).strip() if existing else prefix + str(reason).strip()
+	max_extension_days = get_max_due_date_extension_days(doc.company)
+	if max_extension_days > 0 and extension_days > max_extension_days:
+		frappe.throw(
+			_(
+				"Due date extension of {0} day(s) exceeds the maximum allowed extension of {1} day(s) for company {2}."
+			).format(extension_days, max_extension_days, doc.company),
+			title=_("Extension Limit Exceeded"),
+		)
 
-	frappe.db.set_value("Cash Advance Request", doc.name, updates, update_modified=True)
+	reason_label = reason_code
+	reason_master_description = frappe.db.get_value(
+		"Cash Advance Reason Code", reason_code, "description"
+	)
+	if reason_master_description:
+		reason_label = f"{reason_code} ({reason_master_description})"
+
+	reason_text = str(reason_description).strip()
+	prefix = _("Due date extended to {0} [{1}]: ").format(formatdate(new_due), reason_label)
+	existing = (doc.status_reason or "").strip()
+	status_reason = (existing + "\n" + prefix + reason_text).strip() if existing else prefix + reason_text
+
+	frappe.db.set_value(
+		"Cash Advance Request",
+		doc.name,
+		{
+			"liquidation_due_date": new_due,
+			"status_reason": status_reason,
+		},
+		update_modified=True,
+	)
 
 	return {
 		"success": True,

--- a/logistics/cash_advance/doctype/cash_advance_settings/cash_advance_settings.json
+++ b/logistics/cash_advance/doctype/cash_advance_settings/cash_advance_settings.json
@@ -8,7 +8,10 @@
  "engine": "InnoDB",
  "field_order": [
   "company",
-  "ar_employee_account"
+  "ar_employee_account",
+  "section_break_due_dates",
+  "liquidation_due_date_offset_days",
+  "max_due_date_extension_days"
  ],
  "fields": [
   {
@@ -28,6 +31,29 @@
    "label": "A/R Employee (Employee Advance)",
    "options": "Account",
    "description": "Receivable / employee advance control account debited when cash is released to the employee (required before submitting cash advances)."
+  },
+  {
+   "fieldname": "section_break_due_dates",
+   "fieldtype": "Section Break",
+   "label": "Liquidation Due Dates"
+  },
+  {
+   "default": "30",
+   "description": "Number of days to add to Request Date when setting the default Liquidation Due Date on new Cash Advance Requests.",
+   "fieldname": "liquidation_due_date_offset_days",
+   "fieldtype": "Int",
+   "label": "Default Due Date Offset (Days)",
+   "non_negative": 1,
+   "reqd": 1
+  },
+  {
+   "default": "30",
+   "description": "Maximum number of days a liquidation due date can be extended beyond the current due date in one extension.",
+   "fieldname": "max_due_date_extension_days",
+   "fieldtype": "Int",
+   "label": "Maximum Due Date Extension (Days)",
+   "non_negative": 1,
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,

--- a/logistics/cash_advance/doctype/cash_advance_settings/cash_advance_settings.py
+++ b/logistics/cash_advance/doctype/cash_advance_settings/cash_advance_settings.py
@@ -6,6 +6,11 @@ from __future__ import unicode_literals
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.utils import cint
+
+
+DEFAULT_LIQUIDATION_DUE_DATE_OFFSET_DAYS = 30
+DEFAULT_MAX_DUE_DATE_EXTENSION_DAYS = 30
 
 
 class CashAdvanceSettings(Document):
@@ -13,6 +18,7 @@ class CashAdvanceSettings(Document):
 		if not self.company:
 			frappe.throw(_("Company is required."), title=_("Cash Advance Settings"))
 		self.validate_ar_employee_account()
+		self.validate_due_date_settings()
 
 	def validate_ar_employee_account(self):
 		acc = self.ar_employee_account
@@ -25,6 +31,12 @@ class CashAdvanceSettings(Document):
 			frappe.throw(
 				_("A/R Employee account {0} does not belong to company {1}.").format(acc, self.company)
 			)
+
+	def validate_due_date_settings(self):
+		if cint(self.liquidation_due_date_offset_days) < 0:
+			frappe.throw(_("Default Due Date Offset (Days) cannot be negative."))
+		if cint(self.max_due_date_extension_days) < 0:
+			frappe.throw(_("Maximum Due Date Extension (Days) cannot be negative."))
 
 	def on_update(self):
 		frappe.clear_cache()
@@ -43,3 +55,42 @@ class CashAdvanceSettings(Document):
 		except frappe.DoesNotExistError:
 			pass
 		return None
+
+
+def get_liquidation_due_date_offset_days(company: str | None = None) -> int:
+	"""Return default liquidation due date offset in days for the company."""
+	if not company:
+		return DEFAULT_LIQUIDATION_DUE_DATE_OFFSET_DAYS
+	try:
+		value = frappe.db.get_value(
+			"Cash Advance Settings",
+			{"company": company},
+			"liquidation_due_date_offset_days",
+		)
+		return cint(value) if value is not None else DEFAULT_LIQUIDATION_DUE_DATE_OFFSET_DAYS
+	except Exception:
+		return DEFAULT_LIQUIDATION_DUE_DATE_OFFSET_DAYS
+
+
+def get_max_due_date_extension_days(company: str | None = None) -> int:
+	"""Return maximum due date extension days allowed in one extension."""
+	if not company:
+		return DEFAULT_MAX_DUE_DATE_EXTENSION_DAYS
+	try:
+		value = frappe.db.get_value(
+			"Cash Advance Settings",
+			{"company": company},
+			"max_due_date_extension_days",
+		)
+		return cint(value) if value is not None else DEFAULT_MAX_DUE_DATE_EXTENSION_DAYS
+	except Exception:
+		return DEFAULT_MAX_DUE_DATE_EXTENSION_DAYS
+
+
+@frappe.whitelist()
+def get_due_date_settings(company: str | None = None) -> dict:
+	"""Desk helper for liquidation due date defaults and extension limits."""
+	return {
+		"liquidation_due_date_offset_days": get_liquidation_due_date_offset_days(company),
+		"max_due_date_extension_days": get_max_due_date_extension_days(company),
+	}

--- a/logistics/cash_advance/workspace/cash_advance/cash_advance.json
+++ b/logistics/cash_advance/workspace/cash_advance/cash_advance.json
@@ -45,6 +45,16 @@
   {
    "hidden": 0,
    "is_query_report": 0,
+   "label": "Cash Advance Reason Code",
+   "link_count": 0,
+   "link_to": "Cash Advance Reason Code",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
    "label": "Aging & Overdue",
    "link_count": 3,
    "link_type": "DocType",

--- a/logistics/patches.txt
+++ b/logistics/patches.txt
@@ -320,3 +320,5 @@ logistics.patches.v3_0_drop_cash_advance_request_job_number
 # Cash Advance: migrate global settings to per-company records (#1173)
 logistics.patches.v3_0_migrate_cash_advance_settings_per_company
 logistics.patches.v3_0_ensure_cash_advance_settings_company_records
+# Cash Advance: seed default due date extension reason codes
+logistics.patches.v3_0_seed_cash_advance_reason_codes

--- a/logistics/patches/v3_0_seed_cash_advance_reason_codes.py
+++ b/logistics/patches/v3_0_seed_cash_advance_reason_codes.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2026, Agilasoft and contributors
+# For license information, please see license.txt
+
+"""Seed default Cash Advance Reason Code options for due date extensions."""
+
+from __future__ import annotations
+
+import frappe
+
+DEFAULT_REASON_CODES = (
+	("EXT-OPS", "Operational extension"),
+	("EXT-EMR", "Emergency or urgent need"),
+	("EXT-APR", "Management approval"),
+)
+
+
+def execute():
+	if not frappe.db.exists("DocType", "Cash Advance Reason Code"):
+		return
+
+	for reason_code, description in DEFAULT_REASON_CODES:
+		if frappe.db.exists("Cash Advance Reason Code", reason_code):
+			frappe.db.set_value(
+				"Cash Advance Reason Code",
+				reason_code,
+				{"description": description, "is_active": 1},
+				update_modified=False,
+			)
+			continue
+		doc = frappe.new_doc("Cash Advance Reason Code")
+		doc.reason_code = reason_code
+		doc.description = description
+		doc.is_active = 1
+		doc.insert(ignore_permissions=True)
+
+	frappe.db.commit()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Enhances Cash Advance due date handling with configurable settings and structured extension reasons.

- **Cash Advance Request — Actions > Extend Due Date**: Dialog now requires **Reason Code** (Link to `Cash Advance Reason Code`) and **Reason Description**. Extension is validated against the per-company maximum extension days from settings. Audit trail is appended to `status_reason` with the reason code and description.
- **Cash Advance Settings**: New per-company fields:
  - **Default Due Date Offset (Days)** — days added to Request Date when setting the default `liquidation_due_date` on new draft requests
  - **Maximum Due Date Extension (Days)** — cap on how far a due date can be extended in one action
- **Cash Advance Reason Code**: New master DocType for extension reason codes (seeded with `EXT-OPS`, `EXT-EMR`, `EXT-APR` via migration patch).
- **Workspace**: Added link to Cash Advance Reason Code from the Cash Advance workspace.

## Test plan

- [ ] Open **Cash Advance Settings** for a company and set Default Due Date Offset and Maximum Due Date Extension days.
- [ ] Create a new **Cash Advance Request** draft; confirm `liquidation_due_date` auto-fills as Request Date + offset days when company/date are set.
- [ ] Submit a request with an unliquidated balance; use **Actions > Extend Due Date**.
- [ ] Confirm dialog requires Reason Code and Reason Description; inactive reason codes are not selectable.
- [ ] Confirm extension beyond the configured maximum is rejected server-side.
- [ ] Confirm `status_reason` records the extension with reason code and description.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65b82597-2a14-4e17-8733-0b1ec0ef86e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65b82597-2a14-4e17-8733-0b1ec0ef86e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

