### PR TITLE
fix(sales-quote): populate linked services on sea booking conversion

### DIFF
--- a/logistics/pricing_center/doctype/sales_quote/sales_quote.py
+++ b/logistics/pricing_center/doctype/sales_quote/sales_quote.py
@@ -1911,51 +1911,18 @@ def _propagate_linked_services_to_created_booking(
 	* Regular / blanket call-off: **clone** Linked Services so the quote retains its originals
 	  for later bookings and Services rows are not tied to a single job.
 
-	Logs (without re-raising) on failure so conversion still completes.
+	Raises on failure so conversion does not complete with an empty Linked Services grid.
 	"""
-	try:
-		from logistics.utils.sales_quote_one_off_internal_jobs import (
-			linked_service_names_from_quote_charges,
-			propagate_linked_services_and_remap_charges,
-			stamp_scope_main_when_untagged,
-		)
+	from logistics.utils.sales_quote_one_off_internal_jobs import (
+		propagate_linked_services_from_sales_quote_to_booking,
+	)
 
-		qt = (getattr(sales_quote, "quotation_type", None) or "").strip()
-		use_clone = blanket_call_off or qt == "Regular"
-		if use_clone:
-			sq_name = getattr(sales_quote, "name", None) or ""
-			sq_owned = frappe.get_all(
-				"Linked Service",
-				filters={
-					"parent_booking_type": "Sales Quote",
-					"parent_booking_name": sq_name,
-				},
-				pluck="name",
-				order_by="creation asc",
-			)
-			charge_ls = linked_service_names_from_quote_charges(
-				sales_quote, selected_charge_row_names
-			)
-			if charge_ls:
-				ls_names = [n for n in charge_ls if n in set(sq_owned or [])]
-			else:
-				ls_names = list(sq_owned or [])
-			if ls_names:
-				propagate_linked_services_and_remap_charges(
-					sales_quote, booking_doc, clone=True, ls_names=ls_names
-				)
-		else:
-			propagate_linked_services_and_remap_charges(sales_quote, booking_doc, clone=False)
-		stamp_scope_main_when_untagged(booking_doc)
-	except Exception:
-		frappe.log_error(
-			title="Sales Quote Linked Service propagation failed",
-			message=(
-				f"Sales Quote: {getattr(sales_quote, 'name', None)}; "
-				f"Booking: {getattr(booking_doc, 'doctype', None)} "
-				f"{getattr(booking_doc, 'name', None)}\n{frappe.get_traceback()}"
-			),
-		)
+	return propagate_linked_services_from_sales_quote_to_booking(
+		sales_quote,
+		booking_doc,
+		blanket_call_off=blanket_call_off,
+		selected_charge_row_names=selected_charge_row_names,
+	)
 
 
 def _propagate_one_off_internal_jobs_to_created_booking(sales_quote, booking_doc):

--- a/logistics/pricing_center/sales_quote_booking_creation.py
+++ b/logistics/pricing_center/sales_quote_booking_creation.py
@@ -563,11 +563,11 @@ def _populate_charges_on_target(sq_doc: Any, target_doc: Any) -> None:
 
 
 def _propagate_subsidiary_linked_services(sq_doc: Any, booking_doc: Any) -> None:
-	from logistics.utils.sales_quote_one_off_internal_jobs import (
-		propagate_linked_services_for_special_project_booking,
+	from logistics.pricing_center.doctype.sales_quote.sales_quote import (
+		_propagate_linked_services_to_created_booking,
 	)
 
-	propagate_linked_services_for_special_project_booking(sq_doc, booking_doc)
+	_propagate_linked_services_to_created_booking(sq_doc, booking_doc)
 
 
 def _create_air_booking(

--- a/logistics/utils/sales_quote_one_off_internal_jobs.py
+++ b/logistics/utils/sales_quote_one_off_internal_jobs.py
@@ -416,6 +416,101 @@ def propagate_one_off_internal_jobs_and_remap_charges(
 	return propagate_linked_services_and_remap_charges(sales_quote, booking_doc, clone=False)
 
 
+def _linked_service_names_for_quote_to_booking_propagation(
+	sales_quote: Any,
+	booking_doc: Any,
+	*,
+	blanket_call_off: bool = False,
+	selected_charge_row_names: list[str] | None = None,
+	exclude_main_booking_service_type: bool = True,
+) -> list[str]:
+	"""Resolve which quote-owned Linked Services should transfer onto *booking_doc*."""
+	sq_name = getattr(sales_quote, "name", None) or ""
+	sq_owned = _sq_owned_linked_services(sq_name)
+	if not sq_owned:
+		return []
+
+	sq_owned_set = set(sq_owned)
+	if blanket_call_off and selected_charge_row_names:
+		charge_ls = linked_service_names_from_quote_charges(
+			sales_quote, selected_charge_row_names
+		)
+		return [n for n in charge_ls if n in sq_owned_set]
+
+	ls_names = list(sq_owned)
+	qt = (getattr(sales_quote, "quotation_type", None) or "").strip()
+	use_clone = blanket_call_off or qt == "Regular"
+	if exclude_main_booking_service_type and use_clone:
+		from logistics.utils.charge_service_type import implied_service_type_for_doctype
+
+		main_st = implied_service_type_for_doctype(getattr(booking_doc, "doctype", None) or "")
+		if main_st:
+			ls_names = _filter_linked_service_names(ls_names, exclude_service_types=[main_st])
+	return ls_names
+
+
+def propagate_linked_services_from_sales_quote_to_booking(
+	sales_quote: Any,
+	booking_doc: Any,
+	*,
+	blanket_call_off: bool = False,
+	selected_charge_row_names: list[str] | None = None,
+	exclude_main_booking_service_type: bool = True,
+) -> dict[str, str]:
+	"""Transfer or clone quote-owned Linked Services onto *booking_doc* and remap charge links.
+
+	* One-off / Project full conversion: re-parent the same ``LS-…`` documents.
+	* Regular / blanket call-off: clone so the quote retains its originals.
+
+	Raises on failure so conversion does not complete with an empty Linked Services grid.
+	"""
+	if not sales_quote or not booking_doc:
+		return {}
+
+	qt = (getattr(sales_quote, "quotation_type", None) or "").strip()
+	use_clone = blanket_call_off or qt == "Regular"
+	ls_names = _linked_service_names_for_quote_to_booking_propagation(
+		sales_quote,
+		booking_doc,
+		blanket_call_off=blanket_call_off,
+		selected_charge_row_names=selected_charge_row_names,
+		exclude_main_booking_service_type=exclude_main_booking_service_type,
+	)
+	if not ls_names:
+		stamp_scope_main_when_untagged(booking_doc)
+		return {}
+
+	try:
+		mapping = propagate_linked_services_and_remap_charges(
+			sales_quote,
+			booking_doc,
+			clone=use_clone,
+			ls_names=ls_names,
+		)
+		stamp_scope_main_when_untagged(booking_doc)
+		return mapping
+	except Exception as exc:
+		frappe.log_error(
+			title="Sales Quote Linked Service propagation failed",
+			message=(
+				f"Sales Quote: {getattr(sales_quote, 'name', None)}; "
+				f"Booking: {getattr(booking_doc, 'doctype', None)} "
+				f"{getattr(booking_doc, 'name', None)}\n{frappe.get_traceback()}"
+			),
+		)
+		frappe.throw(
+			_(
+				"Could not copy Linked Services from Sales Quote {0} to {1} {2}: {3}"
+			).format(
+				getattr(sales_quote, "name", ""),
+				getattr(booking_doc, "doctype", ""),
+				getattr(booking_doc, "name", ""),
+				str(exc),
+			),
+			title=_("Linked Service propagation failed"),
+		)
+
+
 def apply_linked_services_from_sales_quote_on_fetch(
 	sales_quote: Any,
 	operational_doc: Any,
@@ -428,32 +523,12 @@ def apply_linked_services_from_sales_quote_on_fetch(
 	the job so the quote remains the source of truth for later call-offs. One-off / Project quotes
 	that still own Linked Services use **re-parent** (same ids).
 	"""
-	if not sales_quote or not operational_doc:
-		return {}
-	qt = (getattr(sales_quote, "quotation_type", None) or "").strip()
-	use_clone = qt == "Regular"
-	ls_names = linked_service_names_from_quote_charges(
-		sales_quote, selected_charge_row_names
-	) or None
-	try:
-		mapping = propagate_linked_services_and_remap_charges(
-			sales_quote,
-			operational_doc,
-			clone=use_clone,
-			ls_names=ls_names,
-		)
-		stamp_scope_main_when_untagged(operational_doc)
-		return mapping
-	except Exception:
-		frappe.log_error(
-			title="Sales Quote fetch — Linked Service propagation failed",
-			message=(
-				f"Sales Quote: {getattr(sales_quote, 'name', None)}; "
-				f"Job: {getattr(operational_doc, 'doctype', None)} "
-				f"{getattr(operational_doc, 'name', None)}\n{frappe.get_traceback()}"
-			),
-		)
-		return {}
+	return propagate_linked_services_from_sales_quote_to_booking(
+		sales_quote,
+		operational_doc,
+		blanket_call_off=bool(selected_charge_row_names),
+		selected_charge_row_names=selected_charge_row_names,
+	)
 
 
 @frappe.whitelist()
@@ -483,7 +558,7 @@ def apply_sales_quote_linked_services_to_job(
 def propagate_linked_services_for_special_project_booking(
 	sp_doc: Any, booking_doc: Any
 ) -> dict[str, str]:
-	"""Clone subsidiary quote-owned Linked Services onto a Special Project booking/order."""
+	"""Clone or re-parent quote-owned Linked Services onto a Special Project booking/order."""
 	sq_name = (
 		(getattr(sp_doc, "sales_quote", None) or getattr(booking_doc, "sales_quote", None) or "")
 		.strip()
@@ -491,38 +566,7 @@ def propagate_linked_services_for_special_project_booking(
 	if not sq_name or not frappe.db.exists("Sales Quote", sq_name):
 		return {}
 	sq = frappe.get_doc("Sales Quote", sq_name)
-
-	from logistics.utils.charge_service_type import implied_service_type_for_doctype
-
-	main_st = implied_service_type_for_doctype(getattr(booking_doc, "doctype", None) or "")
-	exclude = [main_st] if main_st else None
-
-	sq_owned = _sq_owned_linked_services(sq_name)
-	ls_names = _filter_linked_service_names(sq_owned, exclude_service_types=exclude)
-
-	for ls in linked_service_names_from_charge_rows(getattr(booking_doc, "charges", None) or []):
-		if ls in sq_owned and ls not in ls_names:
-			ls_names.append(ls)
-
-	if not ls_names:
-		return {}
-
-	try:
-		mapping = propagate_linked_services_and_remap_charges(
-			sq, booking_doc, clone=True, ls_names=ls_names
-		)
-		stamp_scope_main_when_untagged(booking_doc)
-		return mapping
-	except Exception:
-		frappe.log_error(
-			title="Special Project Linked Service propagation failed",
-			message=(
-				f"Special Project: {getattr(sp_doc, 'name', None)}; "
-				f"Booking: {getattr(booking_doc, 'doctype', None)} "
-				f"{getattr(booking_doc, 'name', None)}\n{frappe.get_traceback()}"
-			),
-		)
-		return {}
+	return propagate_linked_services_from_sales_quote_to_booking(sq, booking_doc)
 
 
 def stamp_scope_main_when_untagged(booking_doc: Any) -> None:

--- a/logistics/utils/test_sales_quote_linked_service_propagation.py
+++ b/logistics/utils/test_sales_quote_linked_service_propagation.py
@@ -16,6 +16,7 @@ from logistics.utils.linked_service_compat import linked_service_doctype
 from logistics.utils.sales_quote_one_off_internal_jobs import (
 	linked_service_names_from_quote_charges,
 	propagate_linked_services_and_remap_charges,
+	propagate_linked_services_from_sales_quote_to_booking,
 )
 
 
@@ -38,6 +39,10 @@ class TestSalesQuoteLinkedServicePropagation(FrappeTestCase):
 		doc.customer = frappe.db.get_value("Customer", {}, "name")
 		if not doc.customer:
 			self.skipTest("No Customer in system")
+		doc.shipper = frappe.db.get_value("Shipper", {}, "name")
+		doc.consignee = frappe.db.get_value("Consignee", {}, "name")
+		if not doc.shipper or not doc.consignee:
+			self.skipTest("No Shipper/Consignee in system")
 		doc.date = frappe.utils.today()
 		doc.valid_until = frappe.utils.add_days(frappe.utils.today(), 30)
 		doc.flags.ignore_mandatory = True
@@ -99,6 +104,14 @@ class TestSalesQuoteLinkedServicePropagation(FrappeTestCase):
 				frappe.db.get_value(linked_service_doctype(), ls_name, "parent_booking_name"),
 				sq.name,
 			)
+			booking_ls = _linked_service_names_from_db("Sea Booking", booking.name)
+			self.assertEqual(len(booking_ls), 1)
+			clone_name = list(booking_ls)[0]
+			self.assertNotEqual(clone_name, ls_name)
+			self.assertEqual(
+				frappe.db.get_value(linked_service_doctype(), clone_name, "parent_booking_name"),
+				booking.name,
+			)
 		finally:
 			if booking and frappe.db.exists("Sea Booking", booking.name):
 				frappe.delete_doc("Sea Booking", booking.name, force=True, ignore_permissions=True)
@@ -125,4 +138,83 @@ class TestSalesQuoteLinkedServicePropagation(FrappeTestCase):
 			found = linked_service_names_from_quote_charges(sq, [ch_row.name])
 			self.assertEqual(found, [ls_names[0]])
 		finally:
+			frappe.delete_doc("Sales Quote", sq.name, force=True, ignore_permissions=True)
+
+	def test_regular_propagates_all_services_when_only_one_charge_tagged(self):
+		"""All Services grid rows copy to the booking even if only one charge is Linked-tagged."""
+		sq = self._minimal_sales_quote("SQ Regular All LS", quotation_type="Regular")
+		booking = None
+		try:
+			sq.append("linked_services", {"service_type": "Transport"})
+			sq.append("linked_services", {"service_type": "Customs"})
+			sq.flags._linked_services_from_form = True
+			sync_internal_job_details_to_internal_jobs(sq)
+			ls_names = list(_linked_service_names_from_db("Sales Quote", sq.name))
+			self.assertEqual(len(ls_names), 2)
+			sq.append(
+				"charges",
+				{
+					"service_type": "Sea",
+					"charge_scope": "Linked",
+					"linked_service": ls_names[0],
+				},
+			)
+			sq.save(ignore_permissions=True)
+
+			booking = frappe.new_doc("Sea Booking")
+			booking.sales_quote = sq.name
+			booking.flags.ignore_mandatory = True
+			booking.insert(ignore_permissions=True)
+			propagate_linked_services_from_sales_quote_to_booking(sq, booking)
+
+			booking_ls = _linked_service_names_from_db("Sea Booking", booking.name)
+			self.assertEqual(len(booking_ls), 2)
+			self.assertEqual(len(_linked_service_names_from_db("Sales Quote", sq.name)), 2)
+		finally:
+			if booking and frappe.db.exists("Sea Booking", booking.name):
+				frappe.delete_doc("Sea Booking", booking.name, force=True, ignore_permissions=True)
+			frappe.delete_doc("Sales Quote", sq.name, force=True, ignore_permissions=True)
+
+	def test_one_off_sea_booking_conversion_populates_linked_services(self):
+		"""End-to-end: Create > Sea Booking copies subsidiary services onto the booking."""
+		from logistics.pricing_center.doctype.sales_quote.sales_quote import (
+			create_sea_booking_from_sales_quote,
+		)
+		from logistics.logistics.doctype.linked_service.linked_service import (
+			get_linked_services_for_booking,
+		)
+
+		sq = self._minimal_sales_quote("SQ One-off Sea LS", quotation_type="One-off")
+		sbk_name = None
+		try:
+			sq.origin_port = "USLAX"
+			sq.destination_port = "USJFK"
+			sq.append(
+				"charges",
+				{
+					"service_type": "sea",
+					"origin_port": "USLAX",
+					"destination_port": "USJFK",
+					"direction": "Export",
+				},
+			)
+			sq.append("linked_services", {"service_type": "Transport"})
+			sq.append("linked_services", {"service_type": "Customs"})
+			sq.flags._linked_services_from_form = True
+			sq.save(ignore_permissions=True)
+			self.assertEqual(len(_linked_service_names_from_db("Sales Quote", sq.name)), 2)
+
+			result = create_sea_booking_from_sales_quote(sq.name)
+			self.assertTrue(result.get("success"))
+			sbk_name = result.get("sea_booking")
+			self.assertTrue(sbk_name)
+
+			rows = get_linked_services_for_booking("Sea Booking", sbk_name)
+			self.assertEqual(len(rows), 2)
+			service_types = {getattr(r, "service_type", None) for r in rows}
+			self.assertEqual(service_types, {"Transport", "Customs"})
+			self.assertEqual(len(_linked_service_names_from_db("Sales Quote", sq.name)), 0)
+		finally:
+			if sbk_name and frappe.db.exists("Sea Booking", sbk_name):
+				frappe.delete_doc("Sea Booking", sbk_name, force=True, ignore_permissions=True)
 			frappe.delete_doc("Sales Quote", sq.name, force=True, ignore_permissions=True)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the issue where subsidiary **Services / Linked Services** did not appear on a Sea Booking after converting from a Sales Quote.

## Changes

- Introduced `propagate_linked_services_from_sales_quote_to_booking()` as the single propagation entry point
- **Full conversion** now always transfers **all** quote-owned `Linked Service` documents (not only those referenced on charge rows)
- **Blanket call-off** still restricts propagation to linked services tied to the selected charge rows
- When cloning (Regular / call-off), the main booking service type (e.g. Sea on a Sea Booking) is excluded to avoid duplicate main-service rows
- Propagation failures now **raise** with a clear error instead of silently completing conversion with an empty Linked Services grid
- Aligned **Create > Sea Booking** and **Create > Booking / Order** to use the same propagation logic

## Expected user behaviour

After converting a Sales Quote to a Sea Booking:

- The **Linked Services** tab on the new booking immediately shows subsidiary services (Transport, Customs, etc.)
- One-off quotes: services move to the booking (quote Services tab becomes empty — by design)
- Regular quotes: booking gets clones; quote retains its originals
- If propagation fails, conversion fails with an explicit error instead of a booking with missing services

## Tests

- Regular quote: all Services grid rows propagate even when only one charge is Linked-tagged
- One-off end-to-end: `create_sea_booking_from_sales_quote` populates booking linked services
- Existing clone/re-parent tests updated to assert booking-side records

## Note for SBK000000544

Existing bookings created before this fix may still need the backfill patch (`v3_0_backfill_sea_booking_linked_services`) or **Fetch Quotations** on the Sea Booking if linked services were never propagated.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc70853a-71b0-448d-965f-fe027c883162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc70853a-71b0-448d-965f-fe027c883162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

