### PR TITLE
fix(deps): align PyPika and gunicorn pins with Frappe v16 for uv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ dependencies = [
     "frappe",
     "zeep>=4.2",
     "xmltodict>=0.13",
+    # Direct git URL pins required by uv when resolving frappe; must match frappe's pyproject.toml
+    "PyPika @ git+https://github.com/frappe/pypika@2c50e6142b2d61d2d243e466fdd5dc03b3d918f2",
+    "gunicorn @ git+https://github.com/frappe/gunicorn@54b59ca884c79dcf04d4882658a32bbaf17e999f",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,6 @@ dependencies = [
     "frappe",
     "zeep>=4.2",
     "xmltodict>=0.13",
-    # URL dependencies required for Frappe v16+ with uv installer
-    # Dependency resolver will handle version conflicts with v15
-    "PyPika @ git+https://github.com/frappe/pypika@2c50e6142b2d61d2d243e466fdd5dc03b3d918f2",
-    "gunicorn @ git+https://github.com/frappe/gunicorn@bb554053bb87218120d76ab6676af7015680e8b6"
 ]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Docker image builds fail at `bench get-app` for logistics during `uv pip install -e logistics`.

Two related uv resolver errors:

1. **Conflicting URLs** — logistics pinned `gunicorn` to commit `bb554053` (Frappe v15), while Frappe v16.26.3 requires `54b59ca`.
2. **Indirect URL dependency** — after removing the pins (#1233), uv requires `PyPika` (and `gunicorn`) as **direct** git URL dependencies when resolving `frappe`.

## Fix

Keep `PyPika` and `gunicorn` as direct git URL dependencies in `pyproject.toml`, but align both commits with Frappe v16.26.3's `pyproject.toml`:

- `PyPika @ …@2c50e6142b2d61d2d243e466fdd5dc03b3d918f2`
- `gunicorn @ …@54b59ca884c79dcf04d4882658a32bbaf17e999f`

Merged latest `develop` and resolved conflict with #1233 by keeping these pins (removal alone is insufficient for uv).

## Test plan

- [ ] Rebuild Docker image with logistics app stage
- [ ] Confirm `bench get-app` completes without uv dependency resolution errors
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e9f9fbc2-ca1b-4d62-8dd1-9f18a7853c81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9f9fbc2-ca1b-4d62-8dd1-9f18a7853c81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

