### PR TITLE
feat(sales-quote): Copy Quotation Services on duplicate

### DIFF
--- a/logistics/pricing_center/doctype/sales_quote/sales_quote.js
+++ b/logistics/pricing_center/doctype/sales_quote/sales_quote.js
@@ -1343,6 +1343,13 @@ frappe.ui.form.on("Sales Quote", {
 			}, __("Action"));
 		}
 
+		// Copy Quotation Services — duplicated draft with empty Services tab
+		if (logistics_should_show_copy_quotation_services_button(frm)) {
+			frm.add_custom_button(__("Copy Quotation Services"), function () {
+				logistics_copy_quotation_services(frm);
+			}, __("Action"));
+		}
+
 		// Recalculate Charges - show when quote has any charge lines
 		const has_charges = frm.doc.charges && frm.doc.charges.length > 0;
 		if (has_charges && !frm.is_new()) {
@@ -2958,3 +2965,97 @@ frappe.ui.form.on("Sales Quote Routing Leg", {
 		logistics_mark_sales_quote_routing_legs_manual(frm);
 	},
 });
+
+function logistics_should_show_copy_quotation_services_button(frm) {
+	if (!frm || !frm.doc) {
+		return false;
+	}
+	if (frm.doc.additional_charge) {
+		return false;
+	}
+	if (frm.doc.docstatus !== 0) {
+		return false;
+	}
+	const source = (frm.doc.logistics_duplicate_from || "").trim();
+	if (!source) {
+		return false;
+	}
+	const fieldname = logistics_sq_linked_services_fieldname(frm);
+	const rows = (frm.doc[fieldname] || []).filter(
+		(r) => (r.service_type || "").trim() || (r.linked_service || "").trim()
+	);
+	return rows.length === 0;
+}
+
+function logistics_copy_quotation_services(frm) {
+	const run_copy = () => {
+		frappe.call({
+			method:
+				"logistics.pricing_center.doctype.sales_quote.sales_quote.copy_quotation_services_from_duplicate_source",
+			args: { sales_quote_name: frm.doc.name },
+			freeze: true,
+			freeze_message: __("Copying quotation services..."),
+			callback(r) {
+				if (r.exc) {
+					return;
+				}
+				const msg = r.message || {};
+				if (msg.success) {
+					frm.reload_doc().then(() => {
+						frappe.show_alert(
+							{
+								message: msg.message || __("Quotation services copied."),
+								indicator: "green",
+							},
+							5
+						);
+					});
+				}
+			},
+		});
+	};
+	if (frm.is_new() || frm.doc.__islocal) {
+		frm.save().then(run_copy);
+		return;
+	}
+	run_copy();
+}
+
+// Duplicate / Copy must not carry Services grid rows; source quote is tracked for optional copy.
+(function () {
+	if (frappe.model._logistics_sales_quote_copy_doc_patched) {
+		return;
+	}
+	frappe.model._logistics_sales_quote_copy_doc_patched = 1;
+	const _origCopyDoc = frappe.model.copy_doc;
+	frappe.model.copy_doc = function (doc, from_amend, parent_doc, parentfield) {
+		const newdoc = _origCopyDoc.apply(this, arguments);
+		if (
+			from_amend ||
+			parent_doc ||
+			!doc ||
+			!newdoc ||
+			doc.doctype !== "Sales Quote" ||
+			newdoc.doctype !== "Sales Quote"
+		) {
+			return newdoc;
+		}
+		if (frappe.meta.has_field("Sales Quote", "linked_services")) {
+			frappe.model.clear_table(newdoc, "linked_services");
+		}
+		if (frappe.meta.has_field("Sales Quote", "internal_job_details")) {
+			frappe.model.clear_table(newdoc, "internal_job_details");
+		}
+		if (frappe.meta.has_field("Sales Quote", "logistics_duplicate_from")) {
+			newdoc.logistics_duplicate_from = (
+				(doc.logistics_duplicate_from || doc.name || "") + ""
+			).trim();
+		}
+		for (const row of newdoc.charges || []) {
+			if (row.charge_scope === "Linked" && !row.linked_service) {
+				row.charge_scope = "Main";
+			}
+		}
+		return newdoc;
+	};
+})();

--- a/logistics/pricing_center/doctype/sales_quote/sales_quote.json
+++ b/logistics/pricing_center/doctype/sales_quote/sales_quote.json
@@ -17,6 +17,7 @@
   "blanket_quotation",
   "section_break_duom",
   "amended_from",
+  "logistics_duplicate_from",
   "consignee",
   "shipper",
   "sales_quote_pack",
@@ -185,6 +186,16 @@
    "print_hide": 1,
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "description": "Set by the desk when duplicating; cleared after Copy Quotation Services.",
+   "fieldname": "logistics_duplicate_from",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Duplicate From",
+   "no_copy": 1,
+   "print_hide": 1,
+   "read_only": 1
   },
   {
    "fieldname": "customer",

--- a/logistics/pricing_center/doctype/sales_quote/sales_quote.py
+++ b/logistics/pricing_center/doctype/sales_quote/sales_quote.py
@@ -397,8 +397,21 @@ class SalesQuote(Document):
 		"""Rows staged in ``__dict__`` (desk grid / API append) must sync before the virtual view reloads."""
 		self._stage_linked_services_from_form()
 
+	def _discard_duplicate_linked_services_staging(self):
+		"""Desk duplicate should not implicitly create Linked Services from copied grid rows."""
+		if not self.is_new():
+			return
+		marker = (getattr(self, "logistics_duplicate_from", None) or "").strip()
+		if not marker or self.flags.get("_linked_services_copy_applied"):
+			return
+		if "linked_services" not in self.__dict__:
+			return
+		self.__dict__["linked_services"] = []
+		self.flags._linked_services_from_form = True
+
 	def validate(self):
 		"""Validate Sales Quote data"""
+		self._discard_duplicate_linked_services_staging()
 		self._honour_linked_services_form_rows()
 		for ch in getattr(self, "charges", None) or []:
 			_sync_sales_quote_charge_load_type_filter_flags_for_row(ch)
@@ -4033,6 +4046,112 @@ def validate_one_off_quote_not_converted(
 			f"Error validating One-off Sales Quote {sales_quote_name}: {str(e)}",
 			"One-off Quote Validation Error"
 		)
+
+
+@frappe.whitelist()
+def copy_quotation_services_from_duplicate_source(sales_quote_name: str):
+	"""Clone Linked Services from the duplicate source quote onto this draft Sales Quote."""
+	if not sales_quote_name:
+		frappe.throw(_("Sales Quote is required."))
+	frappe.has_permission("Sales Quote", "write", doc=sales_quote_name, throw=True)
+
+	target = frappe.get_doc("Sales Quote", sales_quote_name)
+	if target.docstatus != 0:
+		frappe.throw(_("Copy Quotation Services is only available on draft Sales Quotes."))
+	if cint(getattr(target, "additional_charge", 0)):
+		frappe.throw(_("Copy Quotation Services is not available on additional-charge quotes."))
+
+	source_name = (getattr(target, "logistics_duplicate_from", None) or "").strip()
+	if not source_name:
+		frappe.throw(
+			_("This Sales Quote was not created by duplicating another quote."),
+			title=_("No Duplicate Source"),
+		)
+	if not frappe.db.exists("Sales Quote", source_name):
+		frappe.throw(
+			_("Source Sales Quote {0} was not found.").format(frappe.bold(source_name)),
+			title=_("Source Not Found"),
+		)
+
+	from logistics.logistics.doctype.linked_service.linked_service import (
+		get_linked_services_for_sales_quote,
+	)
+
+	if get_linked_services_for_sales_quote(sales_quote_name):
+		frappe.throw(
+			_("This Sales Quote already has services. Remove them before copying again."),
+			title=_("Services Already Exist"),
+		)
+
+	source_services = get_linked_services_for_sales_quote(source_name)
+	if not source_services:
+		frappe.throw(
+			_("Source Sales Quote {0} has no services to copy.").format(frappe.bold(source_name)),
+			title=_("No Services To Copy"),
+		)
+
+	mapping = _clone_sales_quote_linked_services(source_name, target.name)
+	_remap_sales_quote_charges_from_duplicate_source(target, source_name, mapping)
+
+	target.logistics_duplicate_from = None
+	target.flags._linked_services_copy_applied = True
+	target.flags.ignore_mandatory = True
+	target.save(ignore_permissions=True)
+
+	return {
+		"success": True,
+		"copied_count": len(mapping),
+		"mapping": mapping,
+		"message": _("Copied {0} service(s) from {1}.").format(len(mapping), source_name),
+	}
+
+
+def _clone_sales_quote_linked_services(source_sq_name: str, target_sq_name: str) -> dict[str, str]:
+	"""Clone source-quote Linked Services onto *target_sq_name*; return ``{source_ls: target_ls}``."""
+	from logistics.logistics.doctype.linked_service.linked_service import (
+		get_linked_services_for_sales_quote,
+	)
+	from logistics.utils.internal_job_persistence import create_internal_job_for_parent_from_source
+
+	mapping: dict[str, str] = {}
+	for source_ls in get_linked_services_for_sales_quote(source_sq_name):
+		new_name = create_internal_job_for_parent_from_source(
+			"Sales Quote", target_sq_name, source_ls
+		)
+		mapping[source_ls.name] = new_name
+	return mapping
+
+
+def _remap_sales_quote_charges_from_duplicate_source(
+	target_sq: Document, source_sq_name: str, ls_mapping: dict[str, str]
+) -> None:
+	"""Restore Linked charge scope/links on *target_sq* from the duplicate source quote."""
+	if not ls_mapping:
+		return
+	from logistics.utils.linked_service_compat import (
+		CHARGE_SCOPE_LINKED,
+		charge_row_linked_service_link,
+		normalize_charge_scope,
+		set_charge_row_linked_service_link,
+	)
+
+	source_sq = frappe.get_doc("Sales Quote", source_sq_name)
+	source_by_idx = {int(r.idx): r for r in (source_sq.charges or []) if r.idx}
+	for row in target_sq.charges or []:
+		idx = int(getattr(row, "idx", 0) or 0)
+		if not idx:
+			continue
+		source_row = source_by_idx.get(idx)
+		if not source_row:
+			continue
+		if normalize_charge_scope(getattr(source_row, "charge_scope", None)) != CHARGE_SCOPE_LINKED:
+			continue
+		source_ls = charge_row_linked_service_link(source_row)
+		target_ls = ls_mapping.get(source_ls or "")
+		if not target_ls:
+			continue
+		set_charge_row_linked_service_link(row, target_ls)
+		row.charge_scope = CHARGE_SCOPE_LINKED
 
 
 @frappe.whitelist()

--- a/logistics/utils/test_sales_quote_duplicate_services.py
+++ b/logistics/utils/test_sales_quote_duplicate_services.py
@@ -1,0 +1,181 @@
+# Copyright (c) 2026, Agilasoft and contributors
+# For license information, please see license.txt
+
+"""Tests for Copy Quotation Services on Sales Quote duplicate."""
+
+from __future__ import annotations
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from logistics.pricing_center.doctype.sales_quote.sales_quote import (
+	_clone_sales_quote_linked_services,
+	_remap_sales_quote_charges_from_duplicate_source,
+	copy_quotation_services_from_duplicate_source,
+)
+from logistics.utils.internal_job_persistence import (
+	_linked_service_names_from_db,
+	sync_internal_job_details_to_internal_jobs,
+)
+from logistics.utils.linked_service_compat import (
+	CHARGE_SCOPE_LINKED,
+	charge_row_linked_service_link,
+	linked_service_doctype,
+)
+
+
+class TestSalesQuoteDuplicateServices(FrappeTestCase):
+	def setUp(self):
+		if not frappe.db.exists("DocType", "Sales Quote"):
+			self.skipTest("Sales Quote not installed")
+		if not frappe.db.exists("DocType", linked_service_doctype()):
+			self.skipTest("Linked Service not installed")
+
+	def _minimal_sales_quote(self, title: str):
+		doc = frappe.new_doc("Sales Quote")
+		doc.quotation_type = "Project"
+		doc.main_service = "Special Project"
+		doc.naming_series = "PQ.#####"
+		doc.project_name = title
+		doc.customer = frappe.db.get_value("Customer", {}, "name")
+		if not doc.customer:
+			self.skipTest("No Customer in system")
+		doc.date = frappe.utils.today()
+		doc.valid_until = frappe.utils.add_days(frappe.utils.today(), 30)
+		doc.flags.ignore_mandatory = True
+		doc.insert(ignore_permissions=True)
+		return doc
+
+	def _add_linked_service(self, sq, service_type: str):
+		sq.append("linked_services", {"service_type": service_type})
+		sq.flags._linked_services_from_form = True
+		sync_internal_job_details_to_internal_jobs(sq)
+		names = _linked_service_names_from_db("Sales Quote", sq.name)
+		self.assertTrue(names)
+		return names[0]
+
+	def test_clone_sales_quote_linked_services_creates_new_docs(self):
+		source = self._minimal_sales_quote("SQ Dup Services Source")
+		target = self._minimal_sales_quote("SQ Dup Services Target")
+		try:
+			ls1 = self._add_linked_service(source, "Sea")
+			ls2 = self._add_linked_service(source, "Air")
+			source_names = set(_linked_service_names_from_db("Sales Quote", source.name))
+
+			mapping = _clone_sales_quote_linked_services(source.name, target.name)
+			self.assertEqual(len(mapping), 2)
+			self.assertIn(ls1, mapping)
+			self.assertIn(ls2, mapping)
+
+			target_names = set(_linked_service_names_from_db("Sales Quote", target.name))
+			self.assertEqual(len(target_names), 2)
+			self.assertTrue(target_names.isdisjoint(source_names))
+
+			for ls_name in target_names:
+				ls = frappe.get_doc(linked_service_doctype(), ls_name)
+				self.assertEqual(ls.parent_booking_type, "Sales Quote")
+				self.assertEqual(ls.parent_booking_name, target.name)
+
+			self.assertEqual(
+				set(_linked_service_names_from_db("Sales Quote", source.name)), source_names
+			)
+		finally:
+			for name in (source.name, target.name):
+				if frappe.db.exists("Sales Quote", name):
+					frappe.delete_doc("Sales Quote", name, force=True, ignore_permissions=True)
+
+	def test_remap_sales_quote_charges_from_duplicate_source(self):
+		source = self._minimal_sales_quote("SQ Dup Charge Source")
+		target = self._minimal_sales_quote("SQ Dup Charge Target")
+		try:
+			source_ls = self._add_linked_service(source, "Sea")
+			mapping = _clone_sales_quote_linked_services(source.name, target.name)
+			target_ls = mapping[source_ls]
+
+			source.reload()
+			source.append(
+				"charges",
+				{
+					"service_type": "Sea",
+					"charge_scope": CHARGE_SCOPE_LINKED,
+					"linked_service": source_ls,
+					"item_code": frappe.db.get_value("Item", {"is_stock_item": 0}, "name"),
+				},
+			)
+			source.flags.ignore_mandatory = True
+			source.save(ignore_permissions=True)
+
+			target.reload()
+			target.append(
+				"charges",
+				{
+					"service_type": "Sea",
+					"charge_scope": "Main",
+					"item_code": source.charges[0].item_code,
+				},
+			)
+			target.flags.ignore_mandatory = True
+			target.save(ignore_permissions=True)
+
+			_remap_sales_quote_charges_from_duplicate_source(target, source.name, mapping)
+			target_row = target.charges[0]
+			self.assertEqual(target_row.charge_scope, CHARGE_SCOPE_LINKED)
+			self.assertEqual(charge_row_linked_service_link(target_row), target_ls)
+		finally:
+			for name in (source.name, target.name):
+				if frappe.db.exists("Sales Quote", name):
+					frappe.delete_doc("Sales Quote", name, force=True, ignore_permissions=True)
+
+	def test_copy_quotation_services_from_duplicate_source(self):
+		source = self._minimal_sales_quote("SQ Dup Copy Source")
+		target = self._minimal_sales_quote("SQ Dup Copy Target")
+		try:
+			self._add_linked_service(source, "Sea")
+			self._add_linked_service(source, "Transport")
+			frappe.db.set_value(
+				"Sales Quote",
+				target.name,
+				"logistics_duplicate_from",
+				source.name,
+				update_modified=False,
+			)
+
+			result = copy_quotation_services_from_duplicate_source(target.name)
+			self.assertTrue(result["success"])
+			self.assertEqual(result["copied_count"], 2)
+			self.assertFalse(
+				frappe.db.get_value("Sales Quote", target.name, "logistics_duplicate_from")
+			)
+			self.assertEqual(len(_linked_service_names_from_db("Sales Quote", target.name)), 2)
+		finally:
+			for name in (source.name, target.name):
+				if frappe.db.exists("Sales Quote", name):
+					frappe.delete_doc("Sales Quote", name, force=True, ignore_permissions=True)
+
+	def test_copy_quotation_services_rejects_missing_duplicate_source(self):
+		target = self._minimal_sales_quote("SQ Dup No Marker")
+		try:
+			with self.assertRaises(frappe.ValidationError):
+				copy_quotation_services_from_duplicate_source(target.name)
+		finally:
+			frappe.delete_doc("Sales Quote", target.name, force=True, ignore_permissions=True)
+
+	def test_copy_quotation_services_rejects_when_services_already_exist(self):
+		source = self._minimal_sales_quote("SQ Dup Idem Source")
+		target = self._minimal_sales_quote("SQ Dup Idem Target")
+		try:
+			self._add_linked_service(source, "Air")
+			self._add_linked_service(target, "Sea")
+			frappe.db.set_value(
+				"Sales Quote",
+				target.name,
+				"logistics_duplicate_from",
+				source.name,
+				update_modified=False,
+			)
+			with self.assertRaises(frappe.ValidationError):
+				copy_quotation_services_from_duplicate_source(target.name)
+		finally:
+			for name in (source.name, target.name):
+				if frappe.db.exists("Sales Quote", name):
+					frappe.delete_doc("Sales Quote", name, force=True, ignore_permissions=True)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When a Sales Quote is duplicated via Desk Duplicate, the Services tab is now empty by default. A new **Action → Copy Quotation Services** button lets users clone all Linked Service documents from the source quote onto the new draft before submit, including charge→service remapping.

## Changes

- Added hidden `logistics_duplicate_from` field on Sales Quote to track the duplicate source (chain-preserved across re-duplicates).
- Patched `frappe.model.copy_doc` for Sales Quote to clear the Services grid, set the source marker, and reset orphan `Linked` charges to `Main` so the draft can be saved.
- Added server API `copy_quotation_services_from_duplicate_source` that clones Linked Services and remaps charge links by row `idx`.
- Added Action menu button (save-first for unsaved drafts) visible only on duplicated drafts with an empty Services tab.
- Added unit tests for clone, charge remap, and guard cases.

## How to verify

1. Open a Sales Quote with services on the Services tab.
2. Menu → Duplicate.
3. Confirm the Services tab is empty on the new draft.
4. Click **Action → Copy Quotation Services**.
5. Confirm services appear as new Linked Service documents parented to the new quote, and Linked charges are re-tagged.

## Tests

`logistics.utils.test_sales_quote_duplicate_services`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a5f6e84-3583-480a-80a9-8aa9ac91b418"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a5f6e84-3583-480a-80a9-8aa9ac91b418"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

