### PR TITLE
fix(mice): align MICE Project internal jobs with current platform

### DIFF
--- a/logistics/logistics/doctype/internal_job_detail/internal_job_detail.js
+++ b/logistics/logistics/doctype/internal_job_detail/internal_job_detail.js
@@ -11,6 +11,7 @@
 		Customs: "Declaration Order",
 		Warehousing: "VAS Order",
 		"Special Project": "Project Order",
+		MICE: "MICE Order",
 	};
 
 	/** Fields that should refresh the auto-generated Job Description when edited */

--- a/logistics/logistics/doctype/linked_service_detail/linked_service_detail.js
+++ b/logistics/logistics/doctype/linked_service_detail/linked_service_detail.js
@@ -11,6 +11,7 @@
 		Customs: "Declaration Order",
 		Warehousing: "VAS Order",
 		"Special Project": "Project Order",
+		MICE: "MICE Order",
 	};
 
 	/** Fields that should refresh the auto-generated Job Description when edited */

--- a/logistics/mice/doctype/mice_project/mice_project.js
+++ b/logistics/mice/doctype/mice_project/mice_project.js
@@ -164,7 +164,7 @@ function _setup_dockets_grid_buttons(frm) {
 		function () {
 			if (!frm || !frm.doc || !frm.doc.name || frm.doc.__islocal) {
 				frappe.msgprint({
-					message: __("Save this Exhibit before creating a Sales Quote."),
+					message: __("Save this MICE Project before creating a Sales Quote."),
 					indicator: "orange",
 				});
 				return;
@@ -269,9 +269,11 @@ function _exhibit_allocate_costs_dialog(frm) {
 }
 
 function logistics_set_internal_job_site_query(frm) {
-	frm.set_query("sp_site", "lifecycle_jobs", function () {
+	var site_query = function () {
 		return logistics.address.query_for_customer(frm._mice_organizer_customer);
-	});
+	};
+	frm.set_query("sp_site", "internal_jobs", site_query);
+	frm.set_query("sp_site", "lifecycle_jobs", site_query);
 }
 
 function _cache_organizer_customer(frm) {
@@ -371,6 +373,9 @@ frappe.ui.form.on("MICE Project", {
 		}
 
 		if (!frm.is_new() && !frm.doc.__islocal) {
+			if (window.logistics && logistics.add_get_charges_from_quotation_button_if_allowed) {
+				logistics.add_get_charges_from_quotation_button_if_allowed(frm);
+			}
 			frm.add_custom_button(
 				__("Booking / Order"),
 				function () {

--- a/logistics/mice/doctype/mice_project/mice_project.py
+++ b/logistics/mice/doctype/mice_project/mice_project.py
@@ -149,6 +149,16 @@ class MICEProject(Document):
 		except Exception:
 			return None
 
+	def populate_charges_from_sales_quote(self, sales_quote=None):
+		"""GCFQ entry point: link the Sales Quote (programme has no per-service charges table)."""
+		sq_name = (sales_quote or self.sales_quote or "").strip()
+		if not sq_name:
+			frappe.throw(_("No Sales Quote linked."))
+		if not frappe.db.exists("Sales Quote", sq_name):
+			frappe.throw(_("Sales Quote {0} not found.").format(sq_name))
+		self.sales_quote = sq_name
+		return 0
+
 	def _ensure_org_defaults(self):
 		"""Default ``company`` from the linked ERPNext Project (and ``cost_center``
 		from that Company) so the Exhibit-level Organization fields are always

--- a/logistics/mice/doctype/mice_project/mice_project_booking_creation.py
+++ b/logistics/mice/doctype/mice_project/mice_project_booking_creation.py
@@ -197,9 +197,9 @@ def _choice_header(job_type: str, row: Any | None, idx: int | None, jn: str) -> 
 	elif not st:
 		subtitle = _("Select a service type on this line to set the target document type.")
 	elif not jt_label:
-		subtitle = _("This service type cannot be created from an Exhibit.")
+		subtitle = _("This service type cannot be created from a MICE Project.")
 	else:
-		subtitle = _("Creates {0} linked to this Exhibit.").format(
+		subtitle = _("Creates {0} linked to this MICE Project.").format(
 			_(_TARGET_DOC_LABELS.get(jt_label, jt_label))
 		)
 	return {"header_title": title, "header_badge": badge, "header_subtitle": subtitle}
@@ -209,7 +209,7 @@ def _choice_header(job_type: str, row: Any | None, idx: int | None, jn: str) -> 
 def get_exhibit_booking_choices(exhibit: str, internal_jobs: Any = None):
 	"""Return Create > Booking/Order options for each Internal Job row on an Exhibit."""
 	if not exhibit or not frappe.db.exists("MICE Project", exhibit):
-		frappe.throw(_("Invalid Exhibit."))
+		frappe.throw(_("Invalid MICE Project."))
 	doc = frappe.get_doc("MICE Project", exhibit)
 	doc.check_permission("read")
 
@@ -382,7 +382,7 @@ def get_exhibit_booking_preview(
 ):
 	"""Internal Job row parameters that will inform the new operational document."""
 	if not exhibit or not frappe.db.exists("MICE Project", exhibit):
-		frappe.throw(_("Invalid Exhibit."))
+		frappe.throw(_("Invalid MICE Project."))
 	doc = frappe.get_doc("MICE Project", exhibit)
 	doc.check_permission("read")
 
@@ -416,7 +416,7 @@ def get_exhibit_booking_preview(
 				msg = _("This line is already linked to {0}.").format(jn_linked)
 				if cancelled:
 					msg = _(
-						"This line still references {0}, which is cancelled. Reload the Exhibit if the link should have been removed."
+						"This line still references {0}, which is cancelled. Reload the MICE Project if the link should have been removed."
 					).format(jn_linked)
 				return {
 					"job_type": jt or row_jt,
@@ -454,7 +454,7 @@ def get_exhibit_booking_preview(
 				"uses_job_detail_row": True,
 				"creatable": False,
 				"not_creatable_message": _(
-					"This job type cannot be created from an Exhibit. Choose a supported booking/order."
+					"This job type cannot be created from a MICE Project. Choose a supported booking/order."
 				),
 				"source_context": source_context,
 				"target_internal_job": None,
@@ -494,7 +494,7 @@ def get_exhibit_booking_preview(
 
 
 def _apply_exhibit_context(target_doc: Any, ep_doc: Any) -> None:
-	"""Populate accounting and reference fields from the Exhibit onto the new booking/order."""
+	"""Populate accounting and reference fields from the MICE Project onto the new booking/order."""
 	meta = frappe.get_meta(target_doc.doctype)
 	org = _resolve_exhibit_org_context(ep_doc)
 
@@ -510,6 +510,8 @@ def _apply_exhibit_context(target_doc: Any, ep_doc: Any) -> None:
 	_set_if_field("cost_center", org.get("cost_center"))
 	_set_if_field("profit_center", org.get("profit_center"))
 	_set_if_field("project", org.get("project"))
+	sq_name = (getattr(ep_doc, "sales_quote", None) or "").strip() or _resolve_sales_quote_for_exhibit(ep_doc)
+	_set_if_field("sales_quote", sq_name)
 
 	cust = _resolve_organizer_customer(ep_doc)
 	if cust:
@@ -517,6 +519,94 @@ def _apply_exhibit_context(target_doc: Any, ep_doc: Any) -> None:
 			target_doc.local_customer = cust
 		if meta.get_field("customer"):
 			target_doc.customer = cust
+	_apply_sales_quote_parties_to_target(target_doc, ep_doc)
+
+
+def _apply_sales_quote_parties_to_target(target_doc: Any, ep_doc: Any) -> None:
+	"""Copy shipper/consignee from the linked Sales Quote (same as quote → booking creation)."""
+	sq_name = (
+		(getattr(ep_doc, "sales_quote", None) or "").strip()
+		or _resolve_sales_quote_for_exhibit(ep_doc)
+		or getattr(target_doc, "sales_quote", None)
+		or ""
+	).strip()
+	if not sq_name or not frappe.db.exists("Sales Quote", sq_name):
+		return
+	sq = frappe.get_cached_doc("Sales Quote", sq_name)
+	meta = frappe.get_meta(target_doc.doctype)
+	for party_fn in ("shipper", "consignee"):
+		if not meta.get_field(party_fn):
+			continue
+		if not (getattr(target_doc, party_fn, None) or "").strip() and getattr(sq, party_fn, None):
+			target_doc.set(party_fn, sq.get(party_fn))
+	if target_doc.doctype in ("Air Booking", "Sea Booking"):
+		from logistics.utils.party_address_contact_from_masters import (
+			populate_air_sea_booking_party_fields_from_masters,
+		)
+		from logistics.utils.shipper_consignee_defaults import apply_shipper_consignee_defaults
+
+		populate_air_sea_booking_party_fields_from_masters(target_doc)
+		apply_shipper_consignee_defaults(target_doc)
+
+
+def _populate_charges_from_linked_sales_quote(target_doc: Any) -> None:
+	"""Populate operational charges from the linked Sales Quote."""
+	sq_name = getattr(target_doc, "sales_quote", None)
+	if not sq_name or not frappe.db.exists("Sales Quote", sq_name):
+		return
+
+	dt = target_doc.doctype
+	try:
+		if dt == "Air Booking":
+			from logistics.utils.internal_job_from_source import (
+				_populate_air_booking_charges_from_linked_quote_on_internal_create,
+			)
+
+			_populate_air_booking_charges_from_linked_quote_on_internal_create(target_doc)
+		elif dt == "Sea Booking":
+			from logistics.utils.internal_job_from_source import (
+				_populate_sea_booking_charges_from_linked_quote_on_internal_create,
+			)
+
+			_populate_sea_booking_charges_from_linked_quote_on_internal_create(target_doc)
+		elif dt == "Transport Order" and hasattr(target_doc, "_populate_charges_from_sales_quote"):
+			target_doc._populate_charges_from_sales_quote()
+		elif dt == "Declaration Order" and hasattr(target_doc, "_populate_charges_from_sales_quote"):
+			target_doc._populate_charges_from_sales_quote()
+		elif dt == "Inbound Order" and hasattr(target_doc, "_populate_charges_from_sales_quote"):
+			target_doc._populate_charges_from_sales_quote()
+	except Exception:
+		frappe.log_error(
+			frappe.get_traceback(),
+			f"MICE Project — Sales Quote charge population on {dt} create",
+		)
+
+
+def _prepare_operational_charges_before_insert(ep_doc: Any, target_doc: Any, row: Any | None) -> None:
+	"""Load Sales Quote charges onto the new booking/order and scope them to the Internal Job row."""
+	target_meta = frappe.get_meta(target_doc.doctype)
+	charges_df = target_meta.get_field("charges")
+	if not charges_df or charges_df.fieldtype != "Table":
+		return
+
+	if target_meta.get_field("sales_quote") and not (getattr(target_doc, "sales_quote", None) or "").strip():
+		sq_name = (getattr(ep_doc, "sales_quote", None) or "").strip() or _resolve_sales_quote_for_exhibit(ep_doc)
+		if sq_name:
+			target_doc.sales_quote = sq_name
+
+	_populate_charges_from_linked_sales_quote(target_doc)
+	from logistics.utils.charge_service_type import filter_operational_doc_charges_for_internal_job_row
+	from logistics.utils.sales_quote_charge_copy import SCOPE_INTERNAL_JOB, stamp_scope_fields_on_charge_row
+
+	filter_operational_doc_charges_for_internal_job_row(target_doc, row)
+	row_ij = (
+		(getattr(row, "internal_job", None) or getattr(row, "linked_service", None) or "").strip()
+		if row
+		else ""
+	)
+	if row_ij:
+		for charge_row in getattr(target_doc, "charges", None) or []:
+			stamp_scope_fields_on_charge_row(charge_row, SCOPE_INTERNAL_JOB, row_ij)
 
 
 def _apply_air_sea_corridor_ports_from_row(target_doc: Any, row: Any | None) -> None:
@@ -566,6 +656,7 @@ def _create_air_booking(ep_doc: Any, row: Any, detail_idx: int) -> dict[str, Any
 		doc.set(bd, today())
 	apply_internal_job_detail_row_to_operational_doc(doc, row, overwrite=True)
 	_apply_air_sea_corridor_ports_from_row(doc, row)
+	_prepare_operational_charges_before_insert(ep_doc, doc, row)
 	doc.insert(ignore_permissions=True)
 	_persist_row_link(ep_doc.name, "Air Booking", doc.name, detail_idx)
 	frappe.db.commit()
@@ -580,6 +671,7 @@ def _create_sea_booking(ep_doc: Any, row: Any, detail_idx: int) -> dict[str, Any
 		doc.set(bd, today())
 	apply_internal_job_detail_row_to_operational_doc(doc, row, overwrite=True)
 	_apply_air_sea_corridor_ports_from_row(doc, row)
+	_prepare_operational_charges_before_insert(ep_doc, doc, row)
 	doc.insert(ignore_permissions=True)
 	_persist_row_link(ep_doc.name, "Sea Booking", doc.name, detail_idx)
 	frappe.db.commit()
@@ -606,6 +698,7 @@ def _create_transport_order(ep_doc: Any, row: Any, detail_idx: int) -> dict[str,
 	from logistics.utils.service_role_rules import apply_standalone_service_flags
 
 	apply_standalone_service_flags(order)
+	_prepare_operational_charges_before_insert(ep_doc, order, row)
 	order.insert(ignore_permissions=True)
 	_persist_row_link(ep_doc.name, "Transport Order", order.name, detail_idx)
 	frappe.db.commit()
@@ -628,6 +721,7 @@ def _create_declaration_order(ep_doc: Any, row: Any, detail_idx: int) -> dict[st
 	from logistics.utils.service_role_rules import apply_standalone_service_flags
 
 	apply_standalone_service_flags(order)
+	_prepare_operational_charges_before_insert(ep_doc, order, row)
 	order.insert(ignore_permissions=True)
 	_persist_row_link(ep_doc.name, "Declaration Order", order.name, detail_idx)
 	frappe.db.commit()
@@ -643,6 +737,7 @@ def _create_inbound_order(ep_doc: Any, row: Any, detail_idx: int) -> dict[str, A
 	if frappe.get_meta("Inbound Order").get_field("order_date"):
 		order.order_date = today()
 	apply_internal_job_detail_row_to_operational_doc(order, row, overwrite=True)
+	_prepare_operational_charges_before_insert(ep_doc, order, row)
 	order.insert(ignore_permissions=True)
 	_persist_row_link(ep_doc.name, "Inbound Order", order.name, detail_idx)
 	frappe.db.commit()
@@ -766,7 +861,7 @@ def create_booking_or_order_from_exhibit(
 ):
 	"""Create the chosen booking/order from the matching Internal Job row on the Exhibit."""
 	if not exhibit or not frappe.db.exists("MICE Project", exhibit):
-		frappe.throw(_("Invalid Exhibit."))
+		frappe.throw(_("Invalid MICE Project."))
 	jt = (job_type or "").strip()
 	if jt not in EXHIBIT_CREATABLE_JOB_TYPES:
 		frappe.throw(_("Invalid job type."))

--- a/logistics/public/js/exhibit_booking_dialog.js
+++ b/logistics/public/js/exhibit_booking_dialog.js
@@ -13,6 +13,10 @@
 		return JSON.stringify((frm && frm.doc && frm.doc.internal_jobs) || []);
 	}
 
+	function _parentLabel(frm) {
+		return frm && frm.doctype === "MICE Project" ? __("MICE Project") : __("Exhibit");
+	}
+
 	function _encodeChoice(c) {
 		const cr = c.creatable === false ? "0" : "1";
 		const idx = c.detail_idx != null ? String(c.detail_idx) : "";
@@ -243,7 +247,12 @@
 			$("<p>")
 				.addClass("text-muted")
 				.css({ fontSize: "12px", marginBottom: "10px", lineHeight: 1.45 })
-				.text(__("Each card is one Internal Job line on this Exhibit. Expand for details; use Create in the card header when ready."))
+				.text(
+					__(
+						"Each card is one Internal Job line on this {0}. Expand for details; use Create in the card header when ready.",
+						[_parentLabel(frm)]
+					)
+				)
 		);
 		const $scroll = $("<div class='ex-cards-scroll'>");
 		const $cards = $("<div class='ex-cards'>");
@@ -379,7 +388,7 @@
 
 	function _introHtml(frm) {
 		const esc = frappe.utils.escape_html;
-		const ref = esc(__("MICE Project") + " · " + (frm.doc.name || ""));
+		const ref = esc(_parentLabel(frm) + " · " + (frm.doc.name || ""));
 		return (
 			"<div class='" + PREVIEW_CLASS + "' style='margin-bottom:4px'>" +
 			"<div style='font-size:12px;color:var(--text-muted,#64748b);line-height:1.5'>" +
@@ -393,7 +402,7 @@
 		if (!frm || !frm.doc || !frm.doc.name || frm.doc.__islocal) {
 			frappe.msgprint({
 				title: __("Save Required"),
-				message: __("Save the Exhibit before creating bookings or orders."),
+				message: __("Save the {0} before creating bookings or orders.", [_parentLabel(frm)]),
 				indicator: "orange",
 			});
 			return;
@@ -412,7 +421,10 @@
 				if (!choices.length) {
 					frappe.msgprint({
 						title: __("Create Booking / Order"),
-						message: __("No Internal Job lines on this Exhibit. Add a row under the Jobs tab first."),
+						message: __(
+							"No Internal Job lines on this {0}. Add a row under the Jobs tab first.",
+							[_parentLabel(frm)]
+						),
 						indicator: "orange",
 					});
 					return;

--- a/logistics/public/js/get_charges_from_quotation.js
+++ b/logistics/public/js/get_charges_from_quotation.js
@@ -656,12 +656,14 @@ logistics.open_get_charges_from_quotation_dialog = function (frm) {
 	}
 
 	var cust =
-		frm.doctype === "Transport Order" || frm.doctype === "Declaration Order"
-			? frm.doc.customer
-			: frm.doctype === "Special Project" || frm.doctype === "Exhibit"
+		frm.doctype === "MICE Project"
+			? null
+			: frm.doctype === "Transport Order" || frm.doctype === "Declaration Order"
 				? frm.doc.customer
-				: frm.doc.local_customer;
-	if (!cust) {
+				: frm.doctype === "Special Project" || frm.doctype === "Exhibit"
+					? frm.doc.customer
+					: frm.doc.local_customer;
+	if (!cust && frm.doctype !== "MICE Project") {
 		frappe.msgprint(
 			__(
 				frm.doctype === "Transport Order" ||

--- a/logistics/utils/get_charges_from_quotation.py
+++ b/logistics/utils/get_charges_from_quotation.py
@@ -81,10 +81,11 @@ JOB_DOCTYPES = frozenset(
 		"Declaration Order",
 		"Special Project",
 		"Exhibit",
+		"MICE Project",
 	}
 )
 
-_PROGRAMME_GCFQ_DOCTYPES = frozenset({"Special Project", "Exhibit"})
+_PROGRAMME_GCFQ_DOCTYPES = frozenset({"Special Project", "Exhibit", "MICE Project"})
 
 # Whitelisted keys for Action → Get Charges from Quotation dialog filters (client-sent).
 GCFQ_FILTER_KEYS: dict[str, frozenset[str]] = {
@@ -112,6 +113,7 @@ GCFQ_FILTER_KEYS: dict[str, frozenset[str]] = {
 	),
 	"Special Project": frozenset({"branch", "cost_center", "profit_center"}),
 	"Exhibit": frozenset({"branch", "cost_center", "profit_center"}),
+	"MICE Project": frozenset({"branch", "cost_center", "profit_center"}),
 }
 
 
@@ -283,6 +285,11 @@ def assert_one_off_sales_quote_job_rules(doc):
 def _job_customer(doc) -> str | None:
 	if doc.doctype in ("Sea Booking", "Air Booking"):
 		return (getattr(doc, "local_customer", None) or "").strip() or None
+	if doc.doctype == "MICE Project":
+		getter = getattr(doc, "get_organizer_customer", None)
+		if callable(getter):
+			return (getter() or "").strip() or None
+		return None
 	if doc.doctype in ("Transport Order", "Declaration Order", "Special Project", "Exhibit"):
 		return (getattr(doc, "customer", None) or "").strip() or None
 	return None
@@ -864,7 +871,7 @@ def preview_quotation_charges_for_job(
 		from logistics.utils.sales_quote_programme_charges import preview_programme_charges_from_sales_quote
 
 		return preview_programme_charges_from_sales_quote(docname, doctype, sales_quote)
-	if doctype == "Exhibit":
+	if doctype in ("Exhibit", "MICE Project"):
 		from logistics.utils.sales_quote_programme_charges import preview_programme_charges_from_sales_quote
 
 		return preview_programme_charges_from_sales_quote(docname, doctype, sales_quote)
@@ -1306,7 +1313,7 @@ def apply_quotation_charges_to_job(
 			doc._populate_charges_from_sales_quote()
 		elif doctype == "Special Project":
 			doc.populate_charges_from_sales_quote(sales_quote)
-		elif doctype == "Exhibit":
+		elif doctype in ("Exhibit", "MICE Project"):
 			doc.populate_charges_from_sales_quote(sales_quote)
 
 	# Append Internal-Job-scoped Sales Quote Charge rows into the Main's charges table (no separate

--- a/logistics/utils/internal_job_creation_eligibility.py
+++ b/logistics/utils/internal_job_creation_eligibility.py
@@ -39,7 +39,6 @@ _PROGRAMME_CHARGE_PARENTS = frozenset(
 _PROGRAMME_LIFECYCLE_JOB_PARENTS: dict[str, str] = {
 	"Special Project": "special_project_services",
 	"Exhibit": "lifecycle_jobs",
-	"MICE Project": "lifecycle_jobs",
 }
 
 _EXHIBIT_LINKED_SALES_QUOTE_PARENTS = frozenset({"MICE Project", "Exhibit"})

--- a/logistics/utils/test_internal_job_creation_eligibility.py
+++ b/logistics/utils/test_internal_job_creation_eligibility.py
@@ -203,6 +203,68 @@ class TestInternalJobCreationEligibility(FrappeTestCase):
 
 		self.assertEqual(_parent_ij_fieldname("Special Project"), "special_project_services")
 		self.assertEqual(_parent_ij_fieldname("Exhibit"), "lifecycle_jobs")
+		self.assertEqual(_parent_ij_fieldname("MICE Project"), "internal_jobs")
+		self.assertEqual(_parent_ij_fieldname("Docket"), "internal_jobs")
+
+	@patch("logistics.utils.internal_job_creation_eligibility.frappe.db.exists", return_value=True)
+	@patch("logistics.utils.internal_job_creation_eligibility.frappe.get_meta")
+	@patch("logistics.utils.internal_job_creation_eligibility.frappe.get_cached_doc")
+	def test_has_matching_setup_accepts_internal_job_row_on_mice_project(
+		self, mock_cached_doc, mock_meta, _exists
+	):
+		mock_meta.return_value.get_field.return_value = None
+		ij_row = MagicMock(service_type="MICE", name="ij-mice-1")
+		parent = MagicMock(doctype="MICE Project", sales_quote="SQ-1")
+		parent.internal_jobs = [ij_row]
+		with patch(
+			"logistics.utils.internal_job_creation_eligibility.internal_job_matches_charges",
+			return_value=True,
+		):
+			self.assertTrue(has_matching_internal_job_setup("SQ-1", parent, ij_row, "MICE"))
+
+	@patch("logistics.utils.internal_job_creation_eligibility.frappe.db.exists", return_value=False)
+	def test_evaluate_eligible_for_mice_project_internal_job_row(self, _exists):
+		ij_row = frappe._dict(service_type="MICE", name="ij-mice-1")
+		parent = frappe._dict(
+			doctype="MICE Project",
+			sales_quote=None,
+			internal_jobs=[ij_row],
+		)
+		with patch(
+			"logistics.utils.internal_job_creation_eligibility.charges_exist_for_service",
+			return_value=True,
+		):
+			with patch(
+				"logistics.utils.internal_job_creation_eligibility.has_matching_internal_job_setup",
+				return_value=True,
+			):
+				result = evaluate_internal_job_creation_eligibility(
+					parent_doc=parent,
+					ij_row=ij_row,
+					service_type_label="MICE",
+				)
+		self.assertTrue(result["eligible"])
+		self.assertIsNone(result["message"])
+
+	def test_eligibility_message_uses_internal_jobs_tab_for_mice_project(self):
+		parent = MagicMock(doctype="MICE Project")
+		ij_row = MagicMock(service_type="Air", name="ij-air-1")
+		with patch(
+			"logistics.utils.internal_job_creation_eligibility.charges_exist_for_service",
+			return_value=True,
+		):
+			with patch(
+				"logistics.utils.internal_job_creation_eligibility.has_matching_internal_job_setup",
+				return_value=False,
+			):
+				result = evaluate_internal_job_creation_eligibility(
+					parent_doc=parent,
+					ij_row=ij_row,
+					service_type_label="Air",
+				)
+		msg = (result.get("message") or "").lower()
+		self.assertIn("internal jobs", msg)
+		self.assertNotIn("lifecycle", msg)
 
 	def test_quote_has_matching_linked_service_row_uses_virtual_grid(self):
 		"""Regression: eligibility must not read ``sq_doc.get('linked_services')`` (always empty after save)."""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns the MICE Project **Jobs / Internal Jobs** tab with the current platform patterns used by Docket and v3.0 Linked Service flows.

## Changes

- **Eligibility**: `MICE Project` now validates against `internal_jobs` (Jobs tab) instead of the hidden `lifecycle_jobs` table; error messages reference the Internal Jobs tab.
- **Booking creation**: Air/Sea/Transport/Declaration/Inbound creates now load charges from the linked Sales Quote and scope them to the Internal Job row (matching Docket behaviour).
- **Get Charges from Quotation**: Added `MICE Project` to GCFQ server/client support, including organizer-based customer resolution and a form action button.
- **Client polish**: MICE service type maps to MICE Order in grid scripts; site query applies to `internal_jobs`; booking dialog and form copy use MICE Project naming.

## Testing

- Added unit tests for MICE Project eligibility field mapping and messaging.
- Existing `test_mice_project_booking_creation` coverage remains valid for MICE Order creation.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b90bf7a-de5e-4e47-a660-34df4f265b5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b90bf7a-de5e-4e47-a660-34df4f265b5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

