### PR TITLE
fix(sea-booking): preserve linked services when saving booking

### DIFF
--- a/logistics/utils/internal_job_persistence.py
+++ b/logistics/utils/internal_job_persistence.py
@@ -288,11 +288,22 @@ def _linked_service_names_from_db(parent_doctype: str, parent_name: str) -> set[
 	)
 
 
+def _linked_service_name_from_row(row: Any) -> str:
+	"""Resolve the canonical Linked Service name from a detail row or LS document."""
+	name = row_linked_service_link(row)
+	if name:
+		return name
+	if getattr(row, "doctype", None) == linked_service_doctype():
+		return _norm(getattr(row, "name", None))
+	return ""
+
+
 def _currently_linked_internal_jobs(parent_doc: Any, fieldname: str) -> set[str]:
 	return {
-		row_linked_service_link(r)
+		name
 		for r in internal_job_detail_rows_for_parent(parent_doc)
-		if row_linked_service_link(r)
+		for name in [_linked_service_name_from_row(r)]
+		if name
 	}
 
 
@@ -362,7 +373,7 @@ def _ensure_internal_job_docs_for_detail_rows(parent_doc: Any) -> dict[str, str]
 		return remap
 
 	for row in internal_job_detail_rows_for_parent(parent_doc):
-		ij_name = row_linked_service_link(row)
+		ij_name = _linked_service_name_from_row(row)
 		if ij_name and linked_service_record_exists(ij_name):
 			_update_internal_job_from_row(row, ij_name)
 			if _norm(getattr(parent_doc, "name", None)):
@@ -407,7 +418,7 @@ def _internal_job_by_service_type(parent_doc: Any, fieldname: str) -> dict[str, 
 	out: dict[str, str] = {}
 	for row in internal_job_detail_rows_for_parent(parent_doc):
 		st = _norm(_row_value(row, "service_type"))
-		ij = row_linked_service_link(row)
+		ij = _linked_service_name_from_row(row)
 		if st and ij:
 			out[st] = ij
 	return out

--- a/logistics/utils/test_sea_virtual_internal_job_details.py
+++ b/logistics/utils/test_sea_virtual_internal_job_details.py
@@ -105,3 +105,52 @@ class TestOperationalLinkedServices(FrappeTestCase):
 		self.assertEqual(field.fieldtype, "Table")
 		self.assertTrue(field.is_virtual)
 		self.assertIsNone(meta.get_field("internal_job_details"))
+
+	def test_save_preserves_quote_propagated_linked_services(self):
+		"""Regression: saving a Sea Booking must not delete propagated Linked Service docs."""
+		from logistics.utils.sales_quote_one_off_internal_jobs import (
+			propagate_linked_services_from_sales_quote_to_booking,
+		)
+
+		sq = frappe.new_doc("Sales Quote")
+		sq.quotation_type = "One-off"
+		sq.main_service = "Sea"
+		sq.naming_series = "OOQ.#####"
+		sq.customer = frappe.db.get_value("Customer", {}, "name")
+		sq.shipper = frappe.db.get_value("Shipper", {}, "name")
+		sq.consignee = frappe.db.get_value("Consignee", {}, "name")
+		if not sq.customer or not sq.shipper or not sq.consignee:
+			self.skipTest("Missing Customer/Shipper/Consignee master data")
+		sq.date = frappe.utils.today()
+		sq.valid_until = frappe.utils.add_days(frappe.utils.today(), 30)
+		sq.flags.ignore_mandatory = True
+		sq.insert(ignore_permissions=True)
+		booking = None
+		try:
+			sq.append("linked_services", {"service_type": "Transport"})
+			sq.append("linked_services", {"service_type": "Customs"})
+			sq.flags._linked_services_from_form = True
+			sync_internal_job_details_to_internal_jobs(sq)
+			ls_before = _linked_service_names_from_db("Sales Quote", sq.name)
+			self.assertEqual(len(ls_before), 2)
+
+			booking = frappe.new_doc("Sea Booking")
+			booking.sales_quote = sq.name
+			booking.flags.ignore_mandatory = True
+			booking.insert(ignore_permissions=True)
+			propagate_linked_services_from_sales_quote_to_booking(sq, booking)
+			booking_ls = _linked_service_names_from_db("Sea Booking", booking.name)
+			self.assertEqual(len(booking_ls), 2)
+
+			doc = frappe.get_doc("Sea Booking", booking.name)
+			doc.notify_party = (doc.notify_party or "") + " updated"
+			doc.flags.ignore_mandatory = True
+			doc.save(ignore_permissions=True)
+
+			self.assertEqual(_linked_service_names_from_db("Sea Booking", booking.name), booking_ls)
+			reloaded = frappe.get_doc("Sea Booking", booking.name)
+			self.assertEqual(len(reloaded.linked_services), 2)
+		finally:
+			if booking and frappe.db.exists("Sea Booking", booking.name):
+				frappe.delete_doc("Sea Booking", booking.name, force=True, ignore_permissions=True)
+			frappe.delete_doc("Sales Quote", sq.name, force=True, ignore_permissions=True)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

For **SBK000000546** (and other Sea Bookings): linked services appear correctly after converting from a Sales Quote, but **disappear after the user edits and saves** the Sea Booking.

## Root cause

Sea Booking uses a **virtual** `linked_services` grid backed by `Linked Service` documents in the database. On every `before_save`, `sync_internal_job_details_to_internal_jobs` reconciles orphan linked services by comparing:

- **Previous** set: linked service names from DB (correct)
- **Current** set: names extracted via `row_linked_service_link()` on grid rows

For virtual parents, grid rows are **`Linked Service` documents**, not `Linked Service Detail` child rows. Those documents have no `linked_service` / `internal_job` pointer field — their identity is `name`. The sync therefore computed an **empty current set** and deleted every linked service as an "orphan" on save.

## Fix

- Added `_linked_service_name_from_row()` to resolve the canonical name from either a detail row **or** a `Linked Service` document
- Used this helper in orphan reconciliation and in the ensure/update sync path

## Expected behaviour after fix

1. Convert Sales Quote → Sea Booking: linked services appear (unchanged)
2. Edit any field on the Sea Booking and **Save**: linked services **remain** on the Linked Services tab
3. Linked Service documents stay parented to the booking (`parent_booking_type = Sea Booking`)

## Tests

- `test_save_preserves_quote_propagated_linked_services` — propagate services onto a booking, save, assert DB records and virtual grid still show both services

## Note for SBK000000546

If linked services were already deleted by a prior save, they will need to be restored via **Fetch Quotations** on the Sea Booking (or re-conversion from quote if applicable). This fix prevents further loss on save.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc70853a-71b0-448d-965f-fe027c883162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc70853a-71b0-448d-965f-fe027c883162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

