### PR TITLE
docs: add Cursor Cloud dev environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is the **CargoNext** logistics app (`logistics`), a custom app for the **Frappe Framework v16 + ERPNext v16**. It only runs inside a Frappe *bench*. The bench is pre-provisioned in the VM snapshot at `~/frappe-bench`, with `apps/logistics` symlinked to this repo (`/workspace`), so edits here are picked up live.
+
+Key facts:
+- **Bench:** `~/frappe-bench` (Frappe v16 + ERPNext v16, Python 3.14 venv at `~/frappe-bench/env`).
+- **Site:** `logistics.localhost` (default site). Admin login: `Administrator` / `admin`. MariaDB root password: `frappe`.
+- **UI:** http://logistics.localhost:8000 (a `logistics.localhost` → 127.0.0.1 entry is in `/etc/hosts`). The first-run setup wizard has already been completed (Company: CargoNext).
+
+### Starting services (must be done each session — no systemd auto-start)
+Services do not auto-start. Start the database first, then the bench dev stack:
+```bash
+sudo service mariadb start            # MariaDB (required, must be up before bench)
+cd ~/frappe-bench && bench start      # web :8000, socketio :9000, its own Redis (:11000/:13000), workers, scheduler, asset watcher
+```
+`bench start` launches Frappe's own Redis instances and the JS/CSS watcher; you do NOT need the system `redis-server`. Run `bench start` in a long-lived tmux session (it is a foreground dev server — never put it in the update script).
+
+### Node version gotcha (non-obvious)
+Frappe v16 requires **Node >= 24**, but a `node` v22 shim on `PATH` at `/exec-daemon/node` shadows nvm. `~/.bashrc` prepends the nvm Node 24 bin dir so login shells get Node 24 (needed for `yarn`, `bench build`, and the asset watcher). If yarn/asset builds fail with an "engine node incompatible, Expected >=24" error, you are using the wrong Node — start a fresh login shell (`bash -l`) so the bashrc fix applies.
+
+### Syncing DocTypes after code/app changes (non-obvious)
+After pulling new app code or changing DocType JSONs, run a migrate (and clear cache) so the DB schema/metadata matches the code — a DocType can 404 in the UI until this is done:
+```bash
+cd ~/frappe-bench && bench --site logistics.localhost migrate && bench --site logistics.localhost clear-cache
+```
+
+### Tests
+Test execution is enabled for the site (`allow_tests` is set). Run the app suite or a single module:
+```bash
+cd ~/frappe-bench
+bench --site logistics.localhost run-tests --app logistics
+bench --site logistics.localhost run-tests --module logistics.air_freight.utils.test_unlocode_utils
+```
+
+### Lint
+No formal linter is configured in this repo (no ruff/flake8/pre-commit/eslint config). A quick sanity check is `~/frappe-bench/env/bin/python -m compileall logistics` (pre-existing `SyntaxWarning: invalid escape sequence` messages are harmless).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the development environment for **CargoNext** (the `logistics` Frappe/ERPNext v16 app) so Cursor Cloud agents can build, test, and run it end-to-end.

The only code change is a new `AGENTS.md` capturing durable, non-obvious run/startup caveats. All environment provisioning (system packages, Python 3.14, Node 24, `frappe-bench`, ERPNext, the `logistics.localhost` site) lives in the VM snapshot + update script, not in the repo.

### What was provisioned
- System deps: MariaDB, Redis, wkhtmltopdf, build libs, cron
- Python 3.14 (app requires `>=3.14,<3.15`) and Node 24 (Frappe v16 requires Node `>=24`)
- `frappe-bench` with Frappe v16 + ERPNext v16; `apps/logistics` symlinked to the repo
- Site `logistics.localhost` with `frappe`, `erpnext`, `logistics` installed; developer mode + scheduler enabled

### Update script (dependency refresh on startup)
```bash
if [ -x "$HOME/frappe-bench/env/bin/pip" ] && [ -e "$HOME/frappe-bench/apps/logistics" ]; then
  "$HOME/frappe-bench/env/bin/pip" install -e "$HOME/frappe-bench/apps/logistics"
fi
```

## Verification
- ✅ Dev stack runs: `bench start` (web on :8000, `/api/method/ping` → `pong`)
- ✅ Tests: `bench --site logistics.localhost run-tests --module logistics.air_freight.utils.test_unlocode_utils` (27 passed)
- ✅ Compile check: `python -m compileall logistics`
- ✅ Hello-world: logged into the Desk UI and created/saved Vessel records (`DEMO-VSL-001`, `DEMO-VSL-002`), confirmed persisted in the DB

[cargonext_create_vessel_demo.mp4](https://cursor.com/agents/bc-41a49d6a-f91b-42dd-81d7-6a0be53ff095/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcargonext_create_vessel_demo.mp4)

[Vessel list showing two created vessels](https://cursor.com/agents/bc-41a49d6a-f91b-42dd-81d7-6a0be53ff095/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcargonext_vessel_list_two.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41a49d6a-f91b-42dd-81d7-6a0be53ff095"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41a49d6a-f91b-42dd-81d7-6a0be53ff095"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

