### PR TITLE
fix(special-project): populate Service Line on charges from quote linked services

### DIFF
--- a/logistics/pricing_center/doctype/sales_quote/sales_quote.py
+++ b/logistics/pricing_center/doctype/sales_quote/sales_quote.py
@@ -1323,7 +1323,9 @@ def _create_special_project_from_sales_quote(sales_quote):
 	populate_programme_charges_from_sales_quote(
 		sp, sales_quote.name, clear_existing=True, service_types="__all__"
 	)
-	remap_special_project_charges_after_quote_populate(sp, ls_to_sps)
+	remap_special_project_charges_after_quote_populate(
+		sp, ls_to_sps, sales_quote_name=sales_quote.name, service_types="__all__"
+	)
 	from logistics.special_projects.special_project_packages import (
 		seed_packages_from_sales_quote,
 	)

--- a/logistics/special_projects/doctype/special_project/special_project.py
+++ b/logistics/special_projects/doctype/special_project/special_project.py
@@ -905,8 +905,12 @@ class SpecialProject(Document):
 		ls_to_sps = populate_special_project_services_from_sales_quote(
 			self, sq_name, clear_existing=True
 		)
-		populate_programme_charges_from_sales_quote(self, sq_name, clear_existing=True)
-		remap_special_project_charges_after_quote_populate(self, ls_to_sps)
+		populate_programme_charges_from_sales_quote(
+			self, sq_name, clear_existing=True, service_types="__all__"
+		)
+		remap_special_project_charges_after_quote_populate(
+			self, ls_to_sps, sales_quote_name=sq_name, service_types="__all__"
+		)
 		tag_untagged_charges_to_planning_services(self)
 
 	def populate_services_from_sales_quote(self, sales_quote=None):
@@ -925,7 +929,9 @@ class SpecialProject(Document):
 		ls_to_sps = populate_special_project_services_from_sales_quote(
 			self, sq_name, clear_existing=True
 		)
-		remap_special_project_charges_after_quote_populate(self, ls_to_sps)
+		remap_special_project_charges_after_quote_populate(
+			self, ls_to_sps, sales_quote_name=sq_name, service_types="__all__"
+		)
 		tag_untagged_charges_to_planning_services(self)
 
 

--- a/logistics/special_projects/special_project_services_from_sales_quote.py
+++ b/logistics/special_projects/special_project_services_from_sales_quote.py
@@ -152,19 +152,61 @@ def populate_special_project_services_from_sales_quote(
 	return _ensure_main_special_project_service(sp_doc, ls_to_sps)
 
 
+def _iter_special_project_charge_sq_pairs(
+	sp_doc: Any,
+	sales_quote_name: str,
+	*,
+	service_types=None,
+) -> list[tuple[Any | None, Any]]:
+	"""Pair programme charge rows with source Sales Quote charge rows (populate order)."""
+	from logistics.utils.sales_quote_programme_charges import _iter_programme_charge_sq_pairs
+
+	if not sales_quote_name or not frappe.db.exists("Sales Quote", sales_quote_name):
+		return [(None, charge) for charge in (sp_doc.get("charges") or [])]
+
+	pairs = list(
+		_iter_programme_charge_sq_pairs(sp_doc, sales_quote_name, service_types=service_types)
+	)
+	if pairs:
+		return pairs
+	return [(None, charge) for charge in (sp_doc.get("charges") or [])]
+
+
 def remap_special_project_charges_after_quote_populate(
 	sp_doc: Any,
 	ls_to_sps: dict[str, str] | None = None,
-) -> None:
-	"""Tag programme charges to Service Line rows and drop stale quote Linked Service links."""
+	*,
+	sales_quote_name: str | None = None,
+	service_types: Any = "__all__",
+) -> dict[str, str]:
+	"""Tag programme charges to Service Line rows and drop stale quote Linked Service links.
+
+	Quote ``linked_service`` values are not copied onto Special Project charge rows; when
+	*sales_quote_name* is given, each charge is paired with its source Sales Quote charge
+	so the link can be translated to ``special_project_service_line``.
+
+	Returns the updated ``{linked_service_name: special_project_service_name}`` map.
+	"""
 	if not sp_doc or sp_doc.doctype != "Special Project":
-		return
+		return dict(ls_to_sps or {})
 	ls_to_sps = dict(ls_to_sps or {})
+	sq_name = _norm(sales_quote_name) or _norm(getattr(sp_doc, "sales_quote", None))
+
+	# Charges are often populated after services; create the main SP leg once charges exist.
+	ls_to_sps = _ensure_main_special_project_service(sp_doc, ls_to_sps)
 	main_sps = ls_to_sps.get("__main_special_project__")
 	meta = frappe.get_meta("Special Project Charges")
 
-	for charge in sp_doc.get("charges") or []:
+	charge_pairs = (
+		_iter_special_project_charge_sq_pairs(sp_doc, sq_name, service_types=service_types)
+		if sq_name
+		else [(None, charge) for charge in (sp_doc.get("charges") or [])]
+	)
+
+	for sq_row, charge in charge_pairs:
 		ls_name = charge_row_linked_service_link(charge)
+		if not ls_name and sq_row is not None:
+			ls_name = charge_row_linked_service_link(sq_row)
 		line_name = None
 		if ls_name and ls_name in ls_to_sps:
 			line_name = ls_to_sps[ls_name]
@@ -192,6 +234,8 @@ def remap_special_project_charges_after_quote_populate(
 		if meta.has_field("internal_job"):
 			charge.internal_job = None
 
+	return ls_to_sps
+
 
 @frappe.whitelist()
 def repair_special_project_from_sales_quote(docname: str) -> dict[str, Any]:
@@ -211,7 +255,9 @@ def repair_special_project_from_sales_quote(docname: str) -> dict[str, Any]:
 	ls_to_sps = populate_special_project_services_from_sales_quote(
 		sp, sq_name, clear_existing=True
 	)
-	remap_special_project_charges_after_quote_populate(sp, ls_to_sps)
+	remap_special_project_charges_after_quote_populate(
+		sp, ls_to_sps, sales_quote_name=sq_name, service_types="__all__"
+	)
 	tag_untagged_charges_to_planning_services(sp)
 	sp.flags.ignore_permissions = True
 	sp.save(ignore_permissions=True)

--- a/logistics/special_projects/test_special_project_services_from_sales_quote.py
+++ b/logistics/special_projects/test_special_project_services_from_sales_quote.py
@@ -137,15 +137,24 @@ class TestSpecialProjectServicesFromSalesQuote(IntegrationTestCase):
 			)
 			self.assertEqual(ls_to_sps.get(ls_air.name), ls_to_sps[ls_air.name])
 			self.assertEqual(ls_to_sps.get(ls_sea.name), ls_to_sps[ls_sea.name])
+
+			populate_programme_charges_from_sales_quote(
+				sp, sq.name, clear_existing=True, service_types="__all__"
+			)
+			ls_to_sps = remap_special_project_charges_after_quote_populate(
+				sp, ls_to_sps, sales_quote_name=sq.name, service_types="__all__"
+			)
 			self.assertTrue(ls_to_sps.get("__main_special_project__"))
 
 			service_names = _special_project_service_names_from_db(sp.name)
 			self.assertEqual(len(service_names), 3)
 
-			populate_programme_charges_from_sales_quote(
-				sp, sq.name, clear_existing=True, service_types="__all__"
-			)
-			remap_special_project_charges_after_quote_populate(sp, ls_to_sps)
+			for charge in sp.charges:
+				self.assertTrue(
+					charge.special_project_service_line,
+					msg=f"Service Line missing on charge {charge.idx} before save",
+				)
+
 			sp.flags.ignore_mandatory = True
 			sp.save(ignore_permissions=True)
 
@@ -168,6 +177,100 @@ class TestSpecialProjectServicesFromSalesQuote(IntegrationTestCase):
 			main_charges = [c for c in reloaded.charges if (c.charge_scope or "").strip() == "Main"]
 			self.assertEqual(len(main_charges), 1)
 			self.assertTrue(main_charges[0].special_project_service_line)
+		finally:
+			self._cleanup_special_project(sp.name)
+			self._cleanup_sales_quote(sq.name)
+
+	def test_remap_uses_quote_linked_service_when_duplicate_service_types(self):
+		"""Two Air linked services: each charge maps to the correct Service Line via quote link."""
+		if not frappe.db.exists("DocType", linked_service_doctype()):
+			self.skipTest("Linked Service not installed")
+
+		sp = new_special_project_for_test("SP SQ Dup Air")
+		if not sp:
+			self.skipTest("Company, Customer, and Cost Center required")
+
+		company = sp.company
+		customer = sp.customer
+		sq = frappe.new_doc("Sales Quote")
+		sq.quotation_type = "Project"
+		sq.main_service = "Special Project"
+		sq.naming_series = "PQ.#####"
+		sq.company = company
+		sq.customer = customer
+		sq.shipper = frappe.db.get_value("Shipper", {}, "name")
+		sq.consignee = frappe.db.get_value("Consignee", {}, "name")
+		sq.valid_till = frappe.utils.add_days(frappe.utils.today(), 30)
+		sq.flags.ignore_mandatory = True
+		sq.insert(ignore_permissions=True)
+
+		ls_air_a = frappe.new_doc(linked_service_doctype())
+		ls_air_a.service_type = "Air"
+		ls_air_a.parent_booking_type = "Sales Quote"
+		ls_air_a.parent_booking_name = sq.name
+		ls_air_a.flags.ignore_permissions = True
+		ls_air_a.insert(ignore_permissions=True)
+
+		ls_air_b = frappe.new_doc(linked_service_doctype())
+		ls_air_b.service_type = "Air"
+		ls_air_b.parent_booking_type = "Sales Quote"
+		ls_air_b.parent_booking_name = sq.name
+		ls_air_b.flags.ignore_permissions = True
+		ls_air_b.insert(ignore_permissions=True)
+
+		sq.append(
+			"charges",
+			{
+				"service_type": "Air",
+				"item_code": "FREIGHT-A",
+				"charge_scope": "Linked",
+				"linked_service": ls_air_a.name,
+				"unit_rate": 100,
+			},
+		)
+		sq.append(
+			"charges",
+			{
+				"service_type": "Air",
+				"item_code": "FREIGHT-B",
+				"charge_scope": "Linked",
+				"linked_service": ls_air_b.name,
+				"unit_rate": 150,
+			},
+		)
+		sq.flags.ignore_mandatory = True
+		sq.save(ignore_permissions=True)
+		sq.submit()
+
+		sp.sales_quote = sq.name
+		sp.status = "Draft"
+		sp.flags.ignore_mandatory = True
+		sp.insert(ignore_permissions=True)
+
+		try:
+			ls_to_sps = populate_special_project_services_from_sales_quote(
+				sp, sq.name, clear_existing=True
+			)
+			populate_programme_charges_from_sales_quote(
+				sp, sq.name, clear_existing=True, service_types="__all__"
+			)
+			remap_special_project_charges_after_quote_populate(
+				sp, ls_to_sps, sales_quote_name=sq.name, service_types="__all__"
+			)
+
+			by_item = {c.item_code: c for c in sp.charges}
+			self.assertEqual(
+				by_item["FREIGHT-A"].special_project_service_line,
+				ls_to_sps[ls_air_a.name],
+			)
+			self.assertEqual(
+				by_item["FREIGHT-B"].special_project_service_line,
+				ls_to_sps[ls_air_b.name],
+			)
+			self.assertNotEqual(
+				by_item["FREIGHT-A"].special_project_service_line,
+				by_item["FREIGHT-B"].special_project_service_line,
+			)
 		finally:
 			self._cleanup_special_project(sp.name)
 			self._cleanup_sales_quote(sq.name)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Creating a Special Project from a Sales Quote copied linked-scope charge lines but left **Service Line** (`special_project_service_line`) empty. Charge mapping intentionally strips `linked_service` from copied rows, and `remap_special_project_charges_after_quote_populate` only read that field from the programme charge — so the quote-to-service mapping never ran.

## Fix

- Pair each Special Project charge with its source Sales Quote charge during remap and read `linked_service` from the quote row.
- Create the main On-Site Special Project service leg after charges are on the document (services are populated before charges in the create flow).
- Pass `service_types="__all__"` when refreshing charges from the Special Project form so Air/Sea linked charges are included.
- Update all remap call sites (create-from-quote, populate charges/services, repair).

## Tests

- Existing integration test updated to assert Service Line is set **before** save.
- New test covers two Air linked services with distinct quote links (duplicate service types).

## Verification

Integration tests require a Frappe site; logic verified via unit simulation and code review.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96f0329a-a38d-4b17-b192-8d917b04b609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96f0329a-a38d-4b17-b192-8d917b04b609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

