### PR TITLE
fix(deps): use bench frappe-dependencies to fix uv Docker install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,12 +12,8 @@ requires-python = ">=3.14,<3.15"
 readme = "README.md"
 dynamic = ["version"]
 dependencies = [
-    "frappe",
     "zeep>=4.2",
     "xmltodict>=0.13",
-    # Direct git URL pins required by uv when resolving frappe; must match frappe's pyproject.toml
-    "PyPika @ git+https://github.com/frappe/pypika@2c50e6142b2d61d2d243e466fdd5dc03b3d918f2",
-    "gunicorn @ git+https://github.com/frappe/gunicorn@54b59ca884c79dcf04d4882658a32bbaf17e999f",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -31,6 +27,10 @@ classifiers = [
 Homepage = "https://github.com/agilasoft/logistics"
 Repository = "https://github.com/agilasoft/logistics"
 Issues = "https://github.com/agilasoft/logistics/issues"
+
+[tool.bench.frappe-dependencies]
+frappe = ">=16.0.0,<17.0.0"
+erpnext = ">=16.0.0,<17.0.0"
 
 [tool.setuptools]
 packages = ["logistics"]

--- a/workflow_center/pyproject.toml
+++ b/workflow_center/pyproject.toml
@@ -11,9 +11,7 @@ description = "Workflow Center — unified cockpit for pending workflow actions 
 requires-python = ">=3.14,<3.15"
 readme = "README.md"
 dynamic = ["version"]
-dependencies = [
-    "frappe",
-]
+dependencies = []
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -26,6 +24,9 @@ classifiers = [
 Homepage = "https://github.com/agilasoft/logistics"
 Repository = "https://github.com/agilasoft/logistics"
 Issues = "https://github.com/agilasoft/logistics/issues"
+
+[tool.bench.frappe-dependencies]
+frappe = ">=16.0.0,<17.0.0"
 
 [tool.setuptools]
 packages = ["workflow_center"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Docker builds still fail at `bench get-app` for logistics with:

```
Failed to resolve dependencies for `frappe` (v16.26.3)
Package `pypika` was included as a URL dependency.
URL dependencies must be expressed as direct requirements or constraints.
```

PR #1234 added matching `PyPika`/`gunicorn` git URL pins, but uv still fails because listing `frappe` in `project.dependencies` makes `uv pip install -e logistics` re-resolve frappe's full dependency tree (including git URL packages).

## Fix

Follow the official Frappe app pattern used by `payments`, `hrms`, and `erpnext`:

- Remove `frappe` from `project.dependencies` (install only app-specific packages: `zeep`, `xmltodict`)
- Remove `PyPika`/`gunicorn` URL pins (no longer needed)
- Add `[tool.bench.frappe-dependencies]` for framework version constraints

Frappe is already installed in the bench env before custom apps are added during Docker image builds; bench uses `tool.bench.frappe-dependencies` for version validation.

Also updated `workflow_center/pyproject.toml` for consistency.

## Test plan

- [ ] Rebuild Docker image with logistics app stage
- [ ] Confirm `bench get-app file:///.../logistics` completes without uv errors
- [ ] Verify `zeep` and `xmltodict` are still installed in the bench env
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e9f9fbc2-ca1b-4d62-8dd1-9f18a7853c81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9f9fbc2-ca1b-4d62-8dd1-9f18a7853c81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

