### PR TITLE
fix(deps): resolve gunicorn URL conflict during Docker bench get-app

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,6 @@ dependencies = [
     "frappe",
     "zeep>=4.2",
     "xmltodict>=0.13",
-    # URL dependencies required for Frappe v16+ with uv installer
-    # Dependency resolver will handle version conflicts with v15
-    "PyPika @ git+https://github.com/frappe/pypika@2c50e6142b2d61d2d243e466fdd5dc03b3d918f2",
-    "gunicorn @ git+https://github.com/frappe/gunicorn@bb554053bb87218120d76ab6676af7015680e8b6"
 ]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Docker image builds fail at `bench get-app` for logistics with:

```
Failed to resolve dependencies for `frappe` (v16.26.3)
Requirements contain conflicting URLs for package `gunicorn`
```

`pyproject.toml` pinned `gunicorn` to commit `bb554053` (Frappe v15 era), while Frappe v16.26.3 requires `54b59ca`. `uv` treats these as conflicting direct URL dependencies.

## Fix

Remove the duplicate `gunicorn` and `PyPika` git URL dependencies from `pyproject.toml`. Logistics already depends on `frappe`, which declares the correct pins for both packages. This matches how `workflow_center` and ERPNext declare dependencies.

## Test plan

- [ ] Rebuild Docker image with logistics app stage
- [ ] Confirm `bench get-app` completes without uv dependency resolution errors
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e9f9fbc2-ca1b-4d62-8dd1-9f18a7853c81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9f9fbc2-ca1b-4d62-8dd1-9f18a7853c81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

