### PR TITLE
v1.0-fix(mice): align MICE Project internal jobs with current platform

### DIFF
--- a/logistics/logistics/doctype/internal_job_detail/internal_job_detail.js
+++ b/logistics/logistics/doctype/internal_job_detail/internal_job_detail.js
@@ -11,6 +11,7 @@
 		Customs: "Declaration Order",
 		Warehousing: "VAS Order",
 		"Special Project": "Project Order",
+		MICE: "MICE Order",
 	};
 
 	/** Fields that should refresh the auto-generated Job Description when edited */

--- a/logistics/logistics/doctype/linked_service_detail/linked_service_detail.js
+++ b/logistics/logistics/doctype/linked_service_detail/linked_service_detail.js
@@ -11,6 +11,7 @@
 		Customs: "Declaration Order",
 		Warehousing: "VAS Order",
 		"Special Project": "Project Order",
+		MICE: "MICE Order",
 	};
 
 	/** Fields that should refresh the auto-generated Job Description when edited */

--- a/logistics/mice/doctype/mice_project/mice_project.js
+++ b/logistics/mice/doctype/mice_project/mice_project.js
@@ -164,7 +164,7 @@ function _setup_dockets_grid_buttons(frm) {
 		function () {
 			if (!frm || !frm.doc || !frm.doc.name || frm.doc.__islocal) {
 				frappe.msgprint({
-					message: __("Save this Exhibit before creating a Sales Quote."),
+					message: __("Save this MICE Project before creating a Sales Quote."),
 					indicator: "orange",
 				});
 				return;
@@ -269,9 +269,11 @@ function _exhibit_allocate_costs_dialog(frm) {
 }
 
 function logistics_set_internal_job_site_query(frm) {
-	frm.set_query("sp_site", "lifecycle_jobs", function () {
+	var site_query = function () {
 		return logistics.address.query_for_customer(frm._mice_organizer_customer);
-	});
+	};
+	frm.set_query("sp_site", "internal_jobs", site_query);
+	frm.set_query("sp_site", "lifecycle_jobs", site_query);
 }
 
 function _cache_organizer_customer(frm) {
@@ -371,6 +373,9 @@ frappe.ui.form.on("MICE Project", {
 		}
 
 		if (!frm.is_new() && !frm.doc.__islocal) {
+			if (window.logistics && logistics.add_get_charges_from_quotation_button_if_allowed) {
+				logistics.add_get_charges_from_quotation_button_if_allowed(frm);
+			}
 			frm.add_custom_button(
 				__("Booking / Order"),
 				function () {

--- a/logistics/mice/doctype/mice_project/mice_project.py
+++ b/logistics/mice/doctype/mice_project/mice_project.py
@@ -149,6 +149,16 @@ class MICEProject(Document):
 		except Exception:
 			return None
 
+	def populate_charges_from_sales_quote(self, sales_quote=None):
+		"""GCFQ entry point: link the Sales Quote (programme has no per-service charges table)."""
+		sq_name = (sales_quote or self.sales_quote or "").strip()
+		if not sq_name:
+			frappe.throw(_("No Sales Quote linked."))
+		if not frappe.db.exists("Sales Quote", sq_name):
+			frappe.throw(_("Sales Quote {0} not found.").format(sq_name))
+		self.sales_quote = sq_name
+		return 0
+
 	def _ensure_org_defaults(self):
 		"""Default ``company`` from the linked ERPNext Project (and ``cost_center``
 		from that Company) so the Exhibit-level Organization fields are always

--- a/logistics/mice/doctype/mice_project/mice_project_booking_creation.py
+++ b/logistics/mice/doctype/mice_project/mice_project_booking_creation.py
@@ -197,9 +197,9 @@ def _choice_header(job_type: str, row: Any | None, idx: int | None, jn: str) -> 
 	elif not st:
 		subtitle = _("Select a service type on this line to set the target document type.")
 	elif not jt_label:
-		subtitle = _("This service type cannot be created from an Exhibit.")
+		subtitle = _("This service type cannot be created from a MICE Project.")
 	else:
-		subtitle = _("Creates {0} linked to this Exhibit.").format(
+		subtitle = _("Creates {0} linked to this MICE Project.").format(
 			_(_TARGET_DOC_LABELS.get(jt_label, jt_label))
 		)
 	return {"header_title": title, "header_badge": badge, "header_subtitle": subtitle}
@@ -209,7 +209,7 @@ def _choice_header(job_type: str, row: Any | None, idx: int | None, jn: str) -> 
 def get_exhibit_booking_choices(exhibit: str, internal_jobs: Any = None):
 	"""Return Create > Booking/Order options for each Internal Job row on an Exhibit."""
 	if not exhibit or not frappe.db.exists("MICE Project", exhibit):
-		frappe.throw(_("Invalid Exhibit."))
+		frappe.throw(_("Invalid MICE Project."))
 	doc = frappe.get_doc("MICE Project", exhibit)
 	doc.check_permission("read")
 
@@ -382,7 +382,7 @@ def get_exhibit_booking_preview(
 ):
 	"""Internal Job row parameters that will inform the new operational document."""
 	if not exhibit or not frappe.db.exists("MICE Project", exhibit):
-		frappe.throw(_("Invalid Exhibit."))
+		frappe.throw(_("Invalid MICE Project."))
 	doc = frappe.get_doc("MICE Project", exhibit)
 	doc.check_permission("read")
 
@@ -416,7 +416,7 @@ def get_exhibit_booking_preview(
 				msg = _("This line is already linked to {0}.").format(jn_linked)
 				if cancelled:
 					msg = _(
-						"This line still references {0}, which is cancelled. Reload the Exhibit if the link should have been removed."
+						"This line still references {0}, which is cancelled. Reload the MICE Project if the link should have been removed."
 					).format(jn_linked)
 				return {
 					"job_type": jt or row_jt,
@@ -454,7 +454,7 @@ def get_exhibit_booking_preview(
 				"uses_job_detail_row": True,
 				"creatable": False,
 				"not_creatable_message": _(
-					"This job type cannot be created from an Exhibit. Choose a supported booking/order."
+					"This job type cannot be created from a MICE Project. Choose a supported booking/order."
 				),
 				"source_context": source_context,
 				"target_internal_job": None,
@@ -494,7 +494,7 @@ def get_exhibit_booking_preview(
 
 
 def _apply_exhibit_context(target_doc: Any, ep_doc: Any) -> None:
-	"""Populate accounting and reference fields from the Exhibit onto the new booking/order."""
+	"""Populate accounting and reference fields from the MICE Project onto the new booking/order."""
 	meta = frappe.get_meta(target_doc.doctype)
 	org = _resolve_exhibit_org_context(ep_doc)
 
@@ -510,6 +510,8 @@ def _apply_exhibit_context(target_doc: Any, ep_doc: Any) -> None:
 	_set_if_field("cost_center", org.get("cost_center"))
 	_set_if_field("profit_center", org.get("profit_center"))
 	_set_if_field("project", org.get("project"))
+	sq_name = (getattr(ep_doc, "sales_quote", None) or "").strip() or _resolve_sales_quote_for_exhibit(ep_doc)
+	_set_if_field("sales_quote", sq_name)
 
 	cust = _resolve_organizer_customer(ep_doc)
 	if cust:
@@ -517,6 +519,94 @@ def _apply_exhibit_context(target_doc: Any, ep_doc: Any) -> None:
 			target_doc.local_customer = cust
 		if meta.get_field("customer"):
 			target_doc.customer = cust
+	_apply_sales_quote_parties_to_target(target_doc, ep_doc)
+
+
+def _apply_sales_quote_parties_to_target(target_doc: Any, ep_doc: Any) -> None:
+	"""Copy shipper/consignee from the linked Sales Quote (same as quote → booking creation)."""
+	sq_name = (
+		(getattr(ep_doc, "sales_quote", None) or "").strip()
+		or _resolve_sales_quote_for_exhibit(ep_doc)
+		or getattr(target_doc, "sales_quote", None)
+		or ""
+	).strip()
+	if not sq_name or not frappe.db.exists("Sales Quote", sq_name):
+		return
+	sq = frappe.get_cached_doc("Sales Quote", sq_name)
+	meta = frappe.get_meta(target_doc.doctype)
+	for party_fn in ("shipper", "consignee"):
+		if not meta.get_field(party_fn):
+			continue
+		if not (getattr(target_doc, party_fn, None) or "").strip() and getattr(sq, party_fn, None):
+			target_doc.set(party_fn, sq.get(party_fn))
+	if target_doc.doctype in ("Air Booking", "Sea Booking"):
+		from logistics.utils.party_address_contact_from_masters import (
+			populate_air_sea_booking_party_fields_from_masters,
+		)
+		from logistics.utils.shipper_consignee_defaults import apply_shipper_consignee_defaults
+
+		populate_air_sea_booking_party_fields_from_masters(target_doc)
+		apply_shipper_consignee_defaults(target_doc)
+
+
+def _populate_charges_from_linked_sales_quote(target_doc: Any) -> None:
+	"""Populate operational charges from the linked Sales Quote."""
+	sq_name = getattr(target_doc, "sales_quote", None)
+	if not sq_name or not frappe.db.exists("Sales Quote", sq_name):
+		return
+
+	dt = target_doc.doctype
+	try:
+		if dt == "Air Booking":
+			from logistics.utils.internal_job_from_source import (
+				_populate_air_booking_charges_from_linked_quote_on_internal_create,
+			)
+
+			_populate_air_booking_charges_from_linked_quote_on_internal_create(target_doc)
+		elif dt == "Sea Booking":
+			from logistics.utils.internal_job_from_source import (
+				_populate_sea_booking_charges_from_linked_quote_on_internal_create,
+			)
+
+			_populate_sea_booking_charges_from_linked_quote_on_internal_create(target_doc)
+		elif dt == "Transport Order" and hasattr(target_doc, "_populate_charges_from_sales_quote"):
+			target_doc._populate_charges_from_sales_quote()
+		elif dt == "Declaration Order" and hasattr(target_doc, "_populate_charges_from_sales_quote"):
+			target_doc._populate_charges_from_sales_quote()
+		elif dt == "Inbound Order" and hasattr(target_doc, "_populate_charges_from_sales_quote"):
+			target_doc._populate_charges_from_sales_quote()
+	except Exception:
+		frappe.log_error(
+			frappe.get_traceback(),
+			f"MICE Project — Sales Quote charge population on {dt} create",
+		)
+
+
+def _prepare_operational_charges_before_insert(ep_doc: Any, target_doc: Any, row: Any | None) -> None:
+	"""Load Sales Quote charges onto the new booking/order and scope them to the Internal Job row."""
+	target_meta = frappe.get_meta(target_doc.doctype)
+	charges_df = target_meta.get_field("charges")
+	if not charges_df or charges_df.fieldtype != "Table":
+		return
+
+	if target_meta.get_field("sales_quote") and not (getattr(target_doc, "sales_quote", None) or "").strip():
+		sq_name = (getattr(ep_doc, "sales_quote", None) or "").strip() or _resolve_sales_quote_for_exhibit(ep_doc)
+		if sq_name:
+			target_doc.sales_quote = sq_name
+
+	_populate_charges_from_linked_sales_quote(target_doc)
+	from logistics.utils.charge_service_type import filter_operational_doc_charges_for_internal_job_row
+	from logistics.utils.sales_quote_charge_copy import SCOPE_INTERNAL_JOB, stamp_scope_fields_on_charge_row
+
+	filter_operational_doc_charges_for_internal_job_row(target_doc, row)
+	row_ij = (
+		(getattr(row, "internal_job", None) or getattr(row, "linked_service", None) or "").strip()
+		if row
+		else ""
+	)
+	if row_ij:
+		for charge_row in getattr(target_doc, "charges", None) or []:
+			stamp_scope_fields_on_charge_row(charge_row, SCOPE_INTERNAL_JOB, row_ij)
 
 
 def _apply_air_sea_corridor_ports_from_row(target_doc: Any, row: Any | None) -> None:
@@ -566,6 +656,7 @@ def _create_air_booking(ep_doc: Any, row: Any, detail_idx: int) -> dict[str, Any
 		doc.set(bd, today())
 	apply_internal_job_detail_row_to_operational_doc(doc, row, overwrite=True)
 	_apply_air_sea_corridor_ports_from_row(doc, row)
+	_prepare_operational_charges_before_insert(ep_doc, doc, row)
 	doc.insert(ignore_permissions=True)
 	_persist_row_link(ep_doc.name, "Air Booking", doc.name, detail_idx)
 	frappe.db.commit()
@@ -580,6 +671,7 @@ def _create_sea_booking(ep_doc: Any, row: Any, detail_idx: int) -> dict[str, Any
 		doc.set(bd, today())
 	apply_internal_job_detail_row_to_operational_doc(doc, row, overwrite=True)
 	_apply_air_sea_corridor_ports_from_row(doc, row)
+	_prepare_operational_charges_before_insert(ep_doc, doc, row)
 	doc.insert(ignore_permissions=True)
 	_persist_row_link(ep_doc.name, "Sea Booking", doc.name, detail_idx)
 	frappe.db.commit()
@@ -606,6 +698,7 @@ def _create_transport_order(ep_doc: Any, row: Any, detail_idx: int) -> dict[str,
 	from logistics.utils.service_role_rules import apply_standalone_service_flags
 
 	apply_standalone_service_flags(order)
+	_prepare_operational_charges_before_insert(ep_doc, order, row)
 	order.insert(ignore_permissions=True)
 	_persist_row_link(ep_doc.name, "Transport Order", order.name, detail_idx)
 	frappe.db.commit()
@@ -628,6 +721,7 @@ def _create_declaration_order(ep_doc: Any, row: Any, detail_idx: int) -> dict[st
 	from logistics.utils.service_role_rules import apply_standalone_service_flags
 
 	apply_standalone_service_flags(order)
+	_prepare_operational_charges_before_insert(ep_doc, order, row)
 	order.insert(ignore_permissions=True)
 	_persist_row_link(ep_doc.name, "Declaration Order", order.name, detail_idx)
 	frappe.db.commit()
@@ -643,6 +737,7 @@ def _create_inbound_order(ep_doc: Any, row: Any, detail_idx: int) -> dict[str, A
 	if frappe.get_meta("Inbound Order").get_field("order_date"):
 		order.order_date = today()
 	apply_internal_job_detail_row_to_operational_doc(order, row, overwrite=True)
+	_prepare_operational_charges_before_insert(ep_doc, order, row)
 	order.insert(ignore_permissions=True)
 	_persist_row_link(ep_doc.name, "Inbound Order", order.name, detail_idx)
 	frappe.db.commit()
@@ -766,7 +861,7 @@ def create_booking_or_order_from_exhibit(
 ):
 	"""Create the chosen booking/order from the matching Internal Job row on the Exhibit."""
 	if not exhibit or not frappe.db.exists("MICE Project", exhibit):
-		frappe.throw(_("Invalid Exhibit."))
+		frappe.throw(_("Invalid MICE Project."))
 	jt = (job_type or "").strip()
 	if jt not in EXHIBIT_CREATABLE_JOB_TYPES:
 		frappe.throw(_("Invalid job type."))

--- a/logistics/pricing_center/doctype/sales_quote/sales_quote.py
+++ b/logistics/pricing_center/doctype/sales_quote/sales_quote.py
@@ -1911,51 +1911,18 @@ def _propagate_linked_services_to_created_booking(
 	* Regular / blanket call-off: **clone** Linked Services so the quote retains its originals
 	  for later bookings and Services rows are not tied to a single job.
 
-	Logs (without re-raising) on failure so conversion still completes.
+	Raises on failure so conversion does not complete with an empty Linked Services grid.
 	"""
-	try:
-		from logistics.utils.sales_quote_one_off_internal_jobs import (
-			linked_service_names_from_quote_charges,
-			propagate_linked_services_and_remap_charges,
-			stamp_scope_main_when_untagged,
-		)
+	from logistics.utils.sales_quote_one_off_internal_jobs import (
+		propagate_linked_services_from_sales_quote_to_booking,
+	)
 
-		qt = (getattr(sales_quote, "quotation_type", None) or "").strip()
-		use_clone = blanket_call_off or qt == "Regular"
-		if use_clone:
-			sq_name = getattr(sales_quote, "name", None) or ""
-			sq_owned = frappe.get_all(
-				"Linked Service",
-				filters={
-					"parent_booking_type": "Sales Quote",
-					"parent_booking_name": sq_name,
-				},
-				pluck="name",
-				order_by="creation asc",
-			)
-			charge_ls = linked_service_names_from_quote_charges(
-				sales_quote, selected_charge_row_names
-			)
-			if charge_ls:
-				ls_names = [n for n in charge_ls if n in set(sq_owned or [])]
-			else:
-				ls_names = list(sq_owned or [])
-			if ls_names:
-				propagate_linked_services_and_remap_charges(
-					sales_quote, booking_doc, clone=True, ls_names=ls_names
-				)
-		else:
-			propagate_linked_services_and_remap_charges(sales_quote, booking_doc, clone=False)
-		stamp_scope_main_when_untagged(booking_doc)
-	except Exception:
-		frappe.log_error(
-			title="Sales Quote Linked Service propagation failed",
-			message=(
-				f"Sales Quote: {getattr(sales_quote, 'name', None)}; "
-				f"Booking: {getattr(booking_doc, 'doctype', None)} "
-				f"{getattr(booking_doc, 'name', None)}\n{frappe.get_traceback()}"
-			),
-		)
+	return propagate_linked_services_from_sales_quote_to_booking(
+		sales_quote,
+		booking_doc,
+		blanket_call_off=blanket_call_off,
+		selected_charge_row_names=selected_charge_row_names,
+	)
 
 
 def _propagate_one_off_internal_jobs_to_created_booking(sales_quote, booking_doc):

--- a/logistics/pricing_center/sales_quote_booking_creation.py
+++ b/logistics/pricing_center/sales_quote_booking_creation.py
@@ -563,11 +563,11 @@ def _populate_charges_on_target(sq_doc: Any, target_doc: Any) -> None:
 
 
 def _propagate_subsidiary_linked_services(sq_doc: Any, booking_doc: Any) -> None:
-	from logistics.utils.sales_quote_one_off_internal_jobs import (
-		propagate_linked_services_for_special_project_booking,
+	from logistics.pricing_center.doctype.sales_quote.sales_quote import (
+		_propagate_linked_services_to_created_booking,
 	)
 
-	propagate_linked_services_for_special_project_booking(sq_doc, booking_doc)
+	_propagate_linked_services_to_created_booking(sq_doc, booking_doc)
 
 
 def _create_air_booking(

--- a/logistics/public/js/exhibit_booking_dialog.js
+++ b/logistics/public/js/exhibit_booking_dialog.js
@@ -13,6 +13,10 @@
 		return JSON.stringify((frm && frm.doc && frm.doc.internal_jobs) || []);
 	}
 
+	function _parentLabel(frm) {
+		return frm && frm.doctype === "MICE Project" ? __("MICE Project") : __("Exhibit");
+	}
+
 	function _encodeChoice(c) {
 		const cr = c.creatable === false ? "0" : "1";
 		const idx = c.detail_idx != null ? String(c.detail_idx) : "";
@@ -243,7 +247,12 @@
 			$("<p>")
 				.addClass("text-muted")
 				.css({ fontSize: "12px", marginBottom: "10px", lineHeight: 1.45 })
-				.text(__("Each card is one Internal Job line on this Exhibit. Expand for details; use Create in the card header when ready."))
+				.text(
+					__(
+						"Each card is one Internal Job line on this {0}. Expand for details; use Create in the card header when ready.",
+						[_parentLabel(frm)]
+					)
+				)
 		);
 		const $scroll = $("<div class='ex-cards-scroll'>");
 		const $cards = $("<div class='ex-cards'>");
@@ -379,7 +388,7 @@
 
 	function _introHtml(frm) {
 		const esc = frappe.utils.escape_html;
-		const ref = esc(__("MICE Project") + " · " + (frm.doc.name || ""));
+		const ref = esc(_parentLabel(frm) + " · " + (frm.doc.name || ""));
 		return (
 			"<div class='" + PREVIEW_CLASS + "' style='margin-bottom:4px'>" +
 			"<div style='font-size:12px;color:var(--text-muted,#64748b);line-height:1.5'>" +
@@ -393,7 +402,7 @@
 		if (!frm || !frm.doc || !frm.doc.name || frm.doc.__islocal) {
 			frappe.msgprint({
 				title: __("Save Required"),
-				message: __("Save the Exhibit before creating bookings or orders."),
+				message: __("Save the {0} before creating bookings or orders.", [_parentLabel(frm)]),
 				indicator: "orange",
 			});
 			return;
@@ -412,7 +421,10 @@
 				if (!choices.length) {
 					frappe.msgprint({
 						title: __("Create Booking / Order"),
-						message: __("No Internal Job lines on this Exhibit. Add a row under the Jobs tab first."),
+						message: __(
+							"No Internal Job lines on this {0}. Add a row under the Jobs tab first.",
+							[_parentLabel(frm)]
+						),
 						indicator: "orange",
 					});
 					return;

--- a/logistics/public/js/get_charges_from_quotation.js
+++ b/logistics/public/js/get_charges_from_quotation.js
@@ -656,12 +656,14 @@ logistics.open_get_charges_from_quotation_dialog = function (frm) {
 	}
 
 	var cust =
-		frm.doctype === "Transport Order" || frm.doctype === "Declaration Order"
-			? frm.doc.customer
-			: frm.doctype === "Special Project" || frm.doctype === "Exhibit"
+		frm.doctype === "MICE Project"
+			? null
+			: frm.doctype === "Transport Order" || frm.doctype === "Declaration Order"
 				? frm.doc.customer
-				: frm.doc.local_customer;
-	if (!cust) {
+				: frm.doctype === "Special Project" || frm.doctype === "Exhibit"
+					? frm.doc.customer
+					: frm.doc.local_customer;
+	if (!cust && frm.doctype !== "MICE Project") {
 		frappe.msgprint(
 			__(
 				frm.doctype === "Transport Order" ||

--- a/logistics/transport/doctype/transport_order/test_transport_order.py
+++ b/logistics/transport/doctype/transport_order/test_transport_order.py
@@ -4,10 +4,12 @@
 import frappe
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import today
+from unittest.mock import patch
 
 from logistics.transport.doctype.transport_order.transport_order import (
 	_apply_duplicate_pricing_clear,
 	_clear_pricing_after_desk_duplicate,
+	_get_linked_sales_quote,
 	get_vehicle_types_for_transport_order,
 )
 
@@ -189,6 +191,51 @@ class TestTransportOrderDuplicatePricingClear(FrappeTestCase):
 		self.assertTrue(order.flags.logistics_duplicate_pricing_cleared)
 		self.assertEqual(order.sales_quote, None)
 		self.assertEqual(order.logistics_duplicate_from, None)
+
+
+class TestTransportOrderLegacyQuoteLifecycle(FrappeTestCase):
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_on_submit_does_not_query_removed_quote_columns(self):
+		"""Submit hook must not SELECT legacy quote/quote_type when schema has sales_quote only."""
+		from logistics.transport.doctype.transport_order.transport_order import TransportOrder
+
+		order = frappe.get_doc(
+			{
+				"doctype": "Transport Order",
+				"name": "TRO000000057",
+				"sales_quote": "SQU-TEST-LEGACY",
+			}
+		)
+
+		with patch.object(frappe.db, "get_value") as mock_get_value:
+			mock_get_value.return_value = "SQU-TEST-LEGACY"
+			with patch(
+				"logistics.pricing_center.doctype.sales_quote.sales_quote.update_one_off_quote_on_submit"
+			):
+				with patch(
+					"logistics.special_projects.special_project_packages.post_site_receipts_from_transport_order"
+				):
+					TransportOrder.on_submit(order)
+
+			queried_fields = [
+				call.args[2]
+				for call in mock_get_value.call_args_list
+				if len(call.args) >= 3
+			]
+			self.assertNotIn("quote", queried_fields)
+			self.assertNotIn("quote_type", queried_fields)
+
+	def test_get_linked_sales_quote_prefers_sales_quote_on_doc(self):
+		order = frappe.get_doc(
+			{
+				"doctype": "Transport Order",
+				"sales_quote": "SQU-ON-DOC",
+			}
+		)
+		with patch.object(frappe.db, "exists", return_value=True):
+			self.assertEqual(_get_linked_sales_quote(order, from_db=False), "SQU-ON-DOC")
 
 
 class TestTransportOrderChargeSubmitGate(FrappeTestCase):

--- a/logistics/transport/doctype/transport_order/transport_order.py
+++ b/logistics/transport/doctype/transport_order/transport_order.py
@@ -107,6 +107,35 @@ def _sync_quote_and_sales_quote(doc):
         doc.quote = doc.sales_quote
 
 
+def _get_linked_sales_quote(doc, *, from_db=False):
+    """Resolve linked Sales Quote for lifecycle hooks.
+
+    Prefer ``sales_quote``. Legacy ``quote`` is read only when that field still
+    exists on the DocType (older sites); current schema has no ``quote`` column.
+    """
+    sales_quote = None
+    if from_db and getattr(doc, "name", None) and not doc.is_new():
+        sales_quote = frappe.db.get_value(doc.doctype, doc.name, "sales_quote")
+
+    if not sales_quote:
+        sales_quote = getattr(doc, "sales_quote", None)
+
+    if sales_quote and frappe.db.exists("Sales Quote", sales_quote):
+        return sales_quote
+
+    if not doc.meta.get_field("quote"):
+        return None
+
+    legacy_quote = getattr(doc, "quote", None)
+    if not legacy_quote and from_db and getattr(doc, "name", None) and not doc.is_new():
+        legacy_quote = frappe.db.get_value(doc.doctype, doc.name, "quote")
+
+    if legacy_quote and frappe.db.exists("Sales Quote", legacy_quote):
+        return legacy_quote
+
+    return None
+
+
 def _apply_duplicate_pricing_clear(doc):
     """Strip charge child rows and quote / scope links (used for desk Duplicate and after link propagation)."""
     for row in list(doc.get("charges") or []):
@@ -511,36 +540,25 @@ class TransportOrder(Document):
         assert_destination_service_charges_on_submit_unless_internal_job(self)
     
     def on_submit(self):
-        """Ensure quote field values remain after submission; update One-off Sales Quote when converted.
+        """Ensure sales_quote remains after submission; update One-off Sales Quote when converted.
 
         Frappe invokes ``on_submit`` on submit; ``after_submit`` is not a standard Document hook and never runs.
         """
-        # Preserve quote field value after submission - ensure it's not cleared
-        # Get the quote value from the database to ensure it's preserved
-        current_quote = frappe.db.get_value(self.doctype, self.name, 'quote')
-        current_quote_type = frappe.db.get_value(self.doctype, self.name, 'quote_type')
-        current_sales_quote = frappe.db.get_value(self.doctype, self.name, 'sales_quote')
-        if (
-            not current_sales_quote
-            and current_quote
-            and frappe.db.exists("Sales Quote", current_quote)
-        ):
-            current_sales_quote = current_quote
-        if not current_sales_quote:
-            for cand in (getattr(self, "sales_quote", None), getattr(self, "quote", None)):
-                if cand and frappe.db.exists("Sales Quote", cand):
-                    current_sales_quote = cand
-                    break
-        
-        # If quote was set before submission, ensure it remains set
-        # This prevents any code from clearing the quote field after submission
-        if current_quote and not getattr(self, 'quote', None):
-            self.db_set('quote', current_quote, update_modified=False)
-        if current_quote_type and not getattr(self, 'quote_type', None):
-            self.db_set('quote_type', current_quote_type, update_modified=False)
-        if current_sales_quote and not getattr(self, 'sales_quote', None):
-            self.db_set('sales_quote', current_sales_quote, update_modified=False)
-        
+        current_sales_quote = _get_linked_sales_quote(self, from_db=True)
+
+        if current_sales_quote and not getattr(self, "sales_quote", None):
+            self.db_set("sales_quote", current_sales_quote, update_modified=False)
+
+        # Legacy schema: preserve quote / quote_type when those columns still exist
+        if self.meta.get_field("quote"):
+            current_quote = frappe.db.get_value(self.doctype, self.name, "quote")
+            if current_quote and not getattr(self, "quote", None):
+                self.db_set("quote", current_quote, update_modified=False)
+        if self.meta.get_field("quote_type"):
+            current_quote_type = frappe.db.get_value(self.doctype, self.name, "quote_type")
+            if current_quote_type and not getattr(self, "quote_type", None):
+                self.db_set("quote_type", current_quote_type, update_modified=False)
+
         # Update One-off Sales Quote status to Converted
         if current_sales_quote:
             from logistics.pricing_center.doctype.sales_quote.sales_quote import update_one_off_quote_on_submit
@@ -560,12 +578,7 @@ class TransportOrder(Document):
     
     def on_cancel(self):
         """Reset One-off Sales Quote status when Transport Order is cancelled."""
-        current_sales_quote = frappe.db.get_value(self.doctype, self.name, 'sales_quote')
-        if not current_sales_quote:
-            qt = frappe.db.get_value(self.doctype, self.name, 'quote_type')
-            q = frappe.db.get_value(self.doctype, self.name, 'quote')
-            if qt == "One-Off Quote" and q and frappe.db.exists("Sales Quote", q):
-                current_sales_quote = q
+        current_sales_quote = _get_linked_sales_quote(self, from_db=True)
         if current_sales_quote:
             from logistics.pricing_center.doctype.sales_quote.sales_quote import (
                 reset_one_off_quote_on_cancel_for_document,

--- a/logistics/utils/get_charges_from_quotation.py
+++ b/logistics/utils/get_charges_from_quotation.py
@@ -81,10 +81,11 @@ JOB_DOCTYPES = frozenset(
 		"Declaration Order",
 		"Special Project",
 		"Exhibit",
+		"MICE Project",
 	}
 )
 
-_PROGRAMME_GCFQ_DOCTYPES = frozenset({"Special Project", "Exhibit"})
+_PROGRAMME_GCFQ_DOCTYPES = frozenset({"Special Project", "Exhibit", "MICE Project"})
 
 # Whitelisted keys for Action → Get Charges from Quotation dialog filters (client-sent).
 GCFQ_FILTER_KEYS: dict[str, frozenset[str]] = {
@@ -112,6 +113,7 @@ GCFQ_FILTER_KEYS: dict[str, frozenset[str]] = {
 	),
 	"Special Project": frozenset({"branch", "cost_center", "profit_center"}),
 	"Exhibit": frozenset({"branch", "cost_center", "profit_center"}),
+	"MICE Project": frozenset({"branch", "cost_center", "profit_center"}),
 }
 
 
@@ -283,6 +285,11 @@ def assert_one_off_sales_quote_job_rules(doc):
 def _job_customer(doc) -> str | None:
 	if doc.doctype in ("Sea Booking", "Air Booking"):
 		return (getattr(doc, "local_customer", None) or "").strip() or None
+	if doc.doctype == "MICE Project":
+		getter = getattr(doc, "get_organizer_customer", None)
+		if callable(getter):
+			return (getter() or "").strip() or None
+		return None
 	if doc.doctype in ("Transport Order", "Declaration Order", "Special Project", "Exhibit"):
 		return (getattr(doc, "customer", None) or "").strip() or None
 	return None
@@ -864,7 +871,7 @@ def preview_quotation_charges_for_job(
 		from logistics.utils.sales_quote_programme_charges import preview_programme_charges_from_sales_quote
 
 		return preview_programme_charges_from_sales_quote(docname, doctype, sales_quote)
-	if doctype == "Exhibit":
+	if doctype in ("Exhibit", "MICE Project"):
 		from logistics.utils.sales_quote_programme_charges import preview_programme_charges_from_sales_quote
 
 		return preview_programme_charges_from_sales_quote(docname, doctype, sales_quote)
@@ -1306,7 +1313,7 @@ def apply_quotation_charges_to_job(
 			doc._populate_charges_from_sales_quote()
 		elif doctype == "Special Project":
 			doc.populate_charges_from_sales_quote(sales_quote)
-		elif doctype == "Exhibit":
+		elif doctype in ("Exhibit", "MICE Project"):
 			doc.populate_charges_from_sales_quote(sales_quote)
 
 	# Append Internal-Job-scoped Sales Quote Charge rows into the Main's charges table (no separate

--- a/logistics/utils/internal_job_creation_eligibility.py
+++ b/logistics/utils/internal_job_creation_eligibility.py
@@ -39,7 +39,6 @@ _PROGRAMME_CHARGE_PARENTS = frozenset(
 _PROGRAMME_LIFECYCLE_JOB_PARENTS: dict[str, str] = {
 	"Special Project": "special_project_services",
 	"Exhibit": "lifecycle_jobs",
-	"MICE Project": "lifecycle_jobs",
 }
 
 _EXHIBIT_LINKED_SALES_QUOTE_PARENTS = frozenset({"MICE Project", "Exhibit"})

--- a/logistics/utils/sales_quote_one_off_internal_jobs.py
+++ b/logistics/utils/sales_quote_one_off_internal_jobs.py
@@ -416,6 +416,101 @@ def propagate_one_off_internal_jobs_and_remap_charges(
 	return propagate_linked_services_and_remap_charges(sales_quote, booking_doc, clone=False)
 
 
+def _linked_service_names_for_quote_to_booking_propagation(
+	sales_quote: Any,
+	booking_doc: Any,
+	*,
+	blanket_call_off: bool = False,
+	selected_charge_row_names: list[str] | None = None,
+	exclude_main_booking_service_type: bool = True,
+) -> list[str]:
+	"""Resolve which quote-owned Linked Services should transfer onto *booking_doc*."""
+	sq_name = getattr(sales_quote, "name", None) or ""
+	sq_owned = _sq_owned_linked_services(sq_name)
+	if not sq_owned:
+		return []
+
+	sq_owned_set = set(sq_owned)
+	if blanket_call_off and selected_charge_row_names:
+		charge_ls = linked_service_names_from_quote_charges(
+			sales_quote, selected_charge_row_names
+		)
+		return [n for n in charge_ls if n in sq_owned_set]
+
+	ls_names = list(sq_owned)
+	qt = (getattr(sales_quote, "quotation_type", None) or "").strip()
+	use_clone = blanket_call_off or qt == "Regular"
+	if exclude_main_booking_service_type and use_clone:
+		from logistics.utils.charge_service_type import implied_service_type_for_doctype
+
+		main_st = implied_service_type_for_doctype(getattr(booking_doc, "doctype", None) or "")
+		if main_st:
+			ls_names = _filter_linked_service_names(ls_names, exclude_service_types=[main_st])
+	return ls_names
+
+
+def propagate_linked_services_from_sales_quote_to_booking(
+	sales_quote: Any,
+	booking_doc: Any,
+	*,
+	blanket_call_off: bool = False,
+	selected_charge_row_names: list[str] | None = None,
+	exclude_main_booking_service_type: bool = True,
+) -> dict[str, str]:
+	"""Transfer or clone quote-owned Linked Services onto *booking_doc* and remap charge links.
+
+	* One-off / Project full conversion: re-parent the same ``LS-…`` documents.
+	* Regular / blanket call-off: clone so the quote retains its originals.
+
+	Raises on failure so conversion does not complete with an empty Linked Services grid.
+	"""
+	if not sales_quote or not booking_doc:
+		return {}
+
+	qt = (getattr(sales_quote, "quotation_type", None) or "").strip()
+	use_clone = blanket_call_off or qt == "Regular"
+	ls_names = _linked_service_names_for_quote_to_booking_propagation(
+		sales_quote,
+		booking_doc,
+		blanket_call_off=blanket_call_off,
+		selected_charge_row_names=selected_charge_row_names,
+		exclude_main_booking_service_type=exclude_main_booking_service_type,
+	)
+	if not ls_names:
+		stamp_scope_main_when_untagged(booking_doc)
+		return {}
+
+	try:
+		mapping = propagate_linked_services_and_remap_charges(
+			sales_quote,
+			booking_doc,
+			clone=use_clone,
+			ls_names=ls_names,
+		)
+		stamp_scope_main_when_untagged(booking_doc)
+		return mapping
+	except Exception as exc:
+		frappe.log_error(
+			title="Sales Quote Linked Service propagation failed",
+			message=(
+				f"Sales Quote: {getattr(sales_quote, 'name', None)}; "
+				f"Booking: {getattr(booking_doc, 'doctype', None)} "
+				f"{getattr(booking_doc, 'name', None)}\n{frappe.get_traceback()}"
+			),
+		)
+		frappe.throw(
+			_(
+				"Could not copy Linked Services from Sales Quote {0} to {1} {2}: {3}"
+			).format(
+				getattr(sales_quote, "name", ""),
+				getattr(booking_doc, "doctype", ""),
+				getattr(booking_doc, "name", ""),
+				str(exc),
+			),
+			title=_("Linked Service propagation failed"),
+		)
+
+
 def apply_linked_services_from_sales_quote_on_fetch(
 	sales_quote: Any,
 	operational_doc: Any,
@@ -428,32 +523,12 @@ def apply_linked_services_from_sales_quote_on_fetch(
 	the job so the quote remains the source of truth for later call-offs. One-off / Project quotes
 	that still own Linked Services use **re-parent** (same ids).
 	"""
-	if not sales_quote or not operational_doc:
-		return {}
-	qt = (getattr(sales_quote, "quotation_type", None) or "").strip()
-	use_clone = qt == "Regular"
-	ls_names = linked_service_names_from_quote_charges(
-		sales_quote, selected_charge_row_names
-	) or None
-	try:
-		mapping = propagate_linked_services_and_remap_charges(
-			sales_quote,
-			operational_doc,
-			clone=use_clone,
-			ls_names=ls_names,
-		)
-		stamp_scope_main_when_untagged(operational_doc)
-		return mapping
-	except Exception:
-		frappe.log_error(
-			title="Sales Quote fetch — Linked Service propagation failed",
-			message=(
-				f"Sales Quote: {getattr(sales_quote, 'name', None)}; "
-				f"Job: {getattr(operational_doc, 'doctype', None)} "
-				f"{getattr(operational_doc, 'name', None)}\n{frappe.get_traceback()}"
-			),
-		)
-		return {}
+	return propagate_linked_services_from_sales_quote_to_booking(
+		sales_quote,
+		operational_doc,
+		blanket_call_off=bool(selected_charge_row_names),
+		selected_charge_row_names=selected_charge_row_names,
+	)
 
 
 @frappe.whitelist()
@@ -483,7 +558,7 @@ def apply_sales_quote_linked_services_to_job(
 def propagate_linked_services_for_special_project_booking(
 	sp_doc: Any, booking_doc: Any
 ) -> dict[str, str]:
-	"""Clone subsidiary quote-owned Linked Services onto a Special Project booking/order."""
+	"""Clone or re-parent quote-owned Linked Services onto a Special Project booking/order."""
 	sq_name = (
 		(getattr(sp_doc, "sales_quote", None) or getattr(booking_doc, "sales_quote", None) or "")
 		.strip()
@@ -491,38 +566,7 @@ def propagate_linked_services_for_special_project_booking(
 	if not sq_name or not frappe.db.exists("Sales Quote", sq_name):
 		return {}
 	sq = frappe.get_doc("Sales Quote", sq_name)
-
-	from logistics.utils.charge_service_type import implied_service_type_for_doctype
-
-	main_st = implied_service_type_for_doctype(getattr(booking_doc, "doctype", None) or "")
-	exclude = [main_st] if main_st else None
-
-	sq_owned = _sq_owned_linked_services(sq_name)
-	ls_names = _filter_linked_service_names(sq_owned, exclude_service_types=exclude)
-
-	for ls in linked_service_names_from_charge_rows(getattr(booking_doc, "charges", None) or []):
-		if ls in sq_owned and ls not in ls_names:
-			ls_names.append(ls)
-
-	if not ls_names:
-		return {}
-
-	try:
-		mapping = propagate_linked_services_and_remap_charges(
-			sq, booking_doc, clone=True, ls_names=ls_names
-		)
-		stamp_scope_main_when_untagged(booking_doc)
-		return mapping
-	except Exception:
-		frappe.log_error(
-			title="Special Project Linked Service propagation failed",
-			message=(
-				f"Special Project: {getattr(sp_doc, 'name', None)}; "
-				f"Booking: {getattr(booking_doc, 'doctype', None)} "
-				f"{getattr(booking_doc, 'name', None)}\n{frappe.get_traceback()}"
-			),
-		)
-		return {}
+	return propagate_linked_services_from_sales_quote_to_booking(sq, booking_doc)
 
 
 def stamp_scope_main_when_untagged(booking_doc: Any) -> None:

--- a/logistics/utils/test_internal_job_creation_eligibility.py
+++ b/logistics/utils/test_internal_job_creation_eligibility.py
@@ -203,6 +203,68 @@ class TestInternalJobCreationEligibility(FrappeTestCase):
 
 		self.assertEqual(_parent_ij_fieldname("Special Project"), "special_project_services")
 		self.assertEqual(_parent_ij_fieldname("Exhibit"), "lifecycle_jobs")
+		self.assertEqual(_parent_ij_fieldname("MICE Project"), "internal_jobs")
+		self.assertEqual(_parent_ij_fieldname("Docket"), "internal_jobs")
+
+	@patch("logistics.utils.internal_job_creation_eligibility.frappe.db.exists", return_value=True)
+	@patch("logistics.utils.internal_job_creation_eligibility.frappe.get_meta")
+	@patch("logistics.utils.internal_job_creation_eligibility.frappe.get_cached_doc")
+	def test_has_matching_setup_accepts_internal_job_row_on_mice_project(
+		self, mock_cached_doc, mock_meta, _exists
+	):
+		mock_meta.return_value.get_field.return_value = None
+		ij_row = MagicMock(service_type="MICE", name="ij-mice-1")
+		parent = MagicMock(doctype="MICE Project", sales_quote="SQ-1")
+		parent.internal_jobs = [ij_row]
+		with patch(
+			"logistics.utils.internal_job_creation_eligibility.internal_job_matches_charges",
+			return_value=True,
+		):
+			self.assertTrue(has_matching_internal_job_setup("SQ-1", parent, ij_row, "MICE"))
+
+	@patch("logistics.utils.internal_job_creation_eligibility.frappe.db.exists", return_value=False)
+	def test_evaluate_eligible_for_mice_project_internal_job_row(self, _exists):
+		ij_row = frappe._dict(service_type="MICE", name="ij-mice-1")
+		parent = frappe._dict(
+			doctype="MICE Project",
+			sales_quote=None,
+			internal_jobs=[ij_row],
+		)
+		with patch(
+			"logistics.utils.internal_job_creation_eligibility.charges_exist_for_service",
+			return_value=True,
+		):
+			with patch(
+				"logistics.utils.internal_job_creation_eligibility.has_matching_internal_job_setup",
+				return_value=True,
+			):
+				result = evaluate_internal_job_creation_eligibility(
+					parent_doc=parent,
+					ij_row=ij_row,
+					service_type_label="MICE",
+				)
+		self.assertTrue(result["eligible"])
+		self.assertIsNone(result["message"])
+
+	def test_eligibility_message_uses_internal_jobs_tab_for_mice_project(self):
+		parent = MagicMock(doctype="MICE Project")
+		ij_row = MagicMock(service_type="Air", name="ij-air-1")
+		with patch(
+			"logistics.utils.internal_job_creation_eligibility.charges_exist_for_service",
+			return_value=True,
+		):
+			with patch(
+				"logistics.utils.internal_job_creation_eligibility.has_matching_internal_job_setup",
+				return_value=False,
+			):
+				result = evaluate_internal_job_creation_eligibility(
+					parent_doc=parent,
+					ij_row=ij_row,
+					service_type_label="Air",
+				)
+		msg = (result.get("message") or "").lower()
+		self.assertIn("internal jobs", msg)
+		self.assertNotIn("lifecycle", msg)
 
 	def test_quote_has_matching_linked_service_row_uses_virtual_grid(self):
 		"""Regression: eligibility must not read ``sq_doc.get('linked_services')`` (always empty after save)."""

--- a/logistics/utils/test_sales_quote_linked_service_propagation.py
+++ b/logistics/utils/test_sales_quote_linked_service_propagation.py
@@ -16,6 +16,7 @@ from logistics.utils.linked_service_compat import linked_service_doctype
 from logistics.utils.sales_quote_one_off_internal_jobs import (
 	linked_service_names_from_quote_charges,
 	propagate_linked_services_and_remap_charges,
+	propagate_linked_services_from_sales_quote_to_booking,
 )
 
 
@@ -38,6 +39,10 @@ class TestSalesQuoteLinkedServicePropagation(FrappeTestCase):
 		doc.customer = frappe.db.get_value("Customer", {}, "name")
 		if not doc.customer:
 			self.skipTest("No Customer in system")
+		doc.shipper = frappe.db.get_value("Shipper", {}, "name")
+		doc.consignee = frappe.db.get_value("Consignee", {}, "name")
+		if not doc.shipper or not doc.consignee:
+			self.skipTest("No Shipper/Consignee in system")
 		doc.date = frappe.utils.today()
 		doc.valid_until = frappe.utils.add_days(frappe.utils.today(), 30)
 		doc.flags.ignore_mandatory = True
@@ -99,6 +104,14 @@ class TestSalesQuoteLinkedServicePropagation(FrappeTestCase):
 				frappe.db.get_value(linked_service_doctype(), ls_name, "parent_booking_name"),
 				sq.name,
 			)
+			booking_ls = _linked_service_names_from_db("Sea Booking", booking.name)
+			self.assertEqual(len(booking_ls), 1)
+			clone_name = list(booking_ls)[0]
+			self.assertNotEqual(clone_name, ls_name)
+			self.assertEqual(
+				frappe.db.get_value(linked_service_doctype(), clone_name, "parent_booking_name"),
+				booking.name,
+			)
 		finally:
 			if booking and frappe.db.exists("Sea Booking", booking.name):
 				frappe.delete_doc("Sea Booking", booking.name, force=True, ignore_permissions=True)
@@ -125,4 +138,83 @@ class TestSalesQuoteLinkedServicePropagation(FrappeTestCase):
 			found = linked_service_names_from_quote_charges(sq, [ch_row.name])
 			self.assertEqual(found, [ls_names[0]])
 		finally:
+			frappe.delete_doc("Sales Quote", sq.name, force=True, ignore_permissions=True)
+
+	def test_regular_propagates_all_services_when_only_one_charge_tagged(self):
+		"""All Services grid rows copy to the booking even if only one charge is Linked-tagged."""
+		sq = self._minimal_sales_quote("SQ Regular All LS", quotation_type="Regular")
+		booking = None
+		try:
+			sq.append("linked_services", {"service_type": "Transport"})
+			sq.append("linked_services", {"service_type": "Customs"})
+			sq.flags._linked_services_from_form = True
+			sync_internal_job_details_to_internal_jobs(sq)
+			ls_names = list(_linked_service_names_from_db("Sales Quote", sq.name))
+			self.assertEqual(len(ls_names), 2)
+			sq.append(
+				"charges",
+				{
+					"service_type": "Sea",
+					"charge_scope": "Linked",
+					"linked_service": ls_names[0],
+				},
+			)
+			sq.save(ignore_permissions=True)
+
+			booking = frappe.new_doc("Sea Booking")
+			booking.sales_quote = sq.name
+			booking.flags.ignore_mandatory = True
+			booking.insert(ignore_permissions=True)
+			propagate_linked_services_from_sales_quote_to_booking(sq, booking)
+
+			booking_ls = _linked_service_names_from_db("Sea Booking", booking.name)
+			self.assertEqual(len(booking_ls), 2)
+			self.assertEqual(len(_linked_service_names_from_db("Sales Quote", sq.name)), 2)
+		finally:
+			if booking and frappe.db.exists("Sea Booking", booking.name):
+				frappe.delete_doc("Sea Booking", booking.name, force=True, ignore_permissions=True)
+			frappe.delete_doc("Sales Quote", sq.name, force=True, ignore_permissions=True)
+
+	def test_one_off_sea_booking_conversion_populates_linked_services(self):
+		"""End-to-end: Create > Sea Booking copies subsidiary services onto the booking."""
+		from logistics.pricing_center.doctype.sales_quote.sales_quote import (
+			create_sea_booking_from_sales_quote,
+		)
+		from logistics.logistics.doctype.linked_service.linked_service import (
+			get_linked_services_for_booking,
+		)
+
+		sq = self._minimal_sales_quote("SQ One-off Sea LS", quotation_type="One-off")
+		sbk_name = None
+		try:
+			sq.origin_port = "USLAX"
+			sq.destination_port = "USJFK"
+			sq.append(
+				"charges",
+				{
+					"service_type": "sea",
+					"origin_port": "USLAX",
+					"destination_port": "USJFK",
+					"direction": "Export",
+				},
+			)
+			sq.append("linked_services", {"service_type": "Transport"})
+			sq.append("linked_services", {"service_type": "Customs"})
+			sq.flags._linked_services_from_form = True
+			sq.save(ignore_permissions=True)
+			self.assertEqual(len(_linked_service_names_from_db("Sales Quote", sq.name)), 2)
+
+			result = create_sea_booking_from_sales_quote(sq.name)
+			self.assertTrue(result.get("success"))
+			sbk_name = result.get("sea_booking")
+			self.assertTrue(sbk_name)
+
+			rows = get_linked_services_for_booking("Sea Booking", sbk_name)
+			self.assertEqual(len(rows), 2)
+			service_types = {getattr(r, "service_type", None) for r in rows}
+			self.assertEqual(service_types, {"Transport", "Customs"})
+			self.assertEqual(len(_linked_service_names_from_db("Sales Quote", sq.name)), 0)
+		finally:
+			if sbk_name and frappe.db.exists("Sea Booking", sbk_name):
+				frappe.delete_doc("Sea Booking", sbk_name, force=True, ignore_permissions=True)
 			frappe.delete_doc("Sales Quote", sq.name, force=True, ignore_permissions=True)


### PR DESCRIPTION
## Summary

Aligns **MICE Project** with the current internal-jobs platform so Create → Booking/Order, charge population, and Get Charges from Quotation (GCFQ) behave consistently with other programme parents (e.g. Special Project).

### Problem

After the Exhibit → MICE Project rename, several flows still targeted the hidden `lifecycle_jobs` table or legacy “Exhibit” labels. That caused:

- Create → Booking/Order eligibility to look at the wrong child table
- Operational documents created without Sales Quote charges, parties, or `sales_quote` linkage
- GCFQ unavailable on MICE Project
- User-facing copy still referring to “Exhibit”

### Changes

- **Internal job eligibility** — Route MICE Project through `internal_jobs` (not `lifecycle_jobs`) for creation gating and eligibility messages.
- **Booking/Order creation** — On create from a MICE Project internal job row:
  - Link the Sales Quote on the new operational document
  - Copy shipper/consignee from the linked Sales Quote
  - Populate operational charges from the quote and scope them to the internal job row
- **GCFQ** — Add MICE Project to programme GCFQ doctypes, filters, and `populate_charges_from_sales_quote`.
- **Client mappings & labels** — Add `MICE` → `MICE Order` in internal/linked service detail mappings; update booking dialog and form messages to say “MICE Project”.
- **Site query** — Bind `sp_site` on `internal_jobs` (with legacy `lifecycle_jobs` fallback).
- **Tests** — Cover MICE Project `internal_jobs` field resolution and eligibility behavior.

### Also in this merge (`develop` → `v1.0-stable`)

- `fix(transport-order)`: stop querying removed quote columns on submit (#1211)
- `fix(sales-quote)`: ensure linked services populate on sea booking conversion (#1214)
- Branch sync merges (#1210, #1212, #1213)

## Test plan

- [ ] Open a saved **MICE Project** with Internal Job rows and a linked Sales Quote
- [ ] Confirm **Action → Get Charges from Quotation** is available and links the quote
- [ ] Use **Create → Booking/Order** on an eligible internal job row
- [ ] Verify the new booking/order has:
  - [ ] `sales_quote` set
  - [ ] Shipper/consignee from the quote (where applicable)
  - [ ] Charges populated and scoped to the internal job row
- [ ] Confirm ineligible rows show messages referencing **Internal Jobs** (not lifecycle jobs)
- [ ] Confirm UI copy says **MICE Project** (not Exhibit) in booking dialog and save prompts
- [ ] Run `logistics.utils.test_internal_job_creation_eligibility` tests