### PR TITLE
v2.0-update: fix(billing): improve charges retrieval logic in cross_module_billing

### DIFF
--- a/logistics/billing/cross_module_billing.py
+++ b/logistics/billing/cross_module_billing.py
@@ -252,7 +252,10 @@ def iter_main_job_linked_scope_charge_splits(
     job_type = getattr(main_job_doc, "doctype", None)
     if not job_type:
         return
-    charges_table = main_job_doc.get("charges") or []
+    if hasattr(main_job_doc, "get") and callable(main_job_doc.get):
+        charges_table = main_job_doc.get("charges") or []
+    else:
+        charges_table = getattr(main_job_doc, "charges", None) or []
     if not charges_table:
         return
     parent_meta = frappe.get_meta(job_type)

--- a/logistics/billing/cross_module_billing.py
+++ b/logistics/billing/cross_module_billing.py
@@ -85,6 +85,202 @@ def get_main_job_company(main_job_type: str, main_job_name: str) -> Optional[str
     return frappe.db.get_value(main_job_type, main_job_name, "company")
 
 
+# Order/booking DocType -> (operational job DocType, link field on operational job).
+BOOKING_TO_OPERATIONAL_JOB = {
+    "Sea Booking": ("Sea Shipment", "sea_booking"),
+    "Air Booking": ("Air Shipment", "air_booking"),
+    "Transport Order": ("Transport Job", "transport_order"),
+    "Declaration Order": ("Declaration", "declaration_order"),
+    "Inbound Order": ("Warehouse Job", "reference_order"),
+    "Release Order": ("Warehouse Job", "reference_order"),
+    "Transfer Order": ("Warehouse Job", "reference_order"),
+}
+
+
+_LINKED_OPERATIONAL_JOB_TYPES = BILLING_JOB_TYPES + ("Transport Order",)
+
+
+def _operational_job_from_booking_row(
+    job_type: str,
+    job_no: str,
+    sales_quote_name: Optional[str] = None,
+) -> Tuple[Optional[str], Optional[str]]:
+    """Map a booking/order row to its operational shipment/job when applicable."""
+    if not job_type or not job_no:
+        return (None, None)
+    if job_type in _LINKED_OPERATIONAL_JOB_TYPES and frappe.db.exists(job_type, job_no):
+        return (job_type, job_no)
+    mapping = BOOKING_TO_OPERATIONAL_JOB.get(job_type)
+    if not mapping:
+        return (None, None)
+    op_dt, link_field = mapping
+    filters: Dict[str, Any] = {link_field: job_no}
+    if sales_quote_name and frappe.db.has_column(op_dt, "sales_quote"):
+        filters["sales_quote"] = sales_quote_name
+    if op_dt == "Warehouse Job":
+        filters["reference_order_type"] = job_type
+        filters.pop(link_field, None)
+        filters["reference_order"] = job_no
+    names = frappe.get_all(op_dt, filters=filters, pluck="name", limit=1)
+    if names:
+        return (op_dt, names[0])
+    return (None, None)
+
+
+def resolve_operational_job_for_linked_service(
+    linked_service_name: str,
+    main_job_type: str,
+    main_job_name: str,
+    sales_quote_name: Optional[str] = None,
+) -> Tuple[Optional[str], Optional[str]]:
+    """
+    Resolve the operational linked job for a Linked Service / Internal Job record.
+
+    Used when main-job charge rows (charge_scope=Linked) carry revenue attributed to a linked service.
+    """
+    from logistics.utils.internal_job_persistence import internal_job_detail_fieldname
+    from logistics.utils.linked_service_compat import (
+        linked_service_doctype,
+        linked_service_detail_doctype,
+        linked_service_record_exists,
+    )
+
+    if not linked_service_name or not linked_service_record_exists(linked_service_name):
+        return (None, None)
+
+    detail_dt = linked_service_detail_doctype()
+    fieldname = internal_job_detail_fieldname(main_job_type)
+    if fieldname and main_job_type and main_job_name:
+        for link_field in ("linked_service", "internal_job"):
+            if not frappe.db.has_column(detail_dt, link_field):
+                continue
+            rows = frappe.get_all(
+                detail_dt,
+                filters={
+                    "parent": main_job_name,
+                    "parenttype": main_job_type,
+                    "parentfield": fieldname,
+                    link_field: linked_service_name,
+                },
+                fields=["job_type", "job_no"],
+                limit=1,
+            )
+            if rows:
+                return _operational_job_from_booking_row(
+                    rows[0].get("job_type"),
+                    rows[0].get("job_no"),
+                    sales_quote_name=sales_quote_name,
+                )
+
+    try:
+        ls_doc = frappe.get_doc(linked_service_doctype(), linked_service_name)
+    except Exception:
+        return (None, None)
+    if ls_doc.get("job_type") and ls_doc.get("job_no"):
+        op = _operational_job_from_booking_row(
+            ls_doc.job_type,
+            ls_doc.job_no,
+            sales_quote_name=sales_quote_name,
+        )
+        if op[0] and op[1]:
+            return op
+
+    if sales_quote_name:
+        from logistics.utils.internal_job_persistence import resolve_internal_job_for_internal_job_booking
+
+        for jt in _LINKED_OPERATIONAL_JOB_TYPES:
+            if not frappe.db.has_column(jt, "sales_quote"):
+                continue
+            for jn in frappe.get_all(
+                jt,
+                filters={"sales_quote": sales_quote_name, "docstatus": ["!=", 2]},
+                pluck="name",
+            ):
+                try:
+                    job_doc = frappe.get_doc(jt, jn)
+                except Exception:
+                    continue
+                if resolve_internal_job_for_internal_job_booking(job_doc) == linked_service_name:
+                    return (jt, jn)
+
+    return (None, None)
+
+
+def _charge_row_item_code(ch, job_type: str) -> Optional[str]:
+    if job_type == "Sea Shipment":
+        return getattr(ch, "charge_item", None)
+    return getattr(ch, "item_code", None) or getattr(ch, "item", None)
+
+
+def _charge_row_revenue(ch, job_type: str, *, include_estimated: bool = False) -> float:
+    """Revenue amount for internal billing from one charge row."""
+    if job_type == "Sea Shipment":
+        rev = flt(getattr(ch, "actual_revenue", 0)) or flt(getattr(ch, "selling_amount", 0))
+        if include_estimated and not rev:
+            rev = flt(getattr(ch, "estimated_revenue", 0))
+        return rev
+    if job_type == "Air Shipment":
+        rev = flt(getattr(ch, "actual_revenue", 0)) or flt(getattr(ch, "total_amount", 0))
+        if include_estimated and not rev:
+            rev = flt(getattr(ch, "estimated_revenue", 0))
+        return rev
+    if job_type in ("Declaration", "Declaration Order"):
+        rev = (
+            flt(getattr(ch, "actual_revenue", 0))
+            or flt(getattr(ch, "total_amount", 0))
+            or flt(getattr(ch, "estimated_revenue", 0))
+        )
+        return rev
+    rev = flt(getattr(ch, "actual_revenue", 0)) or flt(getattr(ch, "estimated_revenue", 0))
+    return rev
+
+
+def iter_main_job_linked_scope_charge_splits(
+    main_job_doc,
+) -> Iterator[Dict[str, Any]]:
+    """
+    Yield linked-service charge splits from the main job's charges table.
+
+    Rows must have charge_scope=Linked (or legacy Internal Job) and a linked_service link.
+    Revenue uses estimated amounts when actuals are not yet posted.
+    """
+    from logistics.utils.linked_service_compat import (
+        charge_row_linked_service_link,
+        is_linked_charge_scope,
+    )
+
+    job_type = getattr(main_job_doc, "doctype", None)
+    if not job_type:
+        return
+    charges_table = main_job_doc.get("charges") or []
+    if not charges_table:
+        return
+    parent_meta = frappe.get_meta(job_type)
+    charges_df = parent_meta.get_field("charges")
+    if not charges_df or not charges_df.options:
+        return
+    child_meta = frappe.get_meta(charges_df.options)
+    if not child_meta.has_field("charge_scope"):
+        return
+
+    for ch in charges_table:
+        if not is_linked_charge_scope(getattr(ch, "charge_scope", None)):
+            continue
+        linked_service = charge_row_linked_service_link(ch)
+        if not linked_service:
+            continue
+        rev = _charge_row_revenue(ch, job_type, include_estimated=True)
+        if rev <= 0:
+            continue
+        item_code = _charge_row_item_code(ch, job_type)
+        yield {
+            "revenue": rev,
+            "cost": 0,
+            "item_code": item_code,
+            "linked_service": linked_service,
+        }
+
+
 def iter_internal_job_charge_splits(
     job_type: str,
     job_name: str,

--- a/logistics/billing/internal_billing.py
+++ b/logistics/billing/internal_billing.py
@@ -3,12 +3,13 @@
 # For license information, see license.txt
 
 """
-Internal billing: Journal Entry for Internal Jobs where the operating company matches
-the Main Job company. Internal Job is identified by service_role=Linked + Main Service link
+Internal billing: Journal Entry for linked jobs where the operating company matches
+the Main Job company. Linked job is identified by service_role=Linked + Main Service link
 (on the job or parent booking/order). Intercompany SI/PI is handled separately when
 companies differ (see intercompany_invoice).
 
-Revenue (Internal Job) = cost allocated from Main Job; cost = tariff/actual per charge.
+Transfers linked-job charge revenue to main-job cost via Dr expense / Cr income per Item.
+One Journal Entry per billing event (Sales Quote + optional trigger SI).
 JE rows carry Job Number and Item accounting dimensions when configured.
 """
 
@@ -17,9 +18,10 @@ from __future__ import unicode_literals
 import frappe
 from frappe import _
 from frappe.utils import flt, today
-from typing import Dict, Any, Optional, List, Tuple
+from typing import Dict, Any, Optional, List
 
 from logistics.job_management.gl_item_dimension import item_row_dict
+from logistics.utils.item_accounts import get_item_accounts_for_internal_billing
 
 # Job types that can be internal jobs (same as intercompany for consistency)
 INTERNAL_BILLING_JOB_TYPES = (
@@ -33,42 +35,16 @@ INTERNAL_BILLING_JOB_TYPES = (
 )
 
 
-def _get_company_internal_transfer_accounts(company: str) -> Tuple[Optional[str], Optional[str]]:
-    """
-    Get expense and income accounts for internal transfer (cost allocation / revenue).
-    Tries Company default_expense_account, default_income_account; else first leaf account by root_type.
-    """
-    expense_account = frappe.db.get_value("Company", company, "default_expense_account")
-    income_account = frappe.db.get_value("Company", company, "default_income_account")
-    if not expense_account:
-        acc = frappe.db.get_value(
-            "Account",
-            {"company": company, "root_type": "Expense", "is_group": 0},
-            "name",
-            order_by="name",
-        )
-        expense_account = acc
-    if not income_account:
-        acc = frappe.db.get_value(
-            "Account",
-            {"company": company, "root_type": "Income", "is_group": 0},
-            "name",
-            order_by="name",
-        )
-        income_account = acc
-    return (expense_account, income_account)
-
-
-def _internal_billing_jv_user_remark(sales_quote_name: str, trigger_si: Optional[str], company: str) -> str:
-    remark = _("Internal Billing - Sales Quote {0} - Company {1}").format(sales_quote_name, company)
+def _internal_billing_jv_user_remark(sales_quote_name: str, trigger_si: Optional[str]) -> str:
+    remark = _("Internal Billing - Sales Quote {0}").format(sales_quote_name)
     if trigger_si:
         remark += _(" - Trigger SI: {0}").format(trigger_si)
     return remark
 
 
-def _internal_billing_jv_already_created(sales_quote_name: str, trigger_si: Optional[str], company: str) -> bool:
-    """Return True if we already created an internal billing JV for this quote, trigger SI, and company."""
-    remark = _internal_billing_jv_user_remark(sales_quote_name, trigger_si, company)
+def _internal_billing_jv_already_created(sales_quote_name: str, trigger_si: Optional[str]) -> bool:
+    """Return True if we already created an internal billing JV for this quote and trigger SI."""
+    remark = _internal_billing_jv_user_remark(sales_quote_name, trigger_si)
     return bool(
         frappe.db.exists(
             "Journal Entry",
@@ -77,75 +53,145 @@ def _internal_billing_jv_already_created(sales_quote_name: str, trigger_si: Opti
     )
 
 
-def _append_je_split_rows(
+def _job_row_base(job_doc, item_code: Optional[str], je_row_has_jcn: bool) -> Dict[str, Any]:
+    row = {
+        "cost_center": getattr(job_doc, "cost_center", None),
+        "profit_center": getattr(job_doc, "profit_center", None),
+    }
+    row.update(item_row_dict("Journal Entry Account", item_code) if item_code else {})
+    jcn = getattr(job_doc, "job_number", None)
+    if je_row_has_jcn and jcn:
+        row["job_number"] = jcn
+    return row
+
+
+def _append_revenue_transfer_rows(
     entries: List[Dict[str, Any]],
-    expense_account: str,
-    income_account: str,
-    payable_account: Optional[str],
-    job_doc,
+    main_job_doc,
+    linked_job_doc,
     revenue: float,
-    cost: float,
-    item_code: Optional[str],
+    item_code: str,
+    company: str,
     je_row_has_jcn: bool,
 ) -> None:
-    """Append balanced Dr/Cr rows for one charge split; uses internal job cost_center / JCN / item dimension."""
-    cost_center = getattr(job_doc, "cost_center", None)
-    profit_center = getattr(job_doc, "profit_center", None)
-    ref_type = getattr(job_doc, "doctype", None)
-    ref_name = getattr(job_doc, "name", None)
-    jcn = getattr(job_doc, "job_number", None)
-    job_type = ref_type
-    job_no = ref_name
+    """Dr main job expense / Cr linked job income for one charge revenue amount."""
+    amount = flt(revenue, 2)
+    if amount <= 0:
+        return
 
-    item_dim = item_row_dict("Journal Entry Account", item_code) if item_code else {}
+    expense_account, income_account = get_item_accounts_for_internal_billing(item_code, company)
+    main_type = getattr(main_job_doc, "doctype", None)
+    main_no = getattr(main_job_doc, "name", None)
+    linked_type = getattr(linked_job_doc, "doctype", None)
+    linked_no = getattr(linked_job_doc, "name", None)
 
-    def base_row(user_remark: str) -> Dict[str, Any]:
-        row = {
-            "cost_center": cost_center,
-            "profit_center": profit_center,
-            "reference_type": ref_type,
-            "reference_name": ref_name,
-            "user_remark": user_remark,
+    entries.append(
+        {
+            **_job_row_base(main_job_doc, item_code, je_row_has_jcn),
+            "user_remark": _("{0} {1} - Internal cost from linked service").format(main_type, main_no),
+            "account": expense_account,
+            "debit_in_account_currency": amount,
+            "credit_in_account_currency": 0,
         }
-        row.update(item_dim)
-        if je_row_has_jcn and jcn:
-            row["job_number"] = jcn
-        return row
+    )
+    entries.append(
+        {
+            **_job_row_base(linked_job_doc, item_code, je_row_has_jcn),
+            "user_remark": _("{0} {1} - Internal revenue transfer").format(linked_type, linked_no),
+            "account": income_account,
+            "debit_in_account_currency": 0,
+            "credit_in_account_currency": amount,
+        }
+    )
 
-    if flt(revenue) > 0:
-        entries.append(
-            {
-                **base_row(_("{0} {1} - Internal cost allocation").format(job_type, job_no)),
-                "account": expense_account,
-                "debit_in_account_currency": flt(revenue, 2),
-                "credit_in_account_currency": 0,
-            }
+
+def _submit_internal_billing_journal_entry(
+    entries: List[Dict[str, Any]],
+    company: str,
+    posting_date: str,
+    user_remark: str,
+    sales_quote,
+    end_customer: str,
+) -> str:
+    """Build, submit one Journal Entry from prepared account rows; run recognition reversal."""
+    total_debit = sum(flt(e.get("debit_in_account_currency"), 2) for e in entries)
+    total_credit = sum(flt(e.get("credit_in_account_currency"), 2) for e in entries)
+    if abs(total_debit - total_credit) > 0.01:
+        frappe.throw(
+            _("Internal billing entries do not balance (Debit {0} vs Credit {1}).").format(
+                total_debit, total_credit
+            )
         )
-        entries.append(
-            {
-                **base_row(_("{0} {1} - Internal revenue").format(job_type, job_no)),
-                "account": income_account,
-                "debit_in_account_currency": 0,
-                "credit_in_account_currency": flt(revenue, 2),
-            }
+
+    je = frappe.new_doc("Journal Entry")
+    je.posting_date = posting_date
+    je.company = company
+    je.voucher_type = "Journal Entry"
+    je.user_remark = user_remark
+    if getattr(sales_quote, "branch", None):
+        je.branch = sales_quote.branch
+    if getattr(sales_quote, "cost_center", None):
+        je.cost_center = sales_quote.cost_center
+
+    je_acc_meta = frappe.get_meta("Journal Entry Account")
+    je_row_has_jcn = bool(je_acc_meta.get_field("job_number"))
+    fixed_keys = frozenset(
+        {
+            "account",
+            "debit_in_account_currency",
+            "credit_in_account_currency",
+            "cost_center",
+            "profit_center",
+            "reference_type",
+            "reference_name",
+            "user_remark",
+            "job_number",
+        }
+    )
+    for e in entries:
+        row = je.append("accounts", {})
+        row.account = e["account"]
+        row.debit_in_account_currency = flt(e.get("debit_in_account_currency"), 2)
+        row.credit_in_account_currency = flt(e.get("credit_in_account_currency"), 2)
+        if e.get("cost_center"):
+            row.cost_center = e["cost_center"]
+        if e.get("profit_center"):
+            row.profit_center = e["profit_center"]
+        if e.get("reference_type") and e.get("reference_name"):
+            row.reference_type = e["reference_type"]
+            row.reference_name = e["reference_name"]
+        if e.get("user_remark"):
+            row.user_remark = e["user_remark"]
+        if je_row_has_jcn and e.get("job_number"):
+            row.job_number = e["job_number"]
+        for k, v in e.items():
+            if k in fixed_keys or not v:
+                continue
+            if je_acc_meta.get_field(k):
+                setattr(row, k, v)
+
+    je.flags.ignore_permissions = True
+    je.flags.ignore_links = True
+    je.insert()
+    je.submit()
+
+    try:
+        from logistics.invoice_integration.internal_billing_recognition_reversal import (
+            reverse_recognition_for_internal_billing_je,
         )
-    if flt(cost) > 0 and payable_account and payable_account != expense_account:
-        entries.append(
-            {
-                **base_row(_("{0} {1} - Internal cost (tariff/actual)").format(job_type, job_no)),
-                "account": expense_account,
-                "debit_in_account_currency": flt(cost, 2),
-                "credit_in_account_currency": 0,
-            }
+
+        reverse_recognition_for_internal_billing_je(je, end_customer)
+    except Exception as e:
+        frappe.log_error(
+            title="Recognition reversal on Internal Billing JE submit",
+            message=frappe.get_traceback(),
         )
-        entries.append(
-            {
-                **base_row(_("{0} {1} - Internal cost accrual").format(job_type, job_no)),
-                "account": payable_account,
-                "debit_in_account_currency": 0,
-                "credit_in_account_currency": flt(cost, 2),
-            }
+        frappe.msgprint(
+            _("Recognition reversal after internal billing could not be posted: {0}").format(str(e)),
+            indicator="orange",
         )
+
+    return je.name
 
 
 def create_internal_billing_journal_entries_for_quote(
@@ -154,8 +200,8 @@ def create_internal_billing_journal_entries_for_quote(
     posting_date: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
-    For each Internal Job on the quote where job.company == Main Job company, build Journal Entry
-    lines (per charge) with Job Number and Item dimensions. One JE per company.
+    For each linked job on the quote where job.company == Main Job company, build one Journal Entry
+    transferring charge revenue to main job cost (per item accounts). One JE per billing event.
     """
     if not frappe.db.exists("Sales Quote", sales_quote_name):
         return {"success": True, "created": 0, "message": _("Sales Quote not found.")}
@@ -173,6 +219,15 @@ def create_internal_billing_journal_entries_for_quote(
     if not main_job_type or not main_job_no:
         return {"success": True, "created": 0, "message": _("Main Job has no job linked.")}
 
+    try:
+        main_job_doc = frappe.get_doc(main_job_type, main_job_no)
+    except Exception:
+        return {"success": True, "created": 0, "message": _("Main Job document not found.")}
+
+    main_co = getattr(main_job_doc, "company", None)
+    if not main_co:
+        return {"success": True, "created": 0, "message": _("Main Job has no company.")}
+
     posting_date = posting_date or today()
     end_customer = sales_quote.customer
 
@@ -181,13 +236,18 @@ def create_internal_billing_journal_entries_for_quote(
         resolve_internal_job_main_job,
         get_main_job_company,
         iter_internal_job_charge_splits,
+        iter_main_job_linked_scope_charge_splits,
+        resolve_operational_job_for_linked_service,
     )
+    from logistics.utils.internal_job_persistence import resolve_internal_job_for_internal_job_booking
 
     all_jobs = get_all_billing_jobs_from_sales_quote(sales_quote)
     je_row_has_jcn = bool(frappe.get_meta("Journal Entry Account").get_field("job_number"))
 
-    # company -> list of entry dicts
-    by_company: Dict[str, List[Dict[str, Any]]] = {}
+    entries: List[Dict[str, Any]] = []
+    missing_item_codes: List[str] = []
+    linked_services_billed_via_operational_job: set = set()
+    linked_job_doc_cache: Dict[str, Any] = {}
 
     for job_type, job_no in all_jobs:
         if job_type not in INTERNAL_BILLING_JOB_TYPES:
@@ -195,154 +255,124 @@ def create_internal_billing_journal_entries_for_quote(
         if (job_type, job_no) == (main_job_type, main_job_no):
             continue
         mt, mn = resolve_internal_job_main_job(job_type, job_no)
-        if not mt or not mn:
+        if not mt or not mn or (mt, mn) != (main_job_type, main_job_no):
             continue
-        main_co = get_main_job_company(mt, mn)
-        if not main_co:
+        main_co_check = get_main_job_company(mt, mn)
+        if not main_co_check:
             continue
         try:
-            job_doc = frappe.get_doc(job_type, job_no)
+            linked_job_doc = frappe.get_doc(job_type, job_no)
         except Exception:
             continue
-        op_co = getattr(job_doc, "company", None)
-        if not op_co or op_co != main_co:
+        op_co = getattr(linked_job_doc, "company", None)
+        if not op_co or op_co != main_co_check:
             continue
 
         splits = list(iter_internal_job_charge_splits(job_type, job_no, customer=end_customer))
+        if splits:
+            ls_name = resolve_internal_job_for_internal_job_booking(linked_job_doc)
+            if ls_name:
+                linked_services_billed_via_operational_job.add(ls_name)
         if not splits:
             continue
-        if op_co not in by_company:
-            by_company[op_co] = []
-        expense_account, income_account = _get_company_internal_transfer_accounts(op_co)
-        if not expense_account or not income_account:
-            return {
-                "success": False,
-                "created": 0,
-                "message": _(
-                    "Company {0}: set default Expense and Income accounts (or at least one leaf account of each root type) for internal billing."
-                ).format(op_co),
-            }
-        payable_account = frappe.db.get_value("Company", op_co, "default_payable_account")
+
         for split in splits:
             rev = flt(split.get("revenue"))
-            cst = flt(split.get("cost"))
-            if rev <= 0 and cst <= 0:
+            if rev <= 0:
                 continue
-            _append_je_split_rows(
-                by_company[op_co],
-                expense_account,
-                income_account,
-                payable_account,
-                job_doc,
+            item_code = split.get("item_code")
+            if not item_code:
+                missing_item_codes.append("{0} {1}".format(job_type, job_no))
+                continue
+            _append_revenue_transfer_rows(
+                entries,
+                main_job_doc,
+                linked_job_doc,
                 rev,
-                cst,
-                split.get("item_code"),
+                item_code,
+                main_co,
                 je_row_has_jcn,
             )
 
-    journal_entries: List[str] = []
-
-    for company, entries in by_company.items():
-        if not entries:
+    for split in iter_main_job_linked_scope_charge_splits(main_job_doc):
+        ls_name = split.get("linked_service")
+        if not ls_name or ls_name in linked_services_billed_via_operational_job:
             continue
-        if _internal_billing_jv_already_created(sales_quote_name, trigger_si, company):
+        if ls_name not in linked_job_doc_cache:
+            op_jt, op_jn = resolve_operational_job_for_linked_service(
+                ls_name,
+                main_job_type,
+                main_job_no,
+                sales_quote_name=sales_quote_name,
+            )
+            if not op_jt or not op_jn:
+                continue
+            try:
+                linked_job_doc_cache[ls_name] = frappe.get_doc(op_jt, op_jn)
+            except Exception:
+                continue
+        linked_job_doc = linked_job_doc_cache[ls_name]
+        op_co = getattr(linked_job_doc, "company", None)
+        if not op_co or op_co != main_co:
             continue
-
-        total_debit = sum(flt(e.get("debit_in_account_currency"), 2) for e in entries)
-        total_credit = sum(flt(e.get("credit_in_account_currency"), 2) for e in entries)
-        if abs(total_debit - total_credit) > 0.01:
-            return {
-                "success": False,
-                "created": 0,
-                "message": _("Internal billing entries do not balance for company {0} (Debit {1} vs Credit {2}).").format(
-                    company, total_debit, total_credit
-                ),
-            }
-
-        user_remark = _internal_billing_jv_user_remark(sales_quote_name, trigger_si, company)
-
-        je = frappe.new_doc("Journal Entry")
-        je.posting_date = posting_date
-        je.company = company
-        je.voucher_type = "Journal Entry"
-        je.user_remark = user_remark
-        if getattr(sales_quote, "branch", None):
-            je.branch = sales_quote.branch
-        if getattr(sales_quote, "cost_center", None):
-            je.cost_center = sales_quote.cost_center
-
-        je_acc_meta = frappe.get_meta("Journal Entry Account")
-        fixed_keys = frozenset(
-            {
-                "account",
-                "debit_in_account_currency",
-                "credit_in_account_currency",
-                "cost_center",
-                "profit_center",
-                "reference_type",
-                "reference_name",
-                "user_remark",
-                "job_number",
-            }
+        rev = flt(split.get("revenue"))
+        if rev <= 0:
+            continue
+        item_code = split.get("item_code")
+        if not item_code:
+            missing_item_codes.append(
+                _("Main Job {0} linked service {1}").format(main_job_no, ls_name)
+            )
+            continue
+        _append_revenue_transfer_rows(
+            entries,
+            main_job_doc,
+            linked_job_doc,
+            rev,
+            item_code,
+            main_co,
+            je_row_has_jcn,
         )
-        for e in entries:
-            row = je.append("accounts", {})
-            row.account = e["account"]
-            row.debit_in_account_currency = flt(e.get("debit_in_account_currency"), 2)
-            row.credit_in_account_currency = flt(e.get("credit_in_account_currency"), 2)
-            if e.get("cost_center"):
-                row.cost_center = e["cost_center"]
-            if e.get("profit_center"):
-                row.profit_center = e["profit_center"]
-            if e.get("reference_type") and e.get("reference_name"):
-                row.reference_type = e["reference_type"]
-                row.reference_name = e["reference_name"]
-            if e.get("user_remark"):
-                row.user_remark = e["user_remark"]
-            if je_row_has_jcn and e.get("job_number"):
-                row.job_number = e["job_number"]
-            for k, v in e.items():
-                if k in fixed_keys or not v:
-                    continue
-                if je_acc_meta.get_field(k):
-                    setattr(row, k, v)
 
-        je.flags.ignore_permissions = True
-        je.insert()
-        je.submit()
-        journal_entries.append(je.name)
+    if missing_item_codes:
+        return {
+            "success": False,
+            "created": 0,
+            "message": _(
+                "Internal billing requires item_code on charge lines. Missing on: {0}"
+            ).format(", ".join(sorted(set(missing_item_codes)))),
+        }
 
-        try:
-            from logistics.invoice_integration.internal_billing_recognition_reversal import (
-                reverse_recognition_for_internal_billing_je,
-            )
-
-            reverse_recognition_for_internal_billing_je(je, end_customer)
-        except Exception as e:
-            frappe.log_error(
-                title="Recognition reversal on Internal Billing JE submit",
-                message=frappe.get_traceback(),
-            )
-            frappe.msgprint(
-                _("Recognition reversal after internal billing could not be posted: {0}").format(str(e)),
-                indicator="orange",
-            )
-
-    if not journal_entries:
+    if not entries:
         return {
             "success": True,
             "created": 0,
-            "message": _("No same-company internal jobs with revenue/cost to bill."),
+            "message": _("No same-company linked jobs with revenue to bill."),
         }
+
+    if _internal_billing_jv_already_created(sales_quote_name, trigger_si):
+        return {
+            "success": True,
+            "created": 0,
+            "message": _("Internal billing Journal Entry already created for this Sales Quote."),
+        }
+
+    user_remark = _internal_billing_jv_user_remark(sales_quote_name, trigger_si)
+    je_name = _submit_internal_billing_journal_entry(
+        entries,
+        main_co,
+        posting_date,
+        user_remark,
+        sales_quote,
+        end_customer,
+    )
 
     return {
         "success": True,
-        "created": len(journal_entries),
-        "journal_entry": journal_entries[-1],
-        "journal_entries": journal_entries,
-        "message": _("Created {0} Internal Billing Journal Entr(y/ies): {1}.").format(
-            len(journal_entries), ", ".join(journal_entries)
-        ),
+        "created": 1,
+        "journal_entry": je_name,
+        "journal_entries": [je_name],
+        "message": _("Created Internal Billing Journal Entry: {0}.").format(je_name),
     }
 
 
@@ -352,7 +382,7 @@ def create_internal_billing_for_quote(
     posting_date: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
-    Manually create internal billing Journal Entry(ies) for same-company Internal Jobs linked to this Sales Quote.
+    Manually create internal billing Journal Entry for same-company linked jobs on this Sales Quote.
     """
     if not frappe.db.exists("Sales Quote", sales_quote_name):
         frappe.throw(_("Sales Quote {0} not found.").format(sales_quote_name))

--- a/logistics/billing/test_internal_billing.py
+++ b/logistics/billing/test_internal_billing.py
@@ -1,0 +1,463 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026, www.agilasoft.com and contributors
+# For license information, see license.txt
+
+from __future__ import unicode_literals
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import flt
+
+from logistics.billing.internal_billing import (
+    _append_revenue_transfer_rows,
+    _internal_billing_jv_user_remark,
+    create_internal_billing_journal_entries_for_quote,
+)
+from logistics.utils.item_accounts import (
+    get_expense_account_for_item,
+    get_income_account_for_item,
+    get_item_accounts_for_internal_billing,
+)
+
+_REAL_GET_DOC = frappe.get_doc
+
+
+class TestItemAccounts(FrappeTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = frappe.db.get_single_value("Global Defaults", "default_company")
+        if not cls.company:
+            cls.company = frappe.get_all("Company", limit=1)[0].name
+        cls._ensure_account("IB Test Expense", "Expense", "Expense Account")
+        cls._ensure_account("IB Test Income", "Income", "Income Account")
+        cls._ensure_test_item()
+
+    @classmethod
+    def _ensure_account(cls, account_name, root_type, account_type):
+        if frappe.db.exists("Account", {"account_name": account_name, "company": cls.company}):
+            return frappe.db.get_value(
+                "Account", {"account_name": account_name, "company": cls.company}, "name"
+            )
+        parent = frappe.db.get_value(
+            "Account",
+            {"company": cls.company, "root_type": root_type, "is_group": 1},
+            "name",
+        )
+        doc = frappe.new_doc("Account")
+        doc.account_name = account_name
+        doc.company = cls.company
+        doc.root_type = root_type
+        doc.account_type = account_type
+        doc.parent_account = parent
+        doc.insert(ignore_permissions=True)
+        return doc.name
+
+    @classmethod
+    def _ensure_test_item(cls):
+        cls.item_code = "IB-Test-Charge-Item"
+        expense = frappe.db.get_value(
+            "Account", {"account_name": "IB Test Expense", "company": cls.company}, "name"
+        )
+        income = frappe.db.get_value(
+            "Account", {"account_name": "IB Test Income", "company": cls.company}, "name"
+        )
+        if frappe.db.exists("Item", cls.item_code):
+            item = frappe.get_doc("Item", cls.item_code)
+            item.item_defaults = []
+        else:
+            item = frappe.new_doc("Item")
+            item.item_code = cls.item_code
+            item.item_name = cls.item_code
+            item.item_group = "All Item Groups"
+            item.stock_uom = "Nos"
+            item.is_stock_item = 0
+        item.append(
+            "item_defaults",
+            {
+                "company": cls.company,
+                "expense_account": expense,
+                "income_account": income,
+            },
+        )
+        item.save(ignore_permissions=True)
+        cls.expense_account = expense
+        cls.income_account = income
+
+    def test_item_default_accounts_resolved(self):
+        self.assertEqual(
+            get_expense_account_for_item(self.item_code, self.company),
+            self.expense_account,
+        )
+        self.assertEqual(
+            get_income_account_for_item(self.item_code, self.company),
+            self.income_account,
+        )
+        exp, inc = get_item_accounts_for_internal_billing(self.item_code, self.company)
+        self.assertEqual(exp, self.expense_account)
+        self.assertEqual(inc, self.income_account)
+
+    def test_missing_item_accounts_throw(self):
+        with patch(
+            "logistics.utils.item_accounts.get_expense_account_for_item",
+            return_value=None,
+        ):
+            with patch(
+                "logistics.utils.item_accounts.get_income_account_for_item",
+                return_value=None,
+            ):
+                with self.assertRaises(frappe.ValidationError):
+                    get_item_accounts_for_internal_billing(self.item_code, self.company)
+
+
+class TestRevenueTransferRows(FrappeTestCase):
+    def test_append_rows_dr_main_cr_linked(self):
+        main = SimpleNamespace(
+            doctype="Transport Job",
+            name="TJ-MAIN-01",
+            cost_center="CC-Main",
+            profit_center=None,
+            job_number="JCN-MAIN",
+        )
+        linked = SimpleNamespace(
+            doctype="Transport Job",
+            name="TJ-LINK-01",
+            cost_center="CC-Link",
+            profit_center=None,
+            job_number="JCN-LINK",
+        )
+        entries = []
+        with patch(
+            "logistics.billing.internal_billing.get_item_accounts_for_internal_billing",
+            return_value=("Exp-ACC", "Inc-ACC"),
+        ):
+            _append_revenue_transfer_rows(
+                entries,
+                main,
+                linked,
+                150.0,
+                "ITEM-001",
+                "Test Co",
+                je_row_has_jcn=True,
+            )
+        self.assertEqual(len(entries), 2)
+        dr, cr = entries
+        self.assertEqual(dr["account"], "Exp-ACC")
+        self.assertEqual(flt(dr["debit_in_account_currency"]), 150.0)
+        self.assertEqual(dr["job_number"], "JCN-MAIN")
+        self.assertEqual(cr["account"], "Inc-ACC")
+        self.assertEqual(flt(cr["credit_in_account_currency"]), 150.0)
+        self.assertEqual(cr["job_number"], "JCN-LINK")
+
+
+class TestCreateInternalBillingJV(TestItemAccounts):
+    def setUp(self):
+        self.quote_name = "SQ-IB-TEST-{0}".format(frappe.generate_hash(length=6))
+        self.main_job = SimpleNamespace(
+            doctype="Transport Job",
+            name="TJ-IB-MAIN",
+            company=self.company,
+            cost_center=None,
+            profit_center=None,
+            job_number="JCN-IB-MAIN",
+        )
+        self.linked_job = SimpleNamespace(
+            doctype="Transport Job",
+            name="TJ-IB-LINK",
+            company=self.company,
+            cost_center=None,
+            profit_center=None,
+            job_number="JCN-IB-LINK",
+        )
+        self.splits = [{"revenue": 200.0, "cost": 50.0, "item_code": self.item_code}]
+
+    def _quote_doc(self):
+        return SimpleNamespace(
+            name=self.quote_name,
+            customer="Test Customer",
+            routing_legs=[SimpleNamespace()],
+            branch=None,
+            cost_center=None,
+        )
+
+    def _mock_get_doc(self, *args, **kwargs):
+        if args and isinstance(args[0], dict):
+            return _REAL_GET_DOC(*args, **kwargs)
+        doctype, name = args[0], args[1]
+        if doctype == "Sales Quote":
+            return self._quote_doc()
+        if name == self.main_job.name:
+            return self.main_job
+        if name == self.linked_job.name:
+            return self.linked_job
+        return _REAL_GET_DOC(doctype, name)
+
+    def tearDown(self):
+        remark = _internal_billing_jv_user_remark(self.quote_name, None)
+        for je in frappe.get_all("Journal Entry", filters={"user_remark": remark}, pluck="name"):
+            doc = frappe.get_doc("Journal Entry", je)
+            if doc.docstatus == 1:
+                doc.cancel()
+            frappe.delete_doc("Journal Entry", je, force=1)
+
+    @patch(
+        "logistics.invoice_integration.internal_billing_recognition_reversal.reverse_recognition_for_internal_billing_je"
+    )
+    @patch("logistics.billing.internal_billing.frappe.get_doc")
+    @patch("logistics.billing.cross_module_billing.iter_internal_job_charge_splits")
+    @patch("logistics.billing.cross_module_billing.get_all_billing_jobs_from_sales_quote")
+    @patch(
+        "logistics.pricing_center.doctype.sales_quote.sales_quote._resolve_main_job_for_sales_quote"
+    )
+    def test_creates_single_balanced_jv(
+        self,
+        mock_resolve_main,
+        mock_all_jobs,
+        mock_splits,
+        mock_get_doc,
+        _mock_reversal,
+    ):
+        mock_resolve_main.return_value = ("Transport Job", self.main_job.name)
+        mock_all_jobs.return_value = [
+            ("Transport Job", self.main_job.name),
+            ("Transport Job", self.linked_job.name),
+        ]
+        mock_splits.return_value = self.splits
+        mock_get_doc.side_effect = self._mock_get_doc
+
+        original_exists = frappe.db.exists
+        with patch.object(frappe.db, "exists") as mock_exists:
+
+            def _exists(dt, name=None, **kwargs):
+                if dt == "Sales Quote":
+                    return True
+                if dt == "Transport Job":
+                    return True
+                return original_exists(dt, name, **kwargs)
+
+            mock_exists.side_effect = _exists
+            with patch(
+                "logistics.billing.cross_module_billing.resolve_internal_job_main_job",
+                return_value=("Transport Job", self.main_job.name),
+            ):
+                with patch(
+                    "logistics.billing.cross_module_billing.get_main_job_company",
+                    return_value=self.company,
+                ):
+                    result = create_internal_billing_journal_entries_for_quote(
+                        self.quote_name,
+                        trigger_si=None,
+                    )
+
+        self.assertTrue(result.get("success"))
+        self.assertEqual(result.get("created"), 1)
+        je_name = result.get("journal_entry")
+        self.assertTrue(je_name)
+        je = frappe.get_doc("Journal Entry", je_name)
+        self.assertEqual(je.docstatus, 1)
+        self.assertEqual(len(je.accounts), 2)
+        dr_rows = [r for r in je.accounts if flt(r.debit_in_account_currency) > 0]
+        cr_rows = [r for r in je.accounts if flt(r.credit_in_account_currency) > 0]
+        self.assertEqual(len(dr_rows), 1)
+        self.assertEqual(len(cr_rows), 1)
+        self.assertEqual(dr_rows[0].account, self.expense_account)
+        self.assertEqual(cr_rows[0].account, self.income_account)
+        if frappe.get_meta("Journal Entry Account").get_field("job_number"):
+            self.assertEqual(dr_rows[0].job_number, self.main_job.job_number)
+            self.assertEqual(cr_rows[0].job_number, self.linked_job.job_number)
+        total_dr = sum(flt(r.debit_in_account_currency) for r in je.accounts)
+        total_cr = sum(flt(r.credit_in_account_currency) for r in je.accounts)
+        self.assertEqual(total_dr, total_cr)
+
+    @patch(
+        "logistics.invoice_integration.internal_billing_recognition_reversal.reverse_recognition_for_internal_billing_je"
+    )
+    @patch("logistics.billing.internal_billing.frappe.get_doc")
+    @patch("logistics.billing.cross_module_billing.iter_internal_job_charge_splits")
+    @patch("logistics.billing.cross_module_billing.get_all_billing_jobs_from_sales_quote")
+    @patch(
+        "logistics.pricing_center.doctype.sales_quote.sales_quote._resolve_main_job_for_sales_quote"
+    )
+    def test_idempotent_second_run(
+        self,
+        mock_resolve_main,
+        mock_all_jobs,
+        mock_splits,
+        mock_get_doc,
+        _mock_reversal,
+    ):
+        mock_resolve_main.return_value = ("Transport Job", self.main_job.name)
+        mock_all_jobs.return_value = [("Transport Job", self.linked_job.name)]
+        mock_splits.return_value = self.splits
+        mock_get_doc.side_effect = self._mock_get_doc
+
+        original_exists = frappe.db.exists
+        with patch.object(frappe.db, "exists") as mock_exists:
+            created_je = []
+
+            def _exists(dt, name=None, **kwargs):
+                if dt == "Sales Quote":
+                    return True
+                if dt == "Transport Job":
+                    return True
+                if (
+                    dt == "Journal Entry"
+                    and isinstance(name, dict)
+                    and name.get("docstatus") == 1
+                    and name.get("user_remark")
+                ):
+                    return bool(created_je)
+                return original_exists(dt, name, **kwargs)
+
+            mock_exists.side_effect = _exists
+            with patch(
+                "logistics.billing.cross_module_billing.resolve_internal_job_main_job",
+                return_value=("Transport Job", self.main_job.name),
+            ):
+                with patch(
+                    "logistics.billing.cross_module_billing.get_main_job_company",
+                    return_value=self.company,
+                ):
+                    first = create_internal_billing_journal_entries_for_quote(self.quote_name)
+                    created_je.append(first.get("journal_entry"))
+                    second = create_internal_billing_journal_entries_for_quote(self.quote_name)
+
+        self.assertEqual(first.get("created"), 1)
+        self.assertEqual(second.get("created"), 0)
+
+    def test_missing_item_code_returns_error(self):
+        with patch.object(frappe.db, "exists", return_value=True):
+            with patch("logistics.billing.internal_billing.frappe.get_doc") as mock_get_doc:
+                mock_get_doc.side_effect = self._mock_get_doc
+                with patch(
+                    "logistics.pricing_center.doctype.sales_quote.sales_quote._resolve_main_job_for_sales_quote",
+                    return_value=("Transport Job", self.main_job.name),
+                ):
+                    with patch(
+                        "logistics.billing.cross_module_billing.get_all_billing_jobs_from_sales_quote",
+                        return_value=[("Transport Job", self.linked_job.name)],
+                    ):
+                        with patch(
+                            "logistics.billing.cross_module_billing.resolve_internal_job_main_job",
+                            return_value=("Transport Job", self.main_job.name),
+                        ):
+                            with patch(
+                                "logistics.billing.cross_module_billing.get_main_job_company",
+                                return_value=self.company,
+                            ):
+                                with patch(
+                                    "logistics.billing.cross_module_billing.iter_internal_job_charge_splits",
+                                    return_value=[{"revenue": 100, "cost": 0, "item_code": None}],
+                                ):
+                                    result = create_internal_billing_journal_entries_for_quote(
+                                        self.quote_name
+                                    )
+        self.assertFalse(result.get("success"))
+        self.assertIn("item_code", result.get("message", "").lower())
+
+
+class TestMainJobLinkedScopeBilling(TestItemAccounts):
+    def setUp(self):
+        self.quote_name = "SQ-IB-LINKED-{0}".format(frappe.generate_hash(length=6))
+        self.ls_name = "LS-TEST-IB"
+        self.main_job = SimpleNamespace(
+            doctype="Sea Shipment",
+            name="SF-IB-MAIN",
+            company=self.company,
+            cost_center=None,
+            profit_center=None,
+            job_number="JCN-SF-MAIN",
+            charges=[
+                SimpleNamespace(
+                    doctype="Sea Shipment Charges",
+                    charge_scope="Linked",
+                    linked_service=self.ls_name,
+                    charge_item=self.item_code,
+                    actual_revenue=0,
+                    selling_amount=0,
+                    estimated_revenue=350.0,
+                )
+            ],
+        )
+        self.linked_job = SimpleNamespace(
+            doctype="Air Shipment",
+            name="ASP-IB-LINK",
+            company=self.company,
+            cost_center=None,
+            profit_center=None,
+            job_number="JCN-ASP-LINK",
+        )
+
+    def tearDown(self):
+        remark = _internal_billing_jv_user_remark(self.quote_name, None)
+        for je in frappe.get_all("Journal Entry", filters={"user_remark": remark}, pluck="name"):
+            doc = frappe.get_doc("Journal Entry", je)
+            if doc.docstatus == 1:
+                doc.cancel()
+            frappe.delete_doc("Journal Entry", je, force=1)
+
+    @patch(
+        "logistics.invoice_integration.internal_billing_recognition_reversal.reverse_recognition_for_internal_billing_je"
+    )
+    @patch("logistics.billing.internal_billing.frappe.get_doc")
+    @patch("logistics.billing.cross_module_billing.get_all_billing_jobs_from_sales_quote")
+    @patch(
+        "logistics.pricing_center.doctype.sales_quote.sales_quote._resolve_main_job_for_sales_quote"
+    )
+    def test_main_job_linked_scope_charge_creates_jv(
+        self,
+        mock_resolve_main,
+        mock_all_jobs,
+        mock_get_doc,
+        _mock_reversal,
+    ):
+        mock_resolve_main.return_value = ("Sea Shipment", self.main_job.name)
+        mock_all_jobs.return_value = [("Sea Shipment", self.main_job.name)]
+
+        def _get_doc(*args, **kwargs):
+            if args and isinstance(args[0], dict):
+                return _REAL_GET_DOC(*args, **kwargs)
+            doctype, name = args[0], args[1]
+            if doctype == "Sales Quote":
+                return SimpleNamespace(
+                    name=self.quote_name,
+                    customer="Test Customer",
+                    routing_legs=[SimpleNamespace()],
+                    branch=None,
+                    cost_center=None,
+                )
+            if name == self.main_job.name:
+                return self.main_job
+            if name == self.linked_job.name:
+                return self.linked_job
+            return _REAL_GET_DOC(doctype, name)
+
+        mock_get_doc.side_effect = _get_doc
+
+        original_exists = frappe.db.exists
+        with patch.object(frappe.db, "exists") as mock_exists:
+
+            def _exists(dt, name=None, **kwargs):
+                if dt == "Sales Quote":
+                    return True
+                return original_exists(dt, name, **kwargs)
+
+            mock_exists.side_effect = _exists
+            with patch(
+                "logistics.billing.cross_module_billing.resolve_operational_job_for_linked_service",
+                return_value=("Air Shipment", self.linked_job.name),
+            ):
+                with patch(
+                    "logistics.billing.cross_module_billing.iter_internal_job_charge_splits",
+                    return_value=[],
+                ):
+                    result = create_internal_billing_journal_entries_for_quote(self.quote_name)
+
+        self.assertTrue(result.get("success"))
+        self.assertEqual(result.get("created"), 1)
+        je = frappe.get_doc("Journal Entry", result.get("journal_entry"))
+        self.assertEqual(len(je.accounts), 2)
+        self.assertEqual(flt(je.accounts[0].debit_in_account_currency), 350.0)

--- a/logistics/cash_advance/accounting.py
+++ b/logistics/cash_advance/accounting.py
@@ -13,6 +13,7 @@ from frappe.utils import cint, flt
 
 from logistics.cash_advance.totals_sync import _sum_submitted_acknowledgments, get_release_journal_entry
 from logistics.job_management.recognition_engine import apply_journal_entry_posting_header_from_job
+from logistics.utils.item_accounts import get_expense_account_for_item  # re-export
 
 
 def get_ar_employee_account(company: Optional[str] = None) -> str:
@@ -279,54 +280,6 @@ def cancel_journal_entry(je_name: Optional[str]) -> None:
 		je.flags.ignore_permissions = True
 		je.cancel()
 
-
-def get_expense_account_for_item(item_code: str, company: str) -> Optional[str]:
-	"""Resolve expense account: Item Default -> Item Group Default -> Company default."""
-	if not item_code:
-		return None
-
-	# 1) Item Default (per-company) on the Item itself.
-	row = frappe.db.sql(
-		"""
-		SELECT expense_account, purchase_expense_account
-		FROM `tabItem Default`
-		WHERE parent=%(item)s AND parenttype='Item' AND company=%(co)s
-		LIMIT 1
-		""",
-		{"item": item_code, "co": company},
-		as_dict=True,
-	)
-	if row:
-		acc = row[0].get("expense_account") or row[0].get("purchase_expense_account")
-		if acc:
-			return acc
-
-	# 2) Item Group Defaults (per-company) for the item's group.
-	item_group = frappe.db.get_value("Item", item_code, "item_group")
-	if item_group:
-		row = frappe.db.sql(
-			"""
-			SELECT expense_account, purchase_expense_account
-			FROM `tabItem Default`
-			WHERE parent=%(grp)s AND parenttype='Item Group' AND company=%(co)s
-			LIMIT 1
-			""",
-			{"grp": item_group, "co": company},
-			as_dict=True,
-		)
-		if row:
-			acc = row[0].get("expense_account") or row[0].get("purchase_expense_account")
-			if acc:
-				return acc
-
-	# 3) Company-level default (Cost of Goods Sold / Purchase Expense).
-	co_defaults = frappe.db.get_value(
-		"Company",
-		company,
-		["default_expense_account", "purchase_expense_account"],
-		as_dict=True,
-	) or {}
-	return co_defaults.get("default_expense_account") or co_defaults.get("purchase_expense_account") or None
 
 
 def create_liquidation_journal_entry(doc) -> str:

--- a/logistics/invoice_integration/internal_billing_recognition_reversal.py
+++ b/logistics/invoice_integration/internal_billing_recognition_reversal.py
@@ -21,6 +21,28 @@ from logistics.invoice_integration.recognition_voucher_reversal import (
 from logistics.invoice_integration.wip_reversal import post_wip_reversal_journal_multi
 
 
+def _linked_jobs_on_internal_billing_je(je_doc):
+	"""Resolve linked jobs from JE credit rows (job_number) or legacy reference fields."""
+	seen = set()
+	for row in je_doc.get("accounts") or []:
+		rt = row.get("reference_type")
+		rn = row.get("reference_name")
+		if rt in INTERNAL_BILLING_JOB_TYPES and rn and frappe.db.exists(rt, rn):
+			seen.add((rt, rn))
+			continue
+		if flt(row.get("credit_in_account_currency")) <= 0:
+			continue
+		jcn = row.get("job_number")
+		if not jcn:
+			continue
+		for jt in INTERNAL_BILLING_JOB_TYPES:
+			jn = frappe.db.get_value(jt, {"job_number": jcn}, "name")
+			if jn:
+				seen.add((jt, jn))
+				break
+	return seen
+
+
 def reverse_recognition_for_internal_billing_je(je_doc, end_customer):
 	"""
 	Reverse WIP and accrual for each job referenced on the internal billing JE.
@@ -32,12 +54,7 @@ def reverse_recognition_for_internal_billing_je(je_doc, end_customer):
 	if not je_doc or getattr(je_doc, "docstatus", None) != 1:
 		return {}
 
-	seen = set()
-	for row in je_doc.get("accounts") or []:
-		rt = row.get("reference_type")
-		rn = row.get("reference_name")
-		if rt in INTERNAL_BILLING_JOB_TYPES and rn and frappe.db.exists(rt, rn):
-			seen.add((rt, rn))
+	seen = _linked_jobs_on_internal_billing_je(je_doc)
 
 	if not seen:
 		return {}

--- a/logistics/pricing_center/doctype/change_request/change_request.py
+++ b/logistics/pricing_center/doctype/change_request/change_request.py
@@ -130,8 +130,6 @@ class ChangeRequest(Document):
 
 	def validate(self):
 		self._honour_linked_services_form_rows()
-		if self.docstatus == 0:
-			_seed_linked_services_from_job_if_empty(self)
 		self.validate_linked_service_charge_tagging()
 
 	def validate_linked_service_charge_tagging(self):
@@ -442,51 +440,6 @@ def _linked_service_identity(ls_doc) -> tuple:
 		(getattr(ls_doc, "job_type", None) or "").strip(),
 		(getattr(ls_doc, "job_no", None) or "").strip(),
 	)
-
-
-def _seed_linked_services_from_job_if_empty(cr):
-	"""Pre-fill the Services tab from the linked job when the Change Request has no services yet."""
-	cr._honour_linked_services_form_rows()
-	if linked_service_rows(cr):
-		return
-	if cr.flags.get("_cr_linked_services_seeded"):
-		return
-
-	from logistics.logistics.doctype.linked_service.linked_service import get_linked_services_for_booking
-	from logistics.pricing_center.additional_charge_to_job import (
-		INTERNAL_JOB_SATELLITE_JOB_TYPES,
-		MAIN_JOB_TYPES_FOR_CHANGE_REQUEST,
-	)
-	from logistics.utils.sales_quote_one_off_internal_jobs import _payload_from_linked_service_doc
-
-	source_docs = []
-	if cr.job_type in MAIN_JOB_TYPES_FOR_CHANGE_REQUEST:
-		source_docs = get_linked_services_for_booking(cr.job_type, cr.job)
-	elif cr.job_type in INTERNAL_JOB_SATELLITE_JOB_TYPES:
-		from logistics.utils.service_role_rules import get_linked_service_name
-
-		job_row = frappe.db.get_value(
-			cr.job_type,
-			cr.job,
-			("linked_service", "internal_job"),
-			as_dict=True,
-		) or {}
-		ls_name = get_linked_service_name(job_row)
-		if ls_name and linked_service_record_exists(ls_name):
-			source_docs = [frappe.get_doc(linked_service_doctype(), ls_name)]
-
-	if not source_docs:
-		return
-
-	rows = []
-	for ls in source_docs:
-		payload = _payload_from_linked_service_doc(ls, ls.name)
-		set_charge_row_linked_service_link(payload, None)
-		rows.append(payload)
-
-	cr.__dict__["linked_services"] = rows
-	cr.flags._linked_services_from_form = True
-	cr.flags._cr_linked_services_seeded = True
 
 
 def _cr_default_linked_service_for_charges(cr) -> str | None:

--- a/logistics/pricing_center/doctype/change_request/test_change_request.py
+++ b/logistics/pricing_center/doctype/change_request/test_change_request.py
@@ -21,6 +21,13 @@ from logistics.pricing_center.change_request_to_job import (
 
 
 class TestChangeRequestToJob(UnitTestCase):
+	def test_change_request_does_not_seed_linked_services_from_job(self):
+		"""Services tab stays empty on create — CR is for new additional services only."""
+		cr = frappe.new_doc("Change Request")
+		cr.job_type = "Air Shipment"
+		cr.job = "ASP-TEST"
+		cr.validate()
+		self.assertEqual(list(cr.linked_services or []), [])
 	def test_charge_row_service_type_matches_job_accepts_canonical_aliases(self):
 		self.assertTrue(_charge_row_service_type_matches_job("Air Shipment", "air"))
 		self.assertTrue(_charge_row_service_type_matches_job("Air Shipment", "Air"))

--- a/logistics/utils/item_accounts.py
+++ b/logistics/utils/item_accounts.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026, www.agilasoft.com and contributors
+# For license information, see license.txt
+
+"""Resolve GL accounts from Item / Item Group defaults with company fallback."""
+
+from __future__ import unicode_literals
+
+from typing import Optional, Tuple
+
+import frappe
+from frappe import _
+
+
+def _item_default_accounts(item_code: str, company: str, parenttype: str, parent: str) -> dict:
+	row = frappe.db.sql(
+		"""
+		SELECT income_account, expense_account, purchase_expense_account
+		FROM `tabItem Default`
+		WHERE parent=%(parent)s AND parenttype=%(parenttype)s AND company=%(company)s
+		LIMIT 1
+		""",
+		{"parent": parent, "parenttype": parenttype, "company": company},
+		as_dict=True,
+	)
+	return row[0] if row else {}
+
+
+def get_expense_account_for_item(item_code: str, company: str) -> Optional[str]:
+	"""Resolve expense account: Item Default -> Item Group Default -> Company default."""
+	if not item_code:
+		return None
+
+	row = _item_default_accounts(item_code, company, "Item", item_code)
+	acc = row.get("expense_account") or row.get("purchase_expense_account")
+	if acc:
+		return acc
+
+	item_group = frappe.db.get_value("Item", item_code, "item_group")
+	if item_group:
+		row = _item_default_accounts(item_code, company, "Item Group", item_group)
+		acc = row.get("expense_account") or row.get("purchase_expense_account")
+		if acc:
+			return acc
+
+	co_defaults = frappe.db.get_value(
+		"Company",
+		company,
+		["default_expense_account", "purchase_expense_account"],
+		as_dict=True,
+	) or {}
+	return co_defaults.get("default_expense_account") or co_defaults.get("purchase_expense_account") or None
+
+
+def get_income_account_for_item(item_code: str, company: str) -> Optional[str]:
+	"""Resolve income account: Item Default -> Item Group Default -> Company default."""
+	if not item_code:
+		return None
+
+	row = _item_default_accounts(item_code, company, "Item", item_code)
+	acc = row.get("income_account")
+	if acc:
+		return acc
+
+	item_group = frappe.db.get_value("Item", item_code, "item_group")
+	if item_group:
+		row = _item_default_accounts(item_code, company, "Item Group", item_group)
+		acc = row.get("income_account")
+		if acc:
+			return acc
+
+	return frappe.db.get_value("Company", company, "default_income_account") or None
+
+
+def get_item_accounts_for_internal_billing(item_code: str, company: str) -> Tuple[str, str]:
+	"""Return (expense_account, income_account) for internal billing; throw if either is missing."""
+	expense_account = get_expense_account_for_item(item_code, company)
+	income_account = get_income_account_for_item(item_code, company)
+	missing = []
+	if not expense_account:
+		missing.append(_("expense"))
+	if not income_account:
+		missing.append(_("income"))
+	if missing:
+		frappe.throw(
+			_("Item {0} (company {1}): set {2} account in Item Defaults for internal billing.").format(
+				item_code,
+				company,
+				" and ".join(missing),
+			)
+		)
+	return expense_account, income_account

--- a/logistics/warehousing/doctype/warehouse_contract/test_warehouse_contract.py
+++ b/logistics/warehousing/doctype/warehouse_contract/test_warehouse_contract.py
@@ -1,8 +1,11 @@
 # Copyright (c) 2026, www.agilasoft.com and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests import IntegrationTestCase
+
+from logistics.warehousing.doctype.warehouse_contract.warehouse_contract import (
+	_map_sales_quote_unit_type_to_warehouse_contract,
+)
 
 
 # On IntegrationTestCase, the doctype test records and all
@@ -19,4 +22,8 @@ class IntegrationTestWarehouseContract(IntegrationTestCase):
 	Use this class for testing interactions between multiple components.
 	"""
 
-	pass
+	def test_map_sales_quote_unit_type_to_warehouse_contract(self):
+		self.assertEqual(_map_sales_quote_unit_type_to_warehouse_contract("Container"), "TEU")
+		self.assertEqual(_map_sales_quote_unit_type_to_warehouse_contract("Item Count"), "Piece")
+		self.assertEqual(_map_sales_quote_unit_type_to_warehouse_contract("TEU"), "TEU")
+		self.assertEqual(_map_sales_quote_unit_type_to_warehouse_contract("Weight"), "Weight")

--- a/logistics/warehousing/doctype/warehouse_contract/warehouse_contract.py
+++ b/logistics/warehousing/doctype/warehouse_contract/warehouse_contract.py
@@ -6,6 +6,34 @@ from frappe.model.document import Document
 
 from logistics.utils.charge_service_type import sales_quote_charge_service_types_equal
 
+_WAREHOUSE_CONTRACT_UNIT_TYPES = frozenset(
+	{
+		"Handling Unit",
+		"Weight",
+		"Chargeable Weight",
+		"Volume",
+		"Package",
+		"Piece",
+		"Job",
+		"TEU",
+		"Operation Time",
+	}
+)
+
+_QUOTE_ONLY_UNIT_TYPE_MAP = {
+	"Container": "TEU",
+	"Item Count": "Piece",
+}
+
+
+def _map_sales_quote_unit_type_to_warehouse_contract(unit_type):
+	"""Map Sales Quote Charge unit types to Warehouse Contract Item options."""
+	if not unit_type:
+		return unit_type
+	if unit_type in _WAREHOUSE_CONTRACT_UNIT_TYPES:
+		return unit_type
+	return _QUOTE_ONLY_UNIT_TYPE_MAP.get(unit_type, unit_type)
+
 
 class WarehouseContract(Document):
 	def validate(self):
@@ -91,7 +119,13 @@ def get_rates_from_sales_quote(warehouse_contract, sales_quote):
 		contract_item.currency = warehouse_item.get("currency") or warehouse_item.get("selling_currency")
 		contract_item.rate = warehouse_item.get("unit_rate")
 		contract_item.calculation_method = warehouse_item.get("calculation_method")
-		contract_item.unit_type = warehouse_item.get("unit_type")
+		contract_item.unit_type = _map_sales_quote_unit_type_to_warehouse_contract(
+			warehouse_item.get("unit_type")
+		)
+		if contract_item.unit_type == "TEU":
+			container_type = warehouse_item.get("container_type") or sales_quote_doc.get("container_type")
+			if container_type:
+				contract_item.container_type = container_type
 		contract_item.uom = warehouse_item.get("uom")
 		contract_item.minimum_quantity = warehouse_item.get("minimum_quantity")
 		contract_item.minimum_charge = warehouse_item.get("minimum_charge")

--- a/logistics/wiki_content/change_request.md
+++ b/logistics/wiki_content/change_request.md
@@ -10,12 +10,21 @@ To access Change Request, go to:
 
 1. Open a job (e.g., Air Shipment, Transport Job).
 2. Click **Create Change Request** (from the Additional Charges or custom button).
-3. Add charge lines in the **Charges** child table (set **Service Type** to match the fee — Air, Sea, Transport, Customs, or Warehousing).
-4. **Submit** the Change Request — cost rows are pushed to the linked job's **Charges** table (tagged with `change_request` and `change_request_charge`). Revenue on those rows starts at zero until a Sales Quote is submitted.
-5. Create a **Sales Quote** from the Change Request (button on the submitted Change Request).
-6. **Submit** the Additional Charge Sales Quote — revenue is merged onto the existing Change Request charge rows on the job (matched by `change_request_charge`).
+3. On the **Services** tab, add only the **new** additional services you need (e.g. an extra transport leg or customs clearance). The tab starts **empty** — existing services on the shipment or job are **not** copied in.
+4. Add charge lines in the **Charges** child table (set **Service Type** to match the fee — Air, Sea, Transport, Customs, or Warehousing). Use **Scope = Linked** and pick a service from the Services tab when the charge belongs to a new linked leg.
+5. **Submit** the Change Request — cost rows are pushed to the linked job's **Charges** table (tagged with `change_request` and `change_request_charge`). Revenue on those rows starts at zero until a Sales Quote is submitted.
+6. Create a **Sales Quote** from the Change Request (button on the submitted Change Request).
+7. **Submit** the Additional Charge Sales Quote — revenue is merged onto the existing Change Request charge rows on the job (matched by `change_request_charge`).
 
-Charges do **not** appear on the job until step 4 (Change Request submit). Revenue does **not** appear until step 6 (Sales Quote submit).
+Charges do **not** appear on the job until step 5 (Change Request submit). Revenue does **not** appear until step 7 (Sales Quote submit).
+
+### Services tab (new additional services only)
+
+When you create a Change Request from a shipment or job, the **Services** tab is **empty**. CargoNext does **not** copy the job's existing Linked Services into the Change Request.
+
+Use the Services tab like a mini quotation workspace: define only the **new** subsidiary services you are adding (transport leg, customs brokerage, warehousing, and so on). Each row you add creates a Change Request–owned Linked Service. Charges that belong to one of those new legs should use **Scope = Linked** and reference the matching service row.
+
+Charges for fees on the **main** job itself (no new subsidiary leg) can stay on **Scope = Main** without adding a Services row.
 
 ### Multimodal jobs (Air Shipment / Sea Shipment)
 
@@ -55,7 +64,7 @@ Row 4 is tagged with `change_request_charge = 2mipjiaefb`, matching the sole Cha
 | Change Request submitted | 2026-06-02 15:56 | Cost row appears; revenue still 0 |
 | Sales Quote OOQ00319 submitted | 2026-06-02 16:01 | Revenue merged onto existing row |
 
-Charges do **not** appear until the Change Request is **submitted** (step 4). Revenue stays at zero until the Additional Charge Sales Quote is **submitted** (step 6). Reload the Air Shipment form after each submit.
+Charges do **not** appear until the Change Request is **submitted**. Revenue stays at zero until the Additional Charge Sales Quote is **submitted**. Reload the Air Shipment form after each submit.
 
 #### If charges still appear missing
 

--- a/logistics/wiki_content/internal_and_intercompany_billing.md
+++ b/logistics/wiki_content/internal_and_intercompany_billing.md
@@ -107,8 +107,14 @@ When the Main Job and all Internal Jobs are in the **same company**, internal bi
 
 ### 3.3 No Invoice for Internal Billing — Journal Entry Only
 
-- For **internal billing** (same operating company as Main Job), **no Sales Invoice** is raised for Internal Jobs.
-- Internal billing amounts are entered through **Journal Entry** (same company): allocate cost/revenue between Main Job and Internal Jobs so that Internal Job revenue = cost of Main Job allocated, and Internal Job cost = tariff/actual.
+- For **internal billing** (same operating company as Main Job), **no Sales Invoice** is raised for linked (internal) jobs.
+- **One Journal Entry** per billing event (Sales Quote + optional trigger Sales Invoice) transfers each linked job’s **charge revenue** to the **Main Job as cost**.
+- Per charge line with revenue and `item_code`:
+  - **Dr** Item `expense_account` (from Item Defaults) on the **Main Job** (cost center / Job Number dimensions).
+  - **Cr** Item `income_account` (from Item Defaults) on the **linked job** (cost center / Job Number dimensions).
+- Linked-job **cost/tariff** is not posted in this JV (WIP/accrual reversal still runs separately when recognition is open on the linked job).
+- When linked-service revenue is stored on **main job charge rows** (`charge_scope = Linked`), internal billing reads those rows and resolves the operational linked job via the `linked_service` link (e.g. Air Shipment for an air leg on a Sea main job).
+- Each charge item must have **Item Defaults** (or Item Group Defaults) with both income and expense accounts for the company.
 
 ### 3.4 Consolidated vs Per-Product Customer Invoices
 

--- a/logistics/wiki_content/recent_platform_updates.md
+++ b/logistics/wiki_content/recent_platform_updates.md
@@ -58,6 +58,7 @@ Migrations may reset recognition custom fields on Air Shipment (see patches `v1_
 ## 7. Pricing center and jobs
 
 - [Sales Quote](welcome/sales-quote): separate billings per service type, main vs internal job routing, unified charge calculation across modules.
+- **[Change Request](welcome/change-request) — Services tab starts empty:** creating a Change Request from a shipment or job no longer copies existing Linked Services onto the Change Request. Add only **new** additional services on the Services tab; use **Charges** for the fee lines and create a Sales Quote when ready to bill.
 - **General Job** and workspace updates align with costing and recognition where applicable.
 
 ## 8. Integrations and utilities


### PR DESCRIPTION
## Summary

Fixes charge table access in `iter_main_job_linked_scope_charge_splits` so linked-scope internal billing works when the main job document is not a standard Frappe `Document` (e.g. dict-like or mock objects in tests).

## Changes

- Check that `main_job_doc.get` exists and is callable before using it to read `charges`
- Fall back to `getattr(main_job_doc, "charges", None)` when `.get()` is unavailable
- Prevents `AttributeError` / failed charge iteration for non-standard job document structures

## Context

This is a follow-up to the internal billing refactor for linked jobs. The linked-scope charge split logic assumed every main job doc exposed Frappe's `.get()` API; this hardens that assumption.

## Test plan

- [ ] Run internal billing tests: `bench run-tests --app logistics --module logistics.billing.test_internal_billing`
- [ ] Verify linked-scope charges on a main job still split correctly for internal billing
- [ ] Confirm no regression when main job is a normal Frappe document (Transport Job, Sea Shipment, etc.)