### PR TITLE
fix(special-project): bind fulfillment tab status filter chips

### DIFF
--- a/logistics/special_projects/doctype/special_project/special_project.js
+++ b/logistics/special_projects/doctype/special_project/special_project.js
@@ -578,6 +578,14 @@ function _bind_special_project_main_dash_lifecycle($root) {
 	}
 }
 
+function _packages_summary_root($scope) {
+	if (!$scope || !$scope.length) {
+		return $();
+	}
+	const $found = $scope.find(".sp-packages-summary").first();
+	return $found.length ? $found : $scope.filter(".sp-packages-summary");
+}
+
 function _sync_packages_summary_full_width($root) {
 	if (!$root || !$root.length) {
 		return;
@@ -598,11 +606,7 @@ function _bind_packages_summary_layout($scope) {
 		return;
 	}
 	$scope.addClass("sp-packages-summary-field");
-	const $root = $scope.find(".sp-packages-summary").first();
-	if (!$root.length && $scope.hasClass("sp-packages-summary")) {
-		$scope.addClass("sp-packages-summary-field");
-	}
-	const $summary = $root.length ? $root : $scope.filter(".sp-packages-summary");
+	const $summary = _packages_summary_root($scope);
 	_sync_packages_summary_full_width($summary);
 
 	if (!window._logistics_sp_pks_fullwidth_bound) {
@@ -619,7 +623,7 @@ function _bind_packages_summary_collapse($scope) {
 	if (!$scope || !$scope.length) {
 		return;
 	}
-	const $root = $scope.find(".sp-packages-summary").first();
+	const $root = _packages_summary_root($scope);
 	if (!$root.length) {
 		return;
 	}
@@ -659,7 +663,7 @@ function _bind_packages_summary_filters($scope) {
 	if (!$scope || !$scope.length) {
 		return;
 	}
-	const $root = $scope.find(".sp-packages-summary").first();
+	const $root = _packages_summary_root($scope);
 	const $filters = $root.find(".sp-pfn-filters");
 	if (!$root.length || !$filters.length) {
 		return;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #1171 — the **Pending**, **Stalled**, **In Progress**, and **Complete** filter chips on the Special Project **Fulfillment** tab now filter the package table as expected.

## Root cause

`_bind_packages_summary_filters` looked for `.sp-packages-summary` only among descendants of the wrapper. On the Fulfillment tab, the wrapper **is** already `.sp-packages-summary`, so jQuery `.find()` returned nothing and click handlers never attached.

## Fix

- Added `_packages_summary_root()` to resolve the summary container whether it is the wrapper itself or nested inside it.
- Reused that helper in layout, collapse, and filter binding so all three behaviors resolve the same DOM root.

## Test plan

- [ ] Open a Special Project with packages (e.g. SPL-0141) → **Fulfillment** tab
- [ ] Click **Pending**, **Stalled**, **In Progress**, **Complete** — table rows should filter by status
- [ ] Click **All** — all rows should show again
- [ ] Confirm the same filters work on the Dashboard **Required Materials** tab
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb688075-3178-43d1-bbe1-ecda7973523d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb688075-3178-43d1-bbe1-ecda7973523d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

