### PR TITLE
fix(transport-order): stop querying removed quote columns on submit

### DIFF
--- a/logistics/transport/doctype/transport_order/test_transport_order.py
+++ b/logistics/transport/doctype/transport_order/test_transport_order.py
@@ -4,10 +4,12 @@
 import frappe
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import today
+from unittest.mock import patch
 
 from logistics.transport.doctype.transport_order.transport_order import (
 	_apply_duplicate_pricing_clear,
 	_clear_pricing_after_desk_duplicate,
+	_get_linked_sales_quote,
 	get_vehicle_types_for_transport_order,
 )
 
@@ -189,6 +191,51 @@ class TestTransportOrderDuplicatePricingClear(FrappeTestCase):
 		self.assertTrue(order.flags.logistics_duplicate_pricing_cleared)
 		self.assertEqual(order.sales_quote, None)
 		self.assertEqual(order.logistics_duplicate_from, None)
+
+
+class TestTransportOrderLegacyQuoteLifecycle(FrappeTestCase):
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_on_submit_does_not_query_removed_quote_columns(self):
+		"""Submit hook must not SELECT legacy quote/quote_type when schema has sales_quote only."""
+		from logistics.transport.doctype.transport_order.transport_order import TransportOrder
+
+		order = frappe.get_doc(
+			{
+				"doctype": "Transport Order",
+				"name": "TRO000000057",
+				"sales_quote": "SQU-TEST-LEGACY",
+			}
+		)
+
+		with patch.object(frappe.db, "get_value") as mock_get_value:
+			mock_get_value.return_value = "SQU-TEST-LEGACY"
+			with patch(
+				"logistics.pricing_center.doctype.sales_quote.sales_quote.update_one_off_quote_on_submit"
+			):
+				with patch(
+					"logistics.special_projects.special_project_packages.post_site_receipts_from_transport_order"
+				):
+					TransportOrder.on_submit(order)
+
+			queried_fields = [
+				call.args[2]
+				for call in mock_get_value.call_args_list
+				if len(call.args) >= 3
+			]
+			self.assertNotIn("quote", queried_fields)
+			self.assertNotIn("quote_type", queried_fields)
+
+	def test_get_linked_sales_quote_prefers_sales_quote_on_doc(self):
+		order = frappe.get_doc(
+			{
+				"doctype": "Transport Order",
+				"sales_quote": "SQU-ON-DOC",
+			}
+		)
+		with patch.object(frappe.db, "exists", return_value=True):
+			self.assertEqual(_get_linked_sales_quote(order, from_db=False), "SQU-ON-DOC")
 
 
 class TestTransportOrderChargeSubmitGate(FrappeTestCase):

--- a/logistics/transport/doctype/transport_order/transport_order.py
+++ b/logistics/transport/doctype/transport_order/transport_order.py
@@ -107,6 +107,35 @@ def _sync_quote_and_sales_quote(doc):
         doc.quote = doc.sales_quote
 
 
+def _get_linked_sales_quote(doc, *, from_db=False):
+    """Resolve linked Sales Quote for lifecycle hooks.
+
+    Prefer ``sales_quote``. Legacy ``quote`` is read only when that field still
+    exists on the DocType (older sites); current schema has no ``quote`` column.
+    """
+    sales_quote = None
+    if from_db and getattr(doc, "name", None) and not doc.is_new():
+        sales_quote = frappe.db.get_value(doc.doctype, doc.name, "sales_quote")
+
+    if not sales_quote:
+        sales_quote = getattr(doc, "sales_quote", None)
+
+    if sales_quote and frappe.db.exists("Sales Quote", sales_quote):
+        return sales_quote
+
+    if not doc.meta.get_field("quote"):
+        return None
+
+    legacy_quote = getattr(doc, "quote", None)
+    if not legacy_quote and from_db and getattr(doc, "name", None) and not doc.is_new():
+        legacy_quote = frappe.db.get_value(doc.doctype, doc.name, "quote")
+
+    if legacy_quote and frappe.db.exists("Sales Quote", legacy_quote):
+        return legacy_quote
+
+    return None
+
+
 def _apply_duplicate_pricing_clear(doc):
     """Strip charge child rows and quote / scope links (used for desk Duplicate and after link propagation)."""
     for row in list(doc.get("charges") or []):
@@ -511,36 +540,25 @@ class TransportOrder(Document):
         assert_destination_service_charges_on_submit_unless_internal_job(self)
     
     def on_submit(self):
-        """Ensure quote field values remain after submission; update One-off Sales Quote when converted.
+        """Ensure sales_quote remains after submission; update One-off Sales Quote when converted.
 
         Frappe invokes ``on_submit`` on submit; ``after_submit`` is not a standard Document hook and never runs.
         """
-        # Preserve quote field value after submission - ensure it's not cleared
-        # Get the quote value from the database to ensure it's preserved
-        current_quote = frappe.db.get_value(self.doctype, self.name, 'quote')
-        current_quote_type = frappe.db.get_value(self.doctype, self.name, 'quote_type')
-        current_sales_quote = frappe.db.get_value(self.doctype, self.name, 'sales_quote')
-        if (
-            not current_sales_quote
-            and current_quote
-            and frappe.db.exists("Sales Quote", current_quote)
-        ):
-            current_sales_quote = current_quote
-        if not current_sales_quote:
-            for cand in (getattr(self, "sales_quote", None), getattr(self, "quote", None)):
-                if cand and frappe.db.exists("Sales Quote", cand):
-                    current_sales_quote = cand
-                    break
-        
-        # If quote was set before submission, ensure it remains set
-        # This prevents any code from clearing the quote field after submission
-        if current_quote and not getattr(self, 'quote', None):
-            self.db_set('quote', current_quote, update_modified=False)
-        if current_quote_type and not getattr(self, 'quote_type', None):
-            self.db_set('quote_type', current_quote_type, update_modified=False)
-        if current_sales_quote and not getattr(self, 'sales_quote', None):
-            self.db_set('sales_quote', current_sales_quote, update_modified=False)
-        
+        current_sales_quote = _get_linked_sales_quote(self, from_db=True)
+
+        if current_sales_quote and not getattr(self, "sales_quote", None):
+            self.db_set("sales_quote", current_sales_quote, update_modified=False)
+
+        # Legacy schema: preserve quote / quote_type when those columns still exist
+        if self.meta.get_field("quote"):
+            current_quote = frappe.db.get_value(self.doctype, self.name, "quote")
+            if current_quote and not getattr(self, "quote", None):
+                self.db_set("quote", current_quote, update_modified=False)
+        if self.meta.get_field("quote_type"):
+            current_quote_type = frappe.db.get_value(self.doctype, self.name, "quote_type")
+            if current_quote_type and not getattr(self, "quote_type", None):
+                self.db_set("quote_type", current_quote_type, update_modified=False)
+
         # Update One-off Sales Quote status to Converted
         if current_sales_quote:
             from logistics.pricing_center.doctype.sales_quote.sales_quote import update_one_off_quote_on_submit
@@ -560,12 +578,7 @@ class TransportOrder(Document):
     
     def on_cancel(self):
         """Reset One-off Sales Quote status when Transport Order is cancelled."""
-        current_sales_quote = frappe.db.get_value(self.doctype, self.name, 'sales_quote')
-        if not current_sales_quote:
-            qt = frappe.db.get_value(self.doctype, self.name, 'quote_type')
-            q = frappe.db.get_value(self.doctype, self.name, 'quote')
-            if qt == "One-Off Quote" and q and frappe.db.exists("Sales Quote", q):
-                current_sales_quote = q
+        current_sales_quote = _get_linked_sales_quote(self, from_db=True)
         if current_sales_quote:
             from logistics.pricing_center.doctype.sales_quote.sales_quote import (
                 reset_one_off_quote_on_cancel_for_document,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes Transport Order submit failing with `Unknown column 'quote' in 'SELECT'` on sites (e.g. atndemo) where legacy `quote` / `quote_type` columns were removed in favour of `sales_quote`.

## Changes

- Add `_get_linked_sales_quote()` helper that resolves the linked Sales Quote from `sales_quote`, and only falls back to legacy `quote` when that field still exists on the DocType schema.
- Update `on_submit` and `on_cancel` to use the helper instead of unconditionally querying removed columns.
- Guard legacy `quote` / `quote_type` preservation with `meta.get_field()` checks for older sites that still have those columns.
- Add unit tests verifying submit does not query removed columns.

## Expected behaviour after deploy

- Submitting a Transport Order (e.g. TRO000000057) completes successfully.
- Linked `sales_quote` is preserved and one-off Sales Quotes are marked Converted on submit.
- Cancelling still resets the linked Sales Quote status.
- No user workflow changes required.

## Test plan

- [ ] Submit Transport Order with linked Sales Quote on atndemo
- [ ] Cancel submitted Transport Order and confirm Sales Quote status resets
- [ ] Run `bench run-tests --module logistics.transport.doctype.transport_order.test_transport_order`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-84785bef-5437-48a9-8ca0-31b605c7e0f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84785bef-5437-48a9-8ca0-31b605c7e0f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

