### PR TITLE
v2.0-dev-feat(billing): enhance internal billing and charge calculation methods

### DIFF
--- a/logistics/air_freight/doctype/air_booking/air_booking.json
+++ b/logistics/air_freight/doctype/air_booking/air_booking.json
@@ -571,8 +571,9 @@
   },
   {
    "fieldname": "shipper_address_display",
-   "fieldtype": "Small Text",
-   "label": "Shipper Address Display"
+   "fieldtype": "Text Editor",
+   "label": "Shipper Address Display",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_addr",
@@ -586,8 +587,9 @@
   },
   {
    "fieldname": "consignee_address_display",
-   "fieldtype": "Small Text",
-   "label": "Consignee Address Display"
+   "fieldtype": "Text Editor",
+   "label": "Consignee Address Display",
+   "read_only": 1
   },
   {
    "fieldname": "shipper_contact",

--- a/logistics/air_freight/doctype/air_booking/air_booking.py
+++ b/logistics/air_freight/doctype/air_booking/air_booking.py
@@ -1027,7 +1027,7 @@ class AirBooking(VirtualLinkedServicesMixin, Document):
 					# Validate it's in the valid list
 					valid_calc_methods = [
 						"Per Unit", "Fixed Amount", "Flat Rate", "Base Plus Additional",
-						"First Plus Additional", "Percentage", "Location-based", "Weight Break", "Qty Break"
+						"First Plus Additional", "Percentage", "Location-based", "Weight Break", "Qty Break", "Percentage Break"
 					]
 					if calc_method not in valid_calc_methods:
 						frappe.log_error(
@@ -1246,7 +1246,7 @@ class AirBooking(VirtualLinkedServicesMixin, Document):
 			# Normalize calculation_method values in fetched records before processing
 			valid_calc_methods = [
 				"Per Unit", "Fixed Amount", "Flat Rate", "Base Plus Additional",
-				"First Plus Additional", "Percentage", "Location-based", "Weight Break", "Qty Break"
+				"First Plus Additional", "Percentage", "Location-based", "Weight Break", "Qty Break", "Percentage Break"
 			]
 			for sqaf_record in sales_quote_air_freight_records:
 				_raw_method = sqaf_record.get("revenue_calculation_method") or sqaf_record.get("calculation_method")
@@ -1309,7 +1309,7 @@ class AirBooking(VirtualLinkedServicesMixin, Document):
 						# Final safety check: ensure calculation_method is valid before appending
 						valid_calc_methods = [
 							"Per Unit", "Fixed Amount", "Flat Rate", "Base Plus Additional",
-							"First Plus Additional", "Percentage", "Location-based", "Weight Break", "Qty Break"
+							"First Plus Additional", "Percentage", "Location-based", "Weight Break", "Qty Break", "Percentage Break"
 						]
 						if mapped_calc_method not in valid_calc_methods:
 							frappe.log_error(
@@ -1635,7 +1635,7 @@ class AirBooking(VirtualLinkedServicesMixin, Document):
 		
 		valid_calc_methods = [
 			"Per Unit", "Fixed Amount", "Flat Rate", "Base Plus Additional",
-			"First Plus Additional", "Percentage", "Location-based", "Weight Break", "Qty Break"
+			"First Plus Additional", "Percentage", "Location-based", "Weight Break", "Qty Break", "Percentage Break"
 		]
 		
 		from logistics.utils.charges_calculation import normalize_operational_charge_type
@@ -1787,7 +1787,7 @@ class AirBooking(VirtualLinkedServicesMixin, Document):
 			# Define valid calculation methods for Air Booking Charges
 			valid_calc_methods = [
 				"Per Unit", "Fixed Amount", "Flat Rate", "Base Plus Additional",
-				"First Plus Additional", "Percentage", "Location-based", "Weight Break", "Qty Break"
+				"First Plus Additional", "Percentage", "Location-based", "Weight Break", "Qty Break", "Percentage Break"
 			]
 			
 			# STEP 1: Extract UOM from calculation_method if it contains unit strings

--- a/logistics/air_freight/doctype/air_booking_charges/air_booking_charges.json
+++ b/logistics/air_freight/doctype/air_booking_charges/air_booking_charges.json
@@ -75,9 +75,11 @@
   "weight_breaks_section",
   "selling_weight_break",
   "selling_qty_break",
+  "selling_percentage_break",
   "column_break_calc_notes",
   "cost_weight_break",
   "cost_qty_break",
+  "cost_percentage_break",
   "other_services_section",
   "other_service_type",
   "date_started",
@@ -205,7 +207,7 @@
   {
    "fetch_from": "item_code.description",
    "fieldname": "description",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Description"
   },
   {
@@ -303,7 +305,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break",
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break",
    "read_only_depends_on": "eval:['Cost','Disbursement'].includes(doc.charge_type)"
   },
   {
@@ -386,7 +388,7 @@
    "fieldname": "cost_calculation_method",
    "fieldtype": "Select",
    "label": "Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break",
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break",
    "read_only_depends_on": "eval:doc.charge_type == 'Revenue'"
   },
   {
@@ -498,10 +500,22 @@
    "label": "Manage Selling Qty Breaks"
   },
   {
+   "depends_on": "eval:doc.revenue_calculation_method=='Percentage Break'",
+   "fieldname": "selling_percentage_break",
+   "fieldtype": "Button",
+   "label": "Manage Selling Percentage Breaks"
+  },
+  {
    "depends_on": "eval:doc.cost_calculation_method=='Qty Break'",
    "fieldname": "cost_qty_break",
    "fieldtype": "Button",
    "label": "Manage Cost Qty Breaks"
+  },
+  {
+   "depends_on": "eval:doc.cost_calculation_method=='Percentage Break'",
+   "fieldname": "cost_percentage_break",
+   "fieldtype": "Button",
+   "label": "Manage Cost Percentage Breaks"
   },
   {
    "fieldname": "revenue_column",

--- a/logistics/air_freight/doctype/air_consolidation_charges/air_consolidation_charges.json
+++ b/logistics/air_freight/doctype/air_consolidation_charges/air_consolidation_charges.json
@@ -68,7 +68,7 @@
   {
    "fetch_from": "item_code.description",
    "fieldname": "description",
-   "fieldtype": "Long Text",
+   "fieldtype": "Text Editor",
    "label": "Description"
   },
   {
@@ -120,7 +120,7 @@
    "fieldname": "unit_of_measure",
    "fieldtype": "Select",
    "label": "Unit of Measure",
-   "options": "kg\nm\u00b3\npackage\nshipment\nhour\nday"
+   "options": "kg\nm³\npackage\nshipment\nhour\nday"
   },
   {
    "fieldname": "column_break_2",

--- a/logistics/air_freight/doctype/air_shipment/air_shipment.json
+++ b/logistics/air_freight/doctype/air_shipment/air_shipment.json
@@ -629,8 +629,9 @@
   },
   {
    "fieldname": "shipper_address_display",
-   "fieldtype": "Small Text",
-   "label": "Shipper Address Display"
+   "fieldtype": "Text Editor",
+   "label": "Shipper Address Display",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_cyzc",
@@ -644,8 +645,9 @@
   },
   {
    "fieldname": "consignee_address_display",
-   "fieldtype": "Small Text",
-   "label": "Consignee Address Display"
+   "fieldtype": "Text Editor",
+   "label": "Consignee Address Display",
+   "read_only": 1
   },
   {
    "fieldname": "notify_party",

--- a/logistics/air_freight/doctype/air_shipment_charges/air_shipment_charges.json
+++ b/logistics/air_freight/doctype/air_shipment_charges/air_shipment_charges.json
@@ -78,9 +78,11 @@
   "weight_breaks_section",
   "selling_weight_break",
   "selling_qty_break",
+  "selling_percentage_break",
   "column_break_calc_notes",
   "cost_weight_break",
   "cost_qty_break",
+  "cost_percentage_break",
   "section_break_status",
   "cl3",
   "sales_invoice",
@@ -260,7 +262,7 @@
   {
    "fetch_from": "item_code.description",
    "fieldname": "description",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Description"
   },
   {
@@ -278,7 +280,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Revenue Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break",
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break",
    "read_only_depends_on": "eval:['Cost','Disbursement'].includes(doc.charge_type)",
    "reqd": 1
   },
@@ -430,7 +432,7 @@
    "fieldname": "cost_calculation_method",
    "fieldtype": "Select",
    "label": "Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break",
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break",
    "read_only_depends_on": "eval:doc.charge_type == 'Revenue'"
   },
   {
@@ -603,10 +605,22 @@
    "label": "Manage Selling Qty Breaks"
   },
   {
+   "depends_on": "eval:doc.revenue_calculation_method=='Percentage Break'",
+   "fieldname": "selling_percentage_break",
+   "fieldtype": "Button",
+   "label": "Manage Selling Percentage Breaks"
+  },
+  {
    "depends_on": "eval:doc.cost_calculation_method=='Qty Break'",
    "fieldname": "cost_qty_break",
    "fieldtype": "Button",
    "label": "Manage Cost Qty Breaks"
+  },
+  {
+   "depends_on": "eval:doc.cost_calculation_method=='Percentage Break'",
+   "fieldname": "cost_percentage_break",
+   "fieldtype": "Button",
+   "label": "Manage Cost Percentage Breaks"
   },
   {
    "default": "0",

--- a/logistics/billing/cross_module_billing.py
+++ b/logistics/billing/cross_module_billing.py
@@ -108,7 +108,7 @@ def _operational_job_from_booking_row(
     """Map a booking/order row to its operational shipment/job when applicable."""
     if not job_type or not job_no:
         return (None, None)
-    if job_type in _LINKED_OPERATIONAL_JOB_TYPES and frappe.db.exists(job_type, job_no):
+    if job_type in BILLING_JOB_TYPES and frappe.db.exists(job_type, job_no):
         return (job_type, job_no)
     mapping = BOOKING_TO_OPERATIONAL_JOB.get(job_type)
     if not mapping:
@@ -125,6 +125,50 @@ def _operational_job_from_booking_row(
     if names:
         return (op_dt, names[0])
     return (None, None)
+
+
+def resolve_billing_main_job_for_quote(
+    sales_quote,
+) -> Tuple[Optional[str], Optional[str], Optional[str], Optional[str]]:
+    """
+    Return (quote_main_type, quote_main_no, billing_main_type, billing_main_no).
+
+    Quote main is often a booking/order; billing main is the operational shipment/job
+    (e.g. Air Booking -> Air Shipment) used for internal billing Dr rows and linked-job matching.
+    """
+    from logistics.pricing_center.doctype.sales_quote.sales_quote import (
+        _resolve_main_job_for_sales_quote,
+    )
+
+    sq_name = sales_quote.name if hasattr(sales_quote, "name") else sales_quote
+    quote_main_type, quote_main_no = _resolve_main_job_for_sales_quote(sales_quote)
+    if not quote_main_type or not quote_main_no:
+        return (None, None, None, None)
+    billing_main_type, billing_main_no = _operational_job_from_booking_row(
+        quote_main_type,
+        quote_main_no,
+        sales_quote_name=sq_name,
+    )
+    if not billing_main_type or not billing_main_no:
+        billing_main_type, billing_main_no = quote_main_type, quote_main_no
+    return (quote_main_type, quote_main_no, billing_main_type, billing_main_no)
+
+
+def linked_job_matches_billing_main(
+    linked_main_type: Optional[str],
+    linked_main_no: Optional[str],
+    quote_main_type: str,
+    quote_main_no: str,
+    billing_main_type: str,
+    billing_main_no: str,
+) -> bool:
+    """True when a linked job's Main Service points at the quote or billing main job."""
+    if not linked_main_type or not linked_main_no:
+        return False
+    return (linked_main_type, linked_main_no) in (
+        (billing_main_type, billing_main_no),
+        (quote_main_type, quote_main_no),
+    )
 
 
 def resolve_operational_job_for_linked_service(
@@ -201,7 +245,9 @@ def resolve_operational_job_for_linked_service(
                 except Exception:
                     continue
                 if resolve_internal_job_for_internal_job_booking(job_doc) == linked_service_name:
-                    return (jt, jn)
+                    return _operational_job_from_booking_row(
+                        jt, jn, sales_quote_name=sales_quote_name
+                    )
 
     return (None, None)
 
@@ -225,14 +271,48 @@ def _charge_row_revenue(ch, job_type: str, *, include_estimated: bool = False) -
             rev = flt(getattr(ch, "estimated_revenue", 0))
         return rev
     if job_type in ("Declaration", "Declaration Order"):
-        rev = (
-            flt(getattr(ch, "actual_revenue", 0))
-            or flt(getattr(ch, "total_amount", 0))
-            or flt(getattr(ch, "estimated_revenue", 0))
-        )
+        rev = flt(getattr(ch, "actual_revenue", 0)) or flt(getattr(ch, "total_amount", 0))
+        if include_estimated and not rev:
+            rev = flt(getattr(ch, "estimated_revenue", 0))
         return rev
-    rev = flt(getattr(ch, "actual_revenue", 0)) or flt(getattr(ch, "estimated_revenue", 0))
+    rev = flt(getattr(ch, "actual_revenue", 0))
+    if include_estimated and not rev:
+        rev = flt(getattr(ch, "estimated_revenue", 0))
     return rev
+
+
+def _charge_row_cost(ch, job_type: str, *, include_estimated: bool = False) -> float:
+    """Cost amount from one charge row."""
+    cost = flt(getattr(ch, "actual_cost", 0))
+    if include_estimated and not cost:
+        cost = flt(getattr(ch, "estimated_cost", 0))
+    return cost
+
+
+def is_booking_superseded_by_operational_job(
+    job_type: str,
+    job_no: str,
+    quote_job_keys: set,
+    sales_quote_name: Optional[str] = None,
+) -> bool:
+    """
+    True when a booking/order on the quote already has an operational job on the same quote.
+
+    Avoids billing estimated revenue on Transport Order when Transport Job (etc.) exists.
+    """
+    mapping = BOOKING_TO_OPERATIONAL_JOB.get(job_type)
+    if not mapping:
+        return False
+    op_type, link_field = mapping
+    if not frappe.db.has_column(op_type, link_field):
+        return False
+    filters = {link_field: job_no, "docstatus": ["!=", 2]}
+    if sales_quote_name and frappe.db.has_column(op_type, "sales_quote"):
+        filters["sales_quote"] = sales_quote_name
+    for op_name in frappe.get_all(op_type, filters=filters, pluck="name"):
+        if (op_type, op_name) in quote_job_keys:
+            return True
+    return False
 
 
 def iter_main_job_linked_scope_charge_splits(
@@ -288,21 +368,26 @@ def iter_internal_job_charge_splits(
     job_type: str,
     job_name: str,
     customer: Optional[str] = None,
+    *,
+    prefer_actual: bool = False,
 ) -> Iterator[Dict[str, Any]]:
     """
     Yield per charge row: revenue, cost, item_code (for Job Number / Item dimensions on JEs).
-    Same revenue/cost rules as get_internal_job_revenue_and_cost.
+
+    When ``prefer_actual`` is True (internal billing JV), only posted actual revenue/cost
+    amounts are used — estimated booking amounts are excluded.
     """
     if not job_type or not job_name or not frappe.db.exists(job_type, job_name):
         return
     doc = frappe.get_doc(job_type, job_name)
     customer = customer or getattr(doc, "customer", None) or getattr(doc, "local_customer", None)
+    include_estimated = not prefer_actual
 
     if job_type == "Transport Job":
         for ch in doc.get("charges") or []:
             item_code = getattr(ch, "item_code", None)
-            rev = flt(getattr(ch, "actual_revenue", 0)) or flt(getattr(ch, "estimated_revenue", 0))
-            cost = flt(getattr(ch, "actual_cost", 0)) or flt(getattr(ch, "estimated_cost", 0))
+            rev = _charge_row_revenue(ch, job_type, include_estimated=include_estimated)
+            cost = _charge_row_cost(ch, job_type, include_estimated=include_estimated)
             if rev <= 0 and cost <= 0:
                 continue
             yield {"revenue": rev, "cost": cost, "item_code": item_code}
@@ -310,8 +395,8 @@ def iter_internal_job_charge_splits(
     elif job_type == "Transport Order":
         for ch in doc.get("charges") or []:
             item_code = getattr(ch, "item_code", None)
-            rev = flt(getattr(ch, "actual_revenue", 0)) or flt(getattr(ch, "estimated_revenue", 0))
-            cost = flt(getattr(ch, "actual_cost", 0)) or flt(getattr(ch, "estimated_cost", 0))
+            rev = _charge_row_revenue(ch, job_type, include_estimated=include_estimated)
+            cost = _charge_row_cost(ch, job_type, include_estimated=include_estimated)
             if rev <= 0 and cost <= 0:
                 continue
             yield {"revenue": rev, "cost": cost, "item_code": item_code}
@@ -323,8 +408,8 @@ def iter_internal_job_charge_splits(
             if customer and customer not in get_charge_bill_to_customers(ch):
                 continue
             item_code = getattr(ch, "charge_item", None)
-            rev = flt(getattr(ch, "actual_revenue", 0)) or flt(getattr(ch, "selling_amount", 0))
-            cost = flt(getattr(ch, "actual_cost", 0)) or flt(getattr(ch, "estimated_cost", 0))
+            rev = _charge_row_revenue(ch, job_type, include_estimated=include_estimated)
+            cost = _charge_row_cost(ch, job_type, include_estimated=include_estimated)
             if rev <= 0 and cost <= 0:
                 continue
             yield {"revenue": rev, "cost": cost, "item_code": item_code}
@@ -332,8 +417,8 @@ def iter_internal_job_charge_splits(
     elif job_type == "Air Shipment":
         for ch in doc.get("charges") or []:
             item_code = getattr(ch, "item_code", None)
-            rev = flt(getattr(ch, "actual_revenue", 0)) or flt(getattr(ch, "total_amount", 0))
-            cost = flt(getattr(ch, "actual_cost", 0)) or flt(getattr(ch, "estimated_cost", 0))
+            rev = _charge_row_revenue(ch, job_type, include_estimated=include_estimated)
+            cost = _charge_row_cost(ch, job_type, include_estimated=include_estimated)
             if rev <= 0 and cost <= 0:
                 continue
             yield {"revenue": rev, "cost": cost, "item_code": item_code}
@@ -341,8 +426,8 @@ def iter_internal_job_charge_splits(
     elif job_type == "Warehouse Job":
         for ch in doc.get("charges") or []:
             item_code = getattr(ch, "item_code", None) or getattr(ch, "item", None)
-            rev = flt(getattr(ch, "actual_revenue", 0)) or flt(getattr(ch, "estimated_revenue", 0))
-            cost = flt(getattr(ch, "actual_cost", 0)) or flt(getattr(ch, "estimated_cost", 0))
+            rev = _charge_row_revenue(ch, job_type, include_estimated=include_estimated)
+            cost = _charge_row_cost(ch, job_type, include_estimated=include_estimated)
             if rev <= 0 and cost <= 0:
                 continue
             yield {"revenue": rev, "cost": cost, "item_code": item_code}
@@ -350,12 +435,8 @@ def iter_internal_job_charge_splits(
     elif job_type in ("Declaration", "Declaration Order"):
         for ch in doc.get("charges") or []:
             item_code = getattr(ch, "item_code", None)
-            rev = (
-                flt(getattr(ch, "actual_revenue", 0))
-                or flt(getattr(ch, "total_amount", 0))
-                or flt(getattr(ch, "estimated_revenue", 0))
-            )
-            cost = flt(getattr(ch, "actual_cost", 0)) or flt(getattr(ch, "estimated_cost", 0))
+            rev = _charge_row_revenue(ch, job_type, include_estimated=include_estimated)
+            cost = _charge_row_cost(ch, job_type, include_estimated=include_estimated)
             if rev <= 0 and cost <= 0:
                 continue
             yield {"revenue": rev, "cost": cost, "item_code": item_code}
@@ -503,6 +584,8 @@ def get_internal_job_revenue_and_cost(
     job_type: str,
     job_name: str,
     customer: Optional[str] = None,
+    *,
+    prefer_actual: bool = False,
 ) -> Tuple[float, float]:
     """
     Get total revenue (allocated from main job / transfer price) and total cost (tariff or actual)
@@ -511,7 +594,9 @@ def get_internal_job_revenue_and_cost(
     """
     revenue_total = 0.0
     cost_total = 0.0
-    for row in iter_internal_job_charge_splits(job_type, job_name, customer=customer):
+    for row in iter_internal_job_charge_splits(
+        job_type, job_name, customer=customer, prefer_actual=prefer_actual
+    ):
         revenue_total += flt(row.get("revenue"))
         cost_total += flt(row.get("cost"))
     return (revenue_total, cost_total)

--- a/logistics/billing/internal_billing.py
+++ b/logistics/billing/internal_billing.py
@@ -112,6 +112,7 @@ def _submit_internal_billing_journal_entry(
     user_remark: str,
     sales_quote,
     end_customer: str,
+    billing_main_job=None,
 ) -> str:
     """Build, submit one Journal Entry from prepared account rows; run recognition reversal."""
     total_debit = sum(flt(e.get("debit_in_account_currency"), 2) for e in entries)
@@ -180,7 +181,20 @@ def _submit_internal_billing_journal_entry(
             reverse_recognition_for_internal_billing_je,
         )
 
-        reverse_recognition_for_internal_billing_je(je, end_customer)
+        recognition = reverse_recognition_for_internal_billing_je(
+            je, end_customer, billing_main_job=billing_main_job
+        )
+        parts = []
+        if recognition.get("wip_recognition_journal_entry"):
+            parts.append(_("WIP recognition: {0}").format(recognition["wip_recognition_journal_entry"]))
+        if recognition.get("accrual_recognition_journal_entry"):
+            parts.append(_("Accrual recognition: {0}").format(recognition["accrual_recognition_journal_entry"]))
+        if recognition.get("wip_journal_entry"):
+            parts.append(_("WIP reversal: {0}").format(recognition["wip_journal_entry"]))
+        if recognition.get("accrual_journal_entry"):
+            parts.append(_("Accrual reversal: {0}").format(recognition["accrual_journal_entry"]))
+        if parts:
+            frappe.msgprint(" ".join(parts), indicator="green")
     except Exception as e:
         frappe.log_error(
             title="Recognition reversal on Internal Billing JE submit",
@@ -211,16 +225,26 @@ def create_internal_billing_journal_entries_for_quote(
     if not legs:
         return {"success": True, "created": 0, "message": _("No routing legs.")}
 
-    from logistics.pricing_center.doctype.sales_quote.sales_quote import (
-        _resolve_main_job_for_sales_quote,
+    from logistics.billing.cross_module_billing import (
+        get_all_billing_jobs_from_sales_quote,
+        resolve_internal_job_main_job,
+        get_main_job_company,
+        iter_internal_job_charge_splits,
+        iter_main_job_linked_scope_charge_splits,
+        resolve_operational_job_for_linked_service,
+        linked_job_matches_billing_main,
+        resolve_billing_main_job_for_quote,
+        is_booking_superseded_by_operational_job,
     )
 
-    main_job_type, main_job_no = _resolve_main_job_for_sales_quote(sales_quote)
-    if not main_job_type or not main_job_no:
+    quote_main_type, quote_main_no, billing_main_type, billing_main_no = (
+        resolve_billing_main_job_for_quote(sales_quote)
+    )
+    if not quote_main_type or not quote_main_no:
         return {"success": True, "created": 0, "message": _("Main Job has no job linked.")}
 
     try:
-        main_job_doc = frappe.get_doc(main_job_type, main_job_no)
+        main_job_doc = frappe.get_doc(billing_main_type, billing_main_no)
     except Exception:
         return {"success": True, "created": 0, "message": _("Main Job document not found.")}
 
@@ -230,18 +254,10 @@ def create_internal_billing_journal_entries_for_quote(
 
     posting_date = posting_date or today()
     end_customer = sales_quote.customer
-
-    from logistics.billing.cross_module_billing import (
-        get_all_billing_jobs_from_sales_quote,
-        resolve_internal_job_main_job,
-        get_main_job_company,
-        iter_internal_job_charge_splits,
-        iter_main_job_linked_scope_charge_splits,
-        resolve_operational_job_for_linked_service,
-    )
     from logistics.utils.internal_job_persistence import resolve_internal_job_for_internal_job_booking
 
     all_jobs = get_all_billing_jobs_from_sales_quote(sales_quote)
+    quote_job_keys = set(all_jobs)
     je_row_has_jcn = bool(frappe.get_meta("Journal Entry Account").get_field("job_number"))
 
     entries: List[Dict[str, Any]] = []
@@ -252,12 +268,23 @@ def create_internal_billing_journal_entries_for_quote(
     for job_type, job_no in all_jobs:
         if job_type not in INTERNAL_BILLING_JOB_TYPES:
             continue
-        if (job_type, job_no) == (main_job_type, main_job_no):
+        if (job_type, job_no) in (
+            (billing_main_type, billing_main_no),
+            (quote_main_type, quote_main_no),
+        ):
+            continue
+        if is_booking_superseded_by_operational_job(
+            job_type, job_no, quote_job_keys, sales_quote_name=sales_quote_name
+        ):
             continue
         mt, mn = resolve_internal_job_main_job(job_type, job_no)
-        if not mt or not mn or (mt, mn) != (main_job_type, main_job_no):
+        if not linked_job_matches_billing_main(
+            mt, mn, quote_main_type, quote_main_no, billing_main_type, billing_main_no
+        ):
             continue
-        main_co_check = get_main_job_company(mt, mn)
+        main_co_check = get_main_job_company(mt, mn) or get_main_job_company(
+            billing_main_type, billing_main_no
+        )
         if not main_co_check:
             continue
         try:
@@ -268,11 +295,16 @@ def create_internal_billing_journal_entries_for_quote(
         if not op_co or op_co != main_co_check:
             continue
 
-        splits = list(iter_internal_job_charge_splits(job_type, job_no, customer=end_customer))
+        splits = list(
+            iter_internal_job_charge_splits(
+                job_type, job_no, customer=end_customer, prefer_actual=True
+            )
+        )
         if splits:
             ls_name = resolve_internal_job_for_internal_job_booking(linked_job_doc)
             if ls_name:
                 linked_services_billed_via_operational_job.add(ls_name)
+            linked_services_billed_via_operational_job.add((job_type, job_no))
         if not splits:
             continue
 
@@ -301,11 +333,13 @@ def create_internal_billing_journal_entries_for_quote(
         if ls_name not in linked_job_doc_cache:
             op_jt, op_jn = resolve_operational_job_for_linked_service(
                 ls_name,
-                main_job_type,
-                main_job_no,
+                billing_main_type,
+                billing_main_no,
                 sales_quote_name=sales_quote_name,
             )
             if not op_jt or not op_jn:
+                continue
+            if (op_jt, op_jn) in linked_services_billed_via_operational_job:
                 continue
             try:
                 linked_job_doc_cache[ls_name] = frappe.get_doc(op_jt, op_jn)
@@ -321,7 +355,7 @@ def create_internal_billing_journal_entries_for_quote(
         item_code = split.get("item_code")
         if not item_code:
             missing_item_codes.append(
-                _("Main Job {0} linked service {1}").format(main_job_no, ls_name)
+                _("Main Job {0} linked service {1}").format(billing_main_no, ls_name)
             )
             continue
         _append_revenue_transfer_rows(
@@ -365,6 +399,7 @@ def create_internal_billing_journal_entries_for_quote(
         user_remark,
         sales_quote,
         end_customer,
+        billing_main_job=main_job_doc,
     )
 
     return {

--- a/logistics/billing/test_internal_billing.py
+++ b/logistics/billing/test_internal_billing.py
@@ -87,6 +87,21 @@ class TestItemAccounts(FrappeTestCase):
         cls.expense_account = expense
         cls.income_account = income
 
+    @classmethod
+    def _ensure_job_number(cls, job_type, job_no):
+        if frappe.db.exists("Job Number", job_no):
+            return
+        doc = frappe.new_doc("Job Number")
+        doc.job_type = job_type
+        doc.job_no = job_no
+        doc.company = cls.company
+        doc.insert(ignore_permissions=True)
+
+    def _ensure_jv_job_numbers(self, *job_docs):
+        for job in job_docs:
+            job.job_number = job.name
+            self._ensure_job_number(job.doctype, job.name)
+
     def test_item_default_accounts_resolved(self):
         self.assertEqual(
             get_expense_account_for_item(self.item_code, self.company),
@@ -220,6 +235,7 @@ class TestCreateInternalBillingJV(TestItemAccounts):
         mock_get_doc,
         _mock_reversal,
     ):
+        self._ensure_jv_job_numbers(self.main_job, self.linked_job)
         mock_resolve_main.return_value = ("Transport Job", self.main_job.name)
         mock_all_jobs.return_value = [
             ("Transport Job", self.main_job.name),
@@ -289,6 +305,7 @@ class TestCreateInternalBillingJV(TestItemAccounts):
         mock_get_doc,
         _mock_reversal,
     ):
+        self._ensure_jv_job_numbers(self.main_job, self.linked_job)
         mock_resolve_main.return_value = ("Transport Job", self.main_job.name)
         mock_all_jobs.return_value = [("Transport Job", self.linked_job.name)]
         mock_splits.return_value = self.splits
@@ -376,7 +393,7 @@ class TestMainJobLinkedScopeBilling(TestItemAccounts):
                     charge_scope="Linked",
                     linked_service=self.ls_name,
                     charge_item=self.item_code,
-                    actual_revenue=0,
+                    actual_revenue=350.0,
                     selling_amount=0,
                     estimated_revenue=350.0,
                 )
@@ -414,6 +431,7 @@ class TestMainJobLinkedScopeBilling(TestItemAccounts):
         mock_get_doc,
         _mock_reversal,
     ):
+        self._ensure_jv_job_numbers(self.main_job, self.linked_job)
         mock_resolve_main.return_value = ("Sea Shipment", self.main_job.name)
         mock_all_jobs.return_value = [("Sea Shipment", self.main_job.name)]
 
@@ -461,3 +479,108 @@ class TestMainJobLinkedScopeBilling(TestItemAccounts):
         je = frappe.get_doc("Journal Entry", result.get("journal_entry"))
         self.assertEqual(len(je.accounts), 2)
         self.assertEqual(flt(je.accounts[0].debit_in_account_currency), 350.0)
+
+
+class TestBookingOperationalMainMismatch(TestItemAccounts):
+    """Quote main is Air Booking; linked Transport Job points at Air Shipment."""
+
+    def setUp(self):
+        self.quote_name = "SQ-IB-TRJ-{0}".format(frappe.generate_hash(length=6))
+        self.booking_name = "ABK-IB-TEST"
+        self.main_job = SimpleNamespace(
+            doctype="Air Shipment",
+            name="ASP-IB-MAIN",
+            company=self.company,
+            cost_center=None,
+            profit_center=None,
+            job_number="JCN-ASP-MAIN",
+        )
+        self.linked_job = SimpleNamespace(
+            doctype="Transport Job",
+            name="TRJ-IB-LINK",
+            company=self.company,
+            cost_center=None,
+            profit_center=None,
+            job_number="JCN-TRJ-LINK",
+        )
+        self.splits = [{"revenue": 270000.0, "cost": 0, "item_code": self.item_code}]
+
+    def tearDown(self):
+        remark = _internal_billing_jv_user_remark(self.quote_name, None)
+        for je in frappe.get_all("Journal Entry", filters={"user_remark": remark}, pluck="name"):
+            doc = frappe.get_doc("Journal Entry", je)
+            if doc.docstatus == 1:
+                doc.cancel()
+            frappe.delete_doc("Journal Entry", je, force=1)
+
+    @patch(
+        "logistics.invoice_integration.internal_billing_recognition_reversal.reverse_recognition_for_internal_billing_je"
+    )
+    @patch("logistics.billing.internal_billing.frappe.get_doc")
+    @patch("logistics.billing.cross_module_billing.iter_internal_job_charge_splits")
+    @patch("logistics.billing.cross_module_billing.get_all_billing_jobs_from_sales_quote")
+    @patch("logistics.billing.cross_module_billing.resolve_billing_main_job_for_quote")
+    def test_transport_linked_job_bills_when_quote_main_is_booking(
+        self,
+        mock_billing_main,
+        mock_all_jobs,
+        mock_splits,
+        mock_get_doc,
+        _mock_reversal,
+    ):
+        self._ensure_jv_job_numbers(self.main_job, self.linked_job)
+        mock_billing_main.return_value = (
+            "Air Booking",
+            self.booking_name,
+            "Air Shipment",
+            self.main_job.name,
+        )
+        mock_all_jobs.return_value = [("Transport Job", self.linked_job.name)]
+        mock_splits.return_value = self.splits
+
+        def _get_doc(*args, **kwargs):
+            if args and isinstance(args[0], dict):
+                return _REAL_GET_DOC(*args, **kwargs)
+            doctype, name = args[0], args[1]
+            if doctype == "Sales Quote":
+                return SimpleNamespace(
+                    name=self.quote_name,
+                    customer="Test Customer",
+                    routing_legs=[SimpleNamespace()],
+                    branch=None,
+                    cost_center=None,
+                )
+            if name == self.main_job.name:
+                return self.main_job
+            if name == self.linked_job.name:
+                return self.linked_job
+            return _REAL_GET_DOC(doctype, name)
+
+        mock_get_doc.side_effect = _get_doc
+
+        original_exists = frappe.db.exists
+        with patch.object(frappe.db, "exists") as mock_exists:
+
+            def _exists(dt, name=None, **kwargs):
+                if dt == "Sales Quote":
+                    return True
+                if dt == "Transport Job":
+                    return True
+                return original_exists(dt, name, **kwargs)
+
+            mock_exists.side_effect = _exists
+            with patch(
+                "logistics.billing.cross_module_billing.resolve_internal_job_main_job",
+                return_value=("Air Shipment", self.main_job.name),
+            ):
+                with patch(
+                    "logistics.billing.cross_module_billing.get_main_job_company",
+                    return_value=self.company,
+                ):
+                    result = create_internal_billing_journal_entries_for_quote(self.quote_name)
+
+        self.assertTrue(result.get("success"))
+        self.assertEqual(result.get("created"), 1)
+        je = frappe.get_doc("Journal Entry", result.get("journal_entry"))
+        self.assertEqual(len(je.accounts), 2)
+        self.assertEqual(flt(je.accounts[0].debit_in_account_currency), 270000.0)

--- a/logistics/customs/doctype/declaration_charges/declaration_charges.json
+++ b/logistics/customs/doctype/declaration_charges/declaration_charges.json
@@ -77,9 +77,11 @@
   "calculation_notes_section",
   "selling_weight_break",
   "selling_qty_break",
+  "selling_percentage_break",
   "column_break_calc_notes",
   "cost_weight_break",
   "cost_qty_break",
+  "cost_percentage_break",
   "section_break_status",
   "sales_invoice",
   "sales_invoice_status",
@@ -176,7 +178,7 @@
   {
    "fetch_from": "item_code.description",
    "fieldname": "description",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Description"
   },
   {
@@ -238,7 +240,7 @@
   {
    "fetch_from": "item_code.description",
    "fieldname": "charge_description",
-   "fieldtype": "Long Text",
+   "fieldtype": "Text Editor",
    "label": "Charge Description"
   },
   {
@@ -416,10 +418,22 @@
    "label": "Manage Selling Qty Breaks"
   },
   {
+   "depends_on": "eval:doc.revenue_calculation_method=='Percentage Break'",
+   "fieldname": "selling_percentage_break",
+   "fieldtype": "Button",
+   "label": "Manage Selling Percentage Breaks"
+  },
+  {
    "depends_on": "eval:doc.cost_calculation_method=='Qty Break'",
    "fieldname": "cost_qty_break",
    "fieldtype": "Button",
    "label": "Manage Cost Qty Breaks"
+  },
+  {
+   "depends_on": "eval:doc.cost_calculation_method=='Percentage Break'",
+   "fieldname": "cost_percentage_break",
+   "fieldtype": "Button",
+   "label": "Manage Cost Percentage Breaks"
   },
   {
    "fieldname": "section_break_calc",
@@ -437,7 +451,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Revenue Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break",
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break",
    "read_only_depends_on": "eval:['Cost','Disbursement'].includes(doc.charge_type)"
   },
   {
@@ -532,7 +546,7 @@
    "fieldname": "cost_calculation_method",
    "fieldtype": "Select",
    "label": "Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break",
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break",
    "read_only_depends_on": "eval:doc.charge_type == 'Revenue'"
   },
   {

--- a/logistics/customs/doctype/declaration_order_charges/declaration_order_charges.json
+++ b/logistics/customs/doctype/declaration_order_charges/declaration_order_charges.json
@@ -70,9 +70,11 @@
   "section_break_weight_breaks",
   "selling_weight_break",
   "selling_qty_break",
+  "selling_percentage_break",
   "column_break_calc_notes",
   "cost_weight_break",
   "cost_qty_break",
+  "cost_percentage_break",
   "other_services_section",
   "other_service_type",
   "date_started",
@@ -338,10 +340,22 @@
    "label": "Manage Selling Qty Breaks"
   },
   {
+   "depends_on": "eval:doc.revenue_calculation_method=='Percentage Break'",
+   "fieldname": "selling_percentage_break",
+   "fieldtype": "Button",
+   "label": "Manage Selling Percentage Breaks"
+  },
+  {
    "depends_on": "eval:doc.cost_calculation_method=='Qty Break'",
    "fieldname": "cost_qty_break",
    "fieldtype": "Button",
    "label": "Manage Cost Qty Breaks"
+  },
+  {
+   "depends_on": "eval:doc.cost_calculation_method=='Percentage Break'",
+   "fieldname": "cost_percentage_break",
+   "fieldtype": "Button",
+   "label": "Manage Cost Percentage Breaks"
   },
   {
    "fieldname": "revenue_column",
@@ -354,7 +368,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Revenue Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break",
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break",
    "read_only_depends_on": "eval:['Cost','Disbursement'].includes(doc.charge_type)"
   },
   {
@@ -452,7 +466,7 @@
    "fieldname": "cost_calculation_method",
    "fieldtype": "Select",
    "label": "Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break",
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break",
    "read_only_depends_on": "eval:doc.charge_type == 'Revenue'"
   },
   {
@@ -570,7 +584,7 @@
   {
    "fetch_from": "item_code.description",
    "fieldname": "description",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Description"
   },
   {

--- a/logistics/exhibits/doctype/docket/docket.py
+++ b/logistics/exhibits/doctype/docket/docket.py
@@ -29,6 +29,9 @@ class Docket(VirtualLinkedServicesMixin, Document):
 		self._ensure_org_defaults()
 		self._sync_exhibitor_metadata()
 		self._validate_unique_booth_no_on_exhibit()
+		from logistics.utils.document_date_validation import validate_planned_date_range
+
+		validate_planned_date_range(self)
 		self.validate_accounts()
 		self._sync_charges()
 

--- a/logistics/exhibits/doctype/exhibit/exhibit.py
+++ b/logistics/exhibits/doctype/exhibit/exhibit.py
@@ -115,6 +115,9 @@ class Exhibit(Document):
 
 	def validate(self):
 		self._drop_virtual_dockets_rows()
+		from logistics.utils.document_date_validation import validate_planned_date_range
+
+		validate_planned_date_range(self)
 		validate_internal_job_activity_codes(self, module_filter=FOR_EXHIBITS)
 		validate_lifecycle_stage_advance(self)
 		self._recalculate_consolidation_charge_totals()

--- a/logistics/exhibits/doctype/exhibit_charges/exhibit_charges.json
+++ b/logistics/exhibits/doctype/exhibit_charges/exhibit_charges.json
@@ -80,9 +80,11 @@
   "calculation_notes_section",
   "selling_weight_break",
   "selling_qty_break",
+  "selling_percentage_break",
   "column_break_calc_notes",
   "cost_weight_break",
   "cost_qty_break",
+  "cost_percentage_break",
   "section_break_status",
   "sales_invoice",
   "sales_invoice_status",
@@ -418,10 +420,22 @@
    "label": "Manage Selling Qty Breaks"
   },
   {
+   "depends_on": "eval:doc.revenue_calculation_method=='Percentage Break'",
+   "fieldname": "selling_percentage_break",
+   "fieldtype": "Button",
+   "label": "Manage Selling Percentage Breaks"
+  },
+  {
    "depends_on": "eval:doc.cost_calculation_method=='Qty Break'",
    "fieldname": "cost_qty_break",
    "fieldtype": "Button",
    "label": "Manage Cost Qty Breaks"
+  },
+  {
+   "depends_on": "eval:doc.cost_calculation_method=='Percentage Break'",
+   "fieldname": "cost_percentage_break",
+   "fieldtype": "Button",
+   "label": "Manage Cost Percentage Breaks"
   },
   {
    "fieldname": "section_break_calc",
@@ -439,7 +453,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Revenue Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break",
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break",
    "read_only_depends_on": "eval:['Cost','Disbursement'].includes(doc.charge_type)"
   },
   {
@@ -534,7 +548,7 @@
    "fieldname": "cost_calculation_method",
    "fieldtype": "Select",
    "label": "Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break",
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break",
    "read_only_depends_on": "eval:doc.charge_type == 'Revenue'"
   },
   {
@@ -739,7 +753,7 @@
   {
    "fetch_from": "item_code.description",
    "fieldname": "description",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Description"
   }
  ],

--- a/logistics/exhibits/doctype/exhibit_consolidation_charges/exhibit_consolidation_charges.json
+++ b/logistics/exhibits/doctype/exhibit_consolidation_charges/exhibit_consolidation_charges.json
@@ -69,7 +69,7 @@
   {
    "fetch_from": "item_code.description",
    "fieldname": "description",
-   "fieldtype": "Long Text",
+   "fieldtype": "Text Editor",
    "label": "Description"
   },
   {
@@ -121,7 +121,7 @@
    "fieldname": "unit_of_measure",
    "fieldtype": "Select",
    "label": "Unit of Measure",
-   "options": "docket\nexhibit\nbooth\nm\u00b2\nday\npackage\npiece\nhour"
+   "options": "docket\nexhibit\nbooth\nm²\nday\npackage\npiece\nhour"
   },
   {
    "fieldname": "column_break_2",

--- a/logistics/exhibits/doctype/exhibit_job/exhibit_job.json
+++ b/logistics/exhibits/doctype/exhibit_job/exhibit_job.json
@@ -340,7 +340,7 @@
   },
   {
    "fieldname": "shipper_address_display",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Shipper Address Display",
    "read_only": 1
   },
@@ -357,7 +357,7 @@
   },
   {
    "fieldname": "consignee_address_display",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Consignee Address Display",
    "read_only": 1
   },

--- a/logistics/exhibits/doctype/exhibit_job/exhibit_job.py
+++ b/logistics/exhibits/doctype/exhibit_job/exhibit_job.py
@@ -8,6 +8,9 @@ from frappe.model.document import Document
 
 class ExhibitJob(Document):
 	def validate(self):
+		from logistics.utils.document_date_validation import validate_planned_date_range
+
+		validate_planned_date_range(self)
 		if self.exhibit:
 			row = frappe.db.get_value(
 				"Exhibit",

--- a/logistics/hooks.py
+++ b/logistics/hooks.py
@@ -90,16 +90,17 @@ doctype_js = {
 		"logistics/logistics/doctype/unloco/unloco.js",
 		"logistics/logistics/doctype/unloco/unloco_list.js",
 	],
-	# Sales Quote: dialogs first, break row/grid handlers, then air/sea freight scripts
+	# Sales Quote: dialogs first, break row/grid handlers, then air/sea freight scripts.
+	# Paths are module-relative (no leading "logistics/") — see NOTE below for Special Project.
+	# sales_quote.js is omitted: it loads via the DocType's own __js; listing it here would double-bind.
 	"Sales Quote": [
-		"logistics/public/js/operational_exchange_rate_grid.js",
-		"logistics/public/js/charge_break_dialogs.js",
-		"logistics/public/js/charge_break_buttons.js",
-		"logistics/pricing_center/doctype/sales_quote_charge/sales_quote_charge.js",
-		"logistics/pricing_center/doctype/sales_quote_air_freight/sales_quote_air_freight.js",
-		"logistics/pricing_center/doctype/sales_quote_sea_freight/sales_quote_sea_freight.js",
-		"logistics/public/js/sales_quote_booking_dialog.js",
-		"logistics/pricing_center/doctype/sales_quote/sales_quote.js",
+		"public/js/operational_exchange_rate_grid.js",
+		"public/js/charge_break_dialogs.js",
+		"public/js/charge_break_buttons.js",
+		"pricing_center/doctype/sales_quote_charge/sales_quote_charge.js",
+		"pricing_center/doctype/sales_quote_air_freight/sales_quote_air_freight.js",
+		"pricing_center/doctype/sales_quote_sea_freight/sales_quote_sea_freight.js",
+		"public/js/sales_quote_booking_dialog.js",
 	],
 	"Sales Quote Pack": "logistics/pricing_center/doctype/sales_quote_pack/sales_quote_pack.js",
 	"Opportunity": [

--- a/logistics/invoice_integration/internal_billing_recognition_reversal.py
+++ b/logistics/invoice_integration/internal_billing_recognition_reversal.py
@@ -3,81 +3,263 @@
 # For license information, please see license.txt
 
 """
-After internal billing Journal Entry is submitted, reverse WIP and cost accrual on referenced
-Internal Jobs (same amounts basis as internal billing: get_internal_job_revenue_and_cost).
+After internal billing Journal Entry is submitted, recognize and reverse WIP / accrual
+on each main and linked job using that job's Recognition Policy and job-level flags.
+
+- Linked job (credit / income on IB JV): WIP reversal up to credited amounts.
+- Main job (debit / expense on IB JV): accrual reversal up to debited amounts.
+- Linked job cost accrual: reversed from charge cost when the job has no debit on the JV.
 """
 
 from __future__ import unicode_literals
 
+from collections import defaultdict
+
 import frappe
 from frappe.utils import flt
 
-from logistics.billing.cross_module_billing import get_internal_job_revenue_and_cost
-from logistics.billing.internal_billing import INTERNAL_BILLING_JOB_TYPES
-from logistics.invoice_integration.accrual_reversal import post_cost_accrual_reversal_journal_multi
+from logistics.billing.cross_module_billing import iter_internal_job_charge_splits
+from logistics.invoice_integration.accrual_reversal import (
+	_paired_accrual_open_for_item,
+	post_cost_accrual_reversal_journal_multi,
+)
+from logistics.invoice_integration.charge_settled_reversal import compute_item_reversal_amount
 from logistics.invoice_integration.recognition_voucher_reversal import (
 	reversal_journal_entry_exists_by_remark_locate,
 )
-from logistics.invoice_integration.wip_reversal import post_wip_reversal_journal_multi
+from logistics.invoice_integration.wip_reversal import (
+	_paired_wip_open_for_item,
+	post_wip_reversal_journal_multi,
+)
+from logistics.job_management.gl_item_dimension import get_item_dimension_fieldname_on_gl_entry
+from logistics.job_management.recognition_engine import (
+	RecognitionEngine,
+	get_recognition_settings,
+	resolve_policy_row_for_job,
+)
 
 
-def _linked_jobs_on_internal_billing_je(je_doc):
-	"""Resolve linked jobs from JE credit rows (job_number) or legacy reference fields."""
-	seen = set()
+def _resolve_job_doc_from_jcn(jcn):
+	if not jcn or not frappe.db.exists("Job Number", jcn):
+		return None
+	jcn_doc = frappe.get_doc("Job Number", jcn)
+	job_dt = jcn_doc.job_type
+	job_no = jcn_doc.job_no
+	if not job_dt or not job_no or not frappe.db.exists(job_dt, job_no):
+		return None
+	return frappe.get_doc(job_dt, job_no)
+
+
+def _ib_je_line_buckets(je_doc):
+	"""Group IB JV row amounts by job_number: credit (revenue) and debit (cost) per item."""
+	buckets = defaultdict(lambda: {"credit": [], "debit": []})
 	for row in je_doc.get("accounts") or []:
-		rt = row.get("reference_type")
-		rn = row.get("reference_name")
-		if rt in INTERNAL_BILLING_JOB_TYPES and rn and frappe.db.exists(rt, rn):
-			seen.add((rt, rn))
-			continue
-		if flt(row.get("credit_in_account_currency")) <= 0:
-			continue
 		jcn = row.get("job_number")
 		if not jcn:
 			continue
-		for jt in INTERNAL_BILLING_JOB_TYPES:
-			jn = frappe.db.get_value(jt, {"job_number": jcn}, "name")
-			if jn:
-				seen.add((jt, jn))
-				break
-	return seen
+		item_code = row.get("item") or row.get("item_code")
+		cr = flt(row.get("credit_in_account_currency"))
+		dr = flt(row.get("debit_in_account_currency"))
+		if cr > 0:
+			buckets[jcn]["credit"].append((cr, item_code))
+		if dr > 0:
+			buckets[jcn]["debit"].append((dr, item_code))
+	return buckets
 
 
-def reverse_recognition_for_internal_billing_je(je_doc, end_customer):
+def _collect_jobs_from_ib_je(je_doc, billing_main_job=None):
+	"""Unique job documents referenced on the IB JV (main + linked)."""
+	seen = {}
+	for jcn in _ib_je_line_buckets(je_doc):
+		job = _resolve_job_doc_from_jcn(jcn)
+		if job:
+			seen[(job.doctype, job.name)] = job
+	if billing_main_job and getattr(billing_main_job, "name", None):
+		key = (billing_main_job.doctype, billing_main_job.name)
+		seen[key] = billing_main_job
+	return list(seen.values())
+
+
+def _ensure_job_recognition(job, posting_date):
 	"""
-	Reverse WIP and accrual for each job referenced on the internal billing JE.
+	Post WIP and accrual recognition on a job when enabled on the job / policy.
+
+	Uses RecognitionEngine recognition dates (job booking, ATA, user-specified, etc.).
+	"""
+	settings = get_recognition_settings(job)
+	out = {}
+	if not settings.get("enable_wip_recognition") and not settings.get("enable_accrual_recognition"):
+		return out
+
+	engine = RecognitionEngine(job)
+	if settings.get("enable_wip_recognition") and flt(job.get("wip_amount")) <= 0:
+		try:
+			wip_date = engine.get_wip_recognition_date() or posting_date
+			wip_je = engine.recognize_wip(wip_date)
+			if wip_je:
+				out["wip_recognition_journal_entry"] = wip_je
+		except Exception:
+			frappe.log_error(
+				title="WIP recognition before internal billing reversal",
+				message=frappe.get_traceback(),
+			)
+
+	job.reload()
+	engine = RecognitionEngine(job)
+	if settings.get("enable_accrual_recognition") and flt(job.get("accrual_amount")) <= 0:
+		try:
+			acc_date = engine.get_accrual_recognition_date() or posting_date
+			acc_je = engine.recognize_accruals(acc_date)
+			if acc_je:
+				out["accrual_recognition_journal_entry"] = acc_je
+		except Exception:
+			frappe.log_error(
+				title="Accrual recognition before internal billing reversal",
+				message=frappe.get_traceback(),
+			)
+	return out
+
+
+def _wip_reversal_segments_for_job(job, credit_lines, company):
+	"""Build WIP reversal (amount, item) pairs for one job from IB JV credit rows."""
+	meta = frappe.get_meta(job.doctype)
+	if not meta.has_field("wip_amount"):
+		return []
+	settings = get_recognition_settings(job)
+	if not settings.get("enable_wip_recognition"):
+		return []
+
+	jcn = job.get("job_number")
+	_policy, param_row = resolve_policy_row_for_job(job)
+	if not param_row:
+		return []
+	wip_acc = param_row.get("wip_account")
+	liab_acc = param_row.get("revenue_liability_account")
+	if not wip_acc or not liab_acc:
+		return []
+
+	remaining = flt(job.get("wip_amount"))
+	if remaining <= 0:
+		return []
+
+	item_fn_gl = get_item_dimension_fieldname_on_gl_entry()
+	je_pairs = []
+	for amt, item_code in credit_lines:
+		rev = 0
+		if item_fn_gl and item_code:
+			open_item = _paired_wip_open_for_item(jcn, company, wip_acc, liab_acc, item_fn_gl, item_code)
+			if open_item > 0:
+				rev = compute_item_reversal_amount(amt, open_item, remaining, item_code, set(), company)
+		if rev <= 0:
+			rev = min(amt, remaining)
+		if rev <= 0:
+			continue
+		je_pairs.append((rev, item_code))
+		remaining -= rev
+	return je_pairs
+
+
+def _accrual_reversal_segments_for_job(job, debit_lines, company, end_customer):
+	"""Build accrual reversal pairs for one job from IB JV debit rows or charge costs."""
+	meta = frappe.get_meta(job.doctype)
+	if not meta.has_field("accrual_amount"):
+		return []
+	settings = get_recognition_settings(job)
+	if not settings.get("enable_accrual_recognition"):
+		return []
+
+	if not debit_lines:
+		for split in iter_internal_job_charge_splits(
+			job.doctype, job.name, customer=end_customer, prefer_actual=True
+		):
+			cost = flt(split.get("cost"))
+			if cost <= 0:
+				continue
+			debit_lines.append((cost, split.get("item_code")))
+
+	if not debit_lines:
+		return []
+
+	jcn = job.get("job_number")
+	settings = get_recognition_settings(job)
+	cost_acc = settings.get("cost_accrual_account")
+	liab_acc = settings.get("accrued_cost_liability_account")
+	if not cost_acc or not liab_acc:
+		_policy, param_row = resolve_policy_row_for_job(job)
+		if param_row:
+			cost_acc = param_row.get("cost_accrual_account")
+			liab_acc = param_row.get("accrued_cost_liability_account")
+	if not cost_acc or not liab_acc:
+		return []
+
+	remaining = flt(job.get("accrual_amount"))
+	if remaining <= 0:
+		return []
+
+	item_fn_gl = get_item_dimension_fieldname_on_gl_entry()
+	je_pairs = []
+	for amt, item_code in debit_lines:
+		rev = 0
+		if item_fn_gl and item_code:
+			open_item = _paired_accrual_open_for_item(jcn, company, cost_acc, liab_acc, item_fn_gl, item_code)
+			if open_item > 0:
+				rev = compute_item_reversal_amount(amt, open_item, remaining, item_code, set(), company)
+		if rev <= 0:
+			rev = min(amt, remaining)
+		if rev <= 0:
+			continue
+		je_pairs.append((rev, item_code))
+		remaining -= rev
+	return je_pairs
+
+
+def reverse_recognition_for_internal_billing_je(je_doc, end_customer, billing_main_job=None):
+	"""
+	Recognize and reverse WIP / accrual for main and linked jobs on an internal billing JE.
 
 	:param je_doc: submitted Journal Entry (internal billing)
-	:param end_customer: Sales Quote customer (same as internal billing build)
-	:return: dict with optional wip_journal_entry, accrual_journal_entry
+	:param end_customer: Sales Quote customer
+	:param billing_main_job: operational main job document (billing Dr side)
+	:return: dict with optional recognition and reversal journal entry names
 	"""
 	if not je_doc or getattr(je_doc, "docstatus", None) != 1:
 		return {}
 
-	seen = _linked_jobs_on_internal_billing_je(je_doc)
-
-	if not seen:
+	buckets = _ib_je_line_buckets(je_doc)
+	jobs = _collect_jobs_from_ib_je(je_doc, billing_main_job=billing_main_job)
+	if not jobs and not buckets:
 		return {}
-
-	wip_segments = []
-	accrual_segments = []
-
-	for job_type, job_no in seen:
-		job = frappe.get_doc(job_type, job_no)
-		rev, cost = get_internal_job_revenue_and_cost(job_type, job_no, customer=end_customer)
-		meta = frappe.get_meta(job_type)
-
-		if meta.has_field("wip_amount") and flt(job.get("wip_amount")) > 0 and flt(rev) > 0:
-			wip_amt = min(flt(rev), flt(job.get("wip_amount")))
-			wip_segments.append((job, [(wip_amt, None)]))
-
-		if meta.has_field("accrual_amount") and flt(job.get("accrual_amount")) > 0 and flt(cost) > 0:
-			acc_amt = min(flt(cost), flt(job.get("accrual_amount")))
-			accrual_segments.append((job, [(acc_amt, None)]))
 
 	out = {}
 	posting_date = je_doc.posting_date
 	company = je_doc.company
+	wip_segments = []
+	accrual_segments = []
+
+	for job in jobs:
+		recognition = _ensure_job_recognition(job, posting_date)
+		if recognition.get("wip_recognition_journal_entry"):
+			out["wip_recognition_journal_entry"] = recognition["wip_recognition_journal_entry"]
+		if recognition.get("accrual_recognition_journal_entry"):
+			out["accrual_recognition_journal_entry"] = recognition["accrual_recognition_journal_entry"]
+
+		job.reload()
+		jcn = job.get("job_number")
+		sides = buckets.get(jcn) or {"credit": [], "debit": []}
+
+		credit_lines = list(sides.get("credit") or [])
+		wip_pairs = _wip_reversal_segments_for_job(job, credit_lines, company)
+		# Main job: linked-scope revenue WIP may settle on the expense (debit) side of the IB JV.
+		if not wip_pairs and (sides.get("debit") or []):
+			wip_pairs = _wip_reversal_segments_for_job(job, list(sides.get("debit") or []), company)
+		if wip_pairs:
+			wip_segments.append((job, wip_pairs))
+
+		acc_pairs = _accrual_reversal_segments_for_job(
+			job, list(sides.get("debit") or []), company, end_customer
+		)
+		if acc_pairs:
+			accrual_segments.append((job, acc_pairs))
 
 	wip_marker = "WIP recognition reversal (Internal Billing JV {0})".format(je_doc.name)
 	if wip_segments and not reversal_journal_entry_exists_by_remark_locate(wip_marker):

--- a/logistics/logistics/deposit_processing/container_gl_service.py
+++ b/logistics/logistics/deposit_processing/container_gl_service.py
@@ -3,7 +3,8 @@
 """
 Container deposit / charge views from **GL Entry** using the **Container** accounting dimension.
 
-The **Deposits** HTML table lists only GL rows on **Deposits Pending for Refund Request** (Sea Freight Settings).
+The **Deposits** HTML table lists only GL rows on **Deposits Pending for Refund Request** (Sea Freight Settings)
+whose **Item** accounting dimension is a **Container Deposit Charge** item (or non-item refund JE lines).
 **Charges** include only GL rows whose **Item** accounting dimension points to an Item with **Container charge** checked;
 those amounts roll into Total charges and are **not** deducted from the deposit header.
 """
@@ -14,7 +15,10 @@ import frappe
 from frappe import _
 from frappe.utils import escape_html, flt, formatdate
 
-from logistics.invoice_integration.container_deposit_pi import item_is_container_charge
+from logistics.invoice_integration.container_deposit_pi import (
+	item_is_container_charge,
+	item_is_container_deposit,
+)
 from logistics.job_management.gl_item_dimension import get_item_dimension_fieldname_on_gl_entry
 from logistics.job_management.gl_reference_dimension import get_accounting_dimension_fieldname
 
@@ -98,6 +102,25 @@ def get_deposit_system_accounts():
 	return accts
 
 
+def _gl_row_is_container_deposit_charge(row):
+	"""True when a pending-account GL row belongs on the Container Deposit tab."""
+	item_code = row.get("gl_item_code")
+	if item_code:
+		return item_is_container_deposit(item_code)
+	# Refund JEs and other non-item postings on the pending account stay visible.
+	return True
+
+
+def _deposit_gl_item_filter_sql(item_fn):
+	"""SQL fragment: pending-account GL is a container-deposit charge (or non-item refund line)."""
+	if not item_fn or not frappe.db.has_column("Item", "custom_container_deposit_charge"):
+		return "1=1"
+	return """(
+		IFNULL(gle.`{item_fn}`, '') = ''
+		OR IFNULL(item.custom_container_deposit_charge, 0) = 1
+	)""".format(item_fn=item_fn)
+
+
 def _query_gl_for_container(container_name):
 	fn = _container_column()
 	if not fn:
@@ -122,7 +145,7 @@ def _query_gl_for_container(container_name):
 def get_gl_rows_split(container_name):
 	"""Return (deposit_rows, charge_rows) for HTML.
 
-	**Deposit** display rows: only **Deposits Pending for Refund Request** (Sea Freight Settings).
+	**Deposit** display rows: pending-refund account GL with **Container Deposit Charge** Items only.
 	**Charge** display rows: GL lines on **Container charge** Items (Item dimension), excluding deposit account lines.
 	"""
 	fn = _container_column()
@@ -135,7 +158,7 @@ def get_gl_rows_split(container_name):
 		acc = r.get("account")
 		co = r.get("company")
 		pending = _pending_refund_account_for_company(co) if co else None
-		if pending and acc == pending:
+		if pending and acc == pending and _gl_row_is_container_deposit_charge(r):
 			deposit_rows.append(r)
 			continue
 		item_code = r.get("gl_item_code")
@@ -147,15 +170,22 @@ def get_gl_rows_split(container_name):
 def net_pending_balance_for_container(container_name):
 	"""Net balance on the Deposits Pending for Refund account for this container (company currency)."""
 	fn = _container_column()
+	item_fn = _gl_item_column()
 	accounts = _all_pending_refund_accounts()
 	if not fn or not accounts:
 		return 0.0
 	ph = ",".join(["%s"] * len(accounts))
+	item_filter = _deposit_gl_item_filter_sql(item_fn)
+	join_item = ""
+	if item_fn and frappe.db.has_column("Item", "custom_container_deposit_charge"):
+		join_item = "LEFT JOIN `tabItem` item ON item.name = gle.`{item_fn}`".format(item_fn=item_fn)
 	r = frappe.db.sql(
 		"""
-		SELECT COALESCE(SUM(debit - credit), 0) FROM `tabGL Entry`
-		WHERE `{col}` = %s AND account IN ({ph}) AND IFNULL(is_cancelled, 0) = 0
-		""".format(col=fn, ph=ph),
+		SELECT COALESCE(SUM(gle.debit - gle.credit), 0) FROM `tabGL Entry` gle
+		{join_item}
+		WHERE gle.`{col}` = %s AND gle.account IN ({ph}) AND IFNULL(gle.is_cancelled, 0) = 0
+			AND {item_filter}
+		""".format(col=fn, ph=ph, join_item=join_item, item_filter=item_filter),
 		(container_name,) + tuple(accounts),
 	)
 	return flt(r[0][0] if r else 0)
@@ -218,12 +248,19 @@ def sync_deposit_header_from_gl(container_doc):
 		pending_accounts = _all_pending_refund_accounts()
 		if fn and pending_accounts:
 			ph = ",".join(["%s"] * len(pending_accounts))
+			item_fn = _gl_item_column()
+			item_filter = _deposit_gl_item_filter_sql(item_fn)
+			join_item = ""
+			if item_fn and frappe.db.has_column("Item", "custom_container_deposit_charge"):
+				join_item = "LEFT JOIN `tabItem` item ON item.name = gle.`{item_fn}`".format(item_fn=item_fn)
 			cur = frappe.db.sql(
 				"""
 				SELECT gle.account_currency FROM `tabGL Entry` gle
+				{join_item}
 				WHERE gle.`{col}` = %s AND gle.account IN ({ph}) AND IFNULL(gle.is_cancelled, 0) = 0
+					AND {item_filter}
 				ORDER BY gle.posting_date DESC LIMIT 1
-				""".format(col=fn, ph=ph),
+				""".format(col=fn, ph=ph, join_item=join_item, item_filter=item_filter),
 				(name,) + tuple(pending_accounts),
 			)
 			if cur and cur[0][0] and meta.has_field("deposit_currency"):
@@ -231,9 +268,10 @@ def sync_deposit_header_from_gl(container_doc):
 			last_pd = frappe.db.sql(
 				"""
 				SELECT MAX(gle.posting_date) FROM `tabGL Entry` gle
+				{join_item}
 				WHERE gle.`{col}` = %s AND gle.account IN ({ph}) AND gle.voucher_type = 'Purchase Invoice'
-					AND IFNULL(gle.is_cancelled, 0) = 0
-				""".format(col=fn, ph=ph),
+					AND IFNULL(gle.is_cancelled, 0) = 0 AND {item_filter}
+				""".format(col=fn, ph=ph, join_item=join_item, item_filter=item_filter),
 				(name,) + tuple(pending_accounts),
 			)
 			if last_pd and last_pd[0][0] and meta.has_field("deposit_paid_date"):
@@ -307,8 +345,117 @@ def get_deposits_gl_html(container_name):
 		pending_label = _("multiple accounts")
 	return _html_table(
 		deposit_rows,
-		_("Deposits Pending for Refund Request ({0}) — GL (Container dimension)").format(pending_label),
+		_("Container deposit charges only — Deposits Pending for Refund Request ({0})").format(pending_label),
 	)
+
+
+def _account_label(account):
+	if not account:
+		return ""
+	if not frappe.db.exists("Account", account):
+		return account
+	row = frappe.db.get_value(
+		"Account",
+		account,
+		["account_number", "account_name", "company"],
+		as_dict=True,
+	)
+	if not row:
+		return account
+	abbr = frappe.db.get_value("Company", row.company, "abbr") if row.company else ""
+	parts = [p for p in (row.account_number, row.account_name, abbr) if p]
+	return " - ".join(parts) if parts else account
+
+
+def _party_label(party_type, party):
+	if not party:
+		return ""
+	if party_type == "Supplier":
+		return frappe.db.get_value("Supplier", party, "supplier_name") or party
+	if party_type == "Customer":
+		return frappe.db.get_value("Customer", party, "customer_name") or party
+	return party
+
+
+def _refunded_purchase_invoices_for_container(container_name):
+	rows = frappe.get_all(
+		"Container Refund Link",
+		filters={"parent": container_name},
+		fields=["purchase_invoice"],
+	)
+	return {r.purchase_invoice for r in rows if r.get("purchase_invoice")}
+
+
+def _refund_status_for_gl_row(row, refunded_pis):
+	voucher_type = row.get("voucher_type") or ""
+	voucher_no = row.get("voucher_no") or ""
+	if voucher_type == "Journal Entry":
+		return "Refunded"
+	if voucher_type == "Purchase Invoice":
+		return "Refunded" if voucher_no in refunded_pis else "Open"
+	if flt(row.get("credit")) > flt(row.get("debit")):
+		return "Refunded"
+	return "Open"
+
+
+def get_deposit_postings_data(container_name):
+	"""Structured deposit transaction rows for the Container Deposit tab UI."""
+	if not container_name or str(container_name).startswith("new-"):
+		return {"rows": [], "items": [], "currency": None, "error": None}
+
+	accounts = _all_pending_refund_accounts()
+	if not accounts:
+		return {
+			"rows": [],
+			"items": [],
+			"currency": None,
+			"error": _(
+				"No Deposits Pending for Refund Request account is configured on any Sea Freight Settings row. "
+				"Ask an administrator to set it per company on Sea Freight Settings."
+			),
+		}
+
+	deposit_rows, _charge = get_gl_rows_split(container_name)
+	refunded_pis = _refunded_purchase_invoices_for_container(container_name)
+	items = set()
+	out_rows = []
+	currency = None
+
+	for r in deposit_rows:
+		item_code = (r.get("gl_item_code") or "").strip()
+		if item_code:
+			items.add(item_code)
+		if not currency and r.get("company"):
+			currency = frappe.db.get_value("Company", r.get("company"), "default_currency")
+
+		party = _party_label(r.get("party_type"), r.get("party"))
+		if not party and r.get("voucher_type") == "Purchase Invoice" and r.get("voucher_no"):
+			party = frappe.db.get_value("Purchase Invoice", r.voucher_no, "supplier")
+
+		out_rows.append(
+			{
+				"posting_date": str(r.get("posting_date") or ""),
+				"voucher_type": r.get("voucher_type") or "",
+				"voucher_no": r.get("voucher_no") or "",
+				"item_code": item_code,
+				"account": r.get("account") or "",
+				"account_label": _account_label(r.get("account")),
+				"debit": flt(r.get("debit")),
+				"credit": flt(r.get("credit")),
+				"party": party or "",
+				"refund_status": _refund_status_for_gl_row(r, refunded_pis),
+			}
+		)
+
+	if not currency:
+		currency = frappe.defaults.get_user_default("currency")
+
+	return {
+		"rows": out_rows,
+		"items": sorted(items),
+		"currency": currency,
+		"error": None,
+	}
 
 
 def get_charges_gl_html(container_name):
@@ -324,18 +471,24 @@ def get_charges_gl_html(container_name):
 def pending_amount_for_pi_container(container_name, purchase_invoice):
 	"""Carrier deposit posted on PI: debit to pending account with Container dimension."""
 	fn = _container_column()
+	item_fn = _gl_item_column()
 	if not fn or not purchase_invoice:
 		return 0.0
 	co = frappe.db.get_value("Purchase Invoice", purchase_invoice, "company")
 	pending = _pending_refund_account_for_company(co)
 	if not pending:
 		return 0.0
+	item_filter = _deposit_gl_item_filter_sql(item_fn)
+	join_item = ""
+	if item_fn and frappe.db.has_column("Item", "custom_container_deposit_charge"):
+		join_item = "LEFT JOIN `tabItem` item ON item.name = gle.`{item_fn}`".format(item_fn=item_fn)
 	r = frappe.db.sql(
 		"""
-		SELECT COALESCE(SUM(debit), 0) FROM `tabGL Entry`
-		WHERE `{col}` = %s AND account = %s AND voucher_type = 'Purchase Invoice'
-			AND voucher_no = %s AND IFNULL(is_cancelled, 0) = 0
-		""".format(col=fn),
+		SELECT COALESCE(SUM(gle.debit), 0) FROM `tabGL Entry` gle
+		{join_item}
+		WHERE gle.`{col}` = %s AND gle.account = %s AND gle.voucher_type = 'Purchase Invoice'
+			AND gle.voucher_no = %s AND IFNULL(gle.is_cancelled, 0) = 0 AND {item_filter}
+		""".format(col=fn, join_item=join_item, item_filter=item_filter),
 		(container_name, pending, purchase_invoice),
 	)
 	return flt(r[0][0] if r else 0)
@@ -343,16 +496,22 @@ def pending_amount_for_pi_container(container_name, purchase_invoice):
 
 def total_pending_pi_debits_for_container(container_name):
 	fn = _container_column()
+	item_fn = _gl_item_column()
 	accounts = _all_pending_refund_accounts()
 	if not fn or not accounts:
 		return 0.0
 	ph = ",".join(["%s"] * len(accounts))
+	item_filter = _deposit_gl_item_filter_sql(item_fn)
+	join_item = ""
+	if item_fn and frappe.db.has_column("Item", "custom_container_deposit_charge"):
+		join_item = "LEFT JOIN `tabItem` item ON item.name = gle.`{item_fn}`".format(item_fn=item_fn)
 	r = frappe.db.sql(
 		"""
-		SELECT COALESCE(SUM(debit), 0) FROM `tabGL Entry`
-		WHERE `{col}` = %s AND account IN ({ph}) AND voucher_type = 'Purchase Invoice'
-			AND IFNULL(is_cancelled, 0) = 0
-		""".format(col=fn, ph=ph),
+		SELECT COALESCE(SUM(gle.debit), 0) FROM `tabGL Entry` gle
+		{join_item}
+		WHERE gle.`{col}` = %s AND gle.account IN ({ph}) AND gle.voucher_type = 'Purchase Invoice'
+			AND IFNULL(gle.is_cancelled, 0) = 0 AND {item_filter}
+		""".format(col=fn, ph=ph, join_item=join_item, item_filter=item_filter),
 		(container_name,) + tuple(accounts),
 	)
 	return flt(r[0][0] if r else 0)
@@ -397,17 +556,23 @@ def net_refund_amount_after_charges_for_pi(container_name, purchase_invoice):
 def list_eligible_refund_purchase_invoices(container_name):
 	"""Purchase Invoices with pending deposit GL for this container and no refund JE yet."""
 	fn = _container_column()
+	item_fn = _gl_item_column()
 	accounts = _all_pending_refund_accounts()
 	if not fn or not accounts:
 		return []
 	ph = ",".join(["%s"] * len(accounts))
+	item_filter = _deposit_gl_item_filter_sql(item_fn)
+	join_item = ""
+	if item_fn and frappe.db.has_column("Item", "custom_container_deposit_charge"):
+		join_item = "LEFT JOIN `tabItem` item ON item.name = gle.`{item_fn}`".format(item_fn=item_fn)
 	pis = frappe.db.sql(
 		"""
 		SELECT DISTINCT gle.voucher_no
 		FROM `tabGL Entry` gle
+		{join_item}
 		WHERE gle.`{fn}` = %s AND gle.account IN ({ph}) AND gle.voucher_type = 'Purchase Invoice'
-			AND gle.debit > 0 AND IFNULL(gle.is_cancelled, 0) = 0
-		""".format(fn=fn, ph=ph),
+			AND gle.debit > 0 AND IFNULL(gle.is_cancelled, 0) = 0 AND {item_filter}
+		""".format(fn=fn, ph=ph, join_item=join_item, item_filter=item_filter),
 		(container_name,) + tuple(accounts),
 	)
 	out = []

--- a/logistics/logistics/deposit_processing/test_container_gl_service.py
+++ b/logistics/logistics/deposit_processing/test_container_gl_service.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026, Logistics Team and contributors
+
+from unittest.mock import patch
+
+from frappe.tests import UnitTestCase
+
+from logistics.logistics.deposit_processing.container_gl_service import (
+	_gl_row_is_container_deposit_charge,
+	get_deposit_postings_data,
+	get_gl_rows_split,
+)
+
+
+class TestContainerDepositGlFilter(UnitTestCase):
+	def test_gl_row_requires_container_deposit_item_when_item_present(self):
+		with patch(
+			"logistics.logistics.deposit_processing.container_gl_service.item_is_container_deposit",
+			side_effect=lambda code: code == "CONDEP",
+		):
+			self.assertTrue(_gl_row_is_container_deposit_charge({"gl_item_code": "CONDEP"}))
+			self.assertFalse(_gl_row_is_container_deposit_charge({"gl_item_code": "FREIGHT"}))
+
+	def test_gl_row_without_item_is_kept_for_refund_je(self):
+		self.assertTrue(_gl_row_is_container_deposit_charge({}))
+
+	def test_get_gl_rows_split_excludes_non_deposit_items_on_pending_account(self):
+		rows = [
+			{
+				"account": "PENDING-ACC",
+				"company": "Test Co",
+				"gl_item_code": "FREIGHT",
+				"debit": 400,
+			},
+			{
+				"account": "PENDING-ACC",
+				"company": "Test Co",
+				"gl_item_code": "CONDEP",
+				"debit": 10000,
+			},
+			{
+				"account": "EXP-ACC",
+				"company": "Test Co",
+				"gl_item_code": "FREIGHT",
+				"debit": 400,
+			},
+		]
+		with patch(
+			"logistics.logistics.deposit_processing.container_gl_service._container_column",
+			return_value="container",
+		):
+			with patch(
+				"logistics.logistics.deposit_processing.container_gl_service._query_gl_for_container",
+				return_value=rows,
+			):
+				with patch(
+					"logistics.logistics.deposit_processing.container_gl_service._pending_refund_account_for_company",
+					return_value="PENDING-ACC",
+				):
+					with patch(
+						"logistics.logistics.deposit_processing.container_gl_service.item_is_container_deposit",
+						side_effect=lambda code: code == "CONDEP",
+					):
+						with patch(
+							"logistics.logistics.deposit_processing.container_gl_service.item_is_container_charge",
+							return_value=False,
+						):
+							deposit_rows, charge_rows = get_gl_rows_split("TEST-CONT")
+		self.assertEqual(len(deposit_rows), 1)
+		self.assertEqual(deposit_rows[0]["gl_item_code"], "CONDEP")
+		self.assertEqual(charge_rows, [])
+
+	def test_get_deposit_postings_data_shapes_rows(self):
+		deposit_rows = [
+			{
+				"posting_date": "2026-05-11",
+				"voucher_type": "Purchase Invoice",
+				"voucher_no": "PI-1",
+				"account": "PENDING-ACC",
+				"debit": 10000,
+				"credit": 0,
+				"gl_item_code": "CONDEP",
+				"party_type": "Supplier",
+				"party": "SUP-1",
+				"company": "Test Co",
+			},
+			{
+				"posting_date": "2026-05-30",
+				"voucher_type": "Journal Entry",
+				"voucher_no": "JE-1",
+				"account": "PENDING-ACC",
+				"debit": 0,
+				"credit": 5000,
+				"gl_item_code": "",
+				"party_type": "",
+				"party": "",
+				"company": "Test Co",
+			},
+		]
+		with patch(
+			"logistics.logistics.deposit_processing.container_gl_service._all_pending_refund_accounts",
+			return_value=["PENDING-ACC"],
+		):
+			with patch(
+				"logistics.logistics.deposit_processing.container_gl_service.get_gl_rows_split",
+				return_value=(deposit_rows, []),
+			):
+				with patch(
+					"logistics.logistics.deposit_processing.container_gl_service._refunded_purchase_invoices_for_container",
+					return_value=set(),
+				):
+					with patch(
+						"logistics.logistics.deposit_processing.container_gl_service._account_label",
+						side_effect=lambda acc: acc,
+					):
+						with patch(
+							"logistics.logistics.deposit_processing.container_gl_service._party_label",
+							return_value="Test Supplier",
+						):
+							with patch(
+								"frappe.db.get_value",
+								side_effect=lambda dt, name, field, *a, **k: {
+									("Company", "Test Co", "default_currency"): "PHP",
+								}.get((dt, name, field if isinstance(field, str) else tuple(field)))
+								if dt == "Company"
+								else None,
+							):
+								data = get_deposit_postings_data("TEST-CONT")
+		self.assertEqual(len(data["rows"]), 2)
+		self.assertEqual(data["rows"][0]["refund_status"], "Open")
+		self.assertEqual(data["rows"][1]["refund_status"], "Refunded")
+		self.assertEqual(data["items"], ["CONDEP"])
+
+	def test_get_deposit_postings_data_unconfigured(self):
+		with patch(
+			"logistics.logistics.deposit_processing.container_gl_service._all_pending_refund_accounts",
+			return_value=[],
+		):
+			data = get_deposit_postings_data("TEST-CONT")
+		self.assertTrue(data["error"])
+		self.assertEqual(data["rows"], [])

--- a/logistics/logistics/doctype/container/container.js
+++ b/logistics/logistics/doctype/container/container.js
@@ -134,14 +134,10 @@ frappe.ui.form.on("Container", {
 				}
 			},
 		});
-		frappe.call({
-			method: "logistics.logistics.doctype.container.container.get_deposits_gl_html",
-			args: { container: frm.doc.name },
-			callback: function (r) {
-				if (r.message && frm.fields_dict.deposits_gl_html) {
-					frm.fields_dict.deposits_gl_html.$wrapper.html(r.message);
-				}
-			},
+		frappe.require("/assets/logistics/js/container_deposit_postings.js", () => {
+			if (window.logistics && window.logistics.container_deposit_postings) {
+				window.logistics.container_deposit_postings.render(frm);
+			}
 		});
 		frappe.call({
 			method: "logistics.logistics.doctype.container.container.get_charges_gl_html",

--- a/logistics/logistics/doctype/container/container.json
+++ b/logistics/logistics/doctype/container/container.json
@@ -248,10 +248,10 @@
    "label": "Transaction Postings"
   },
   {
-   "description": "GL lines with **Container** dimension on **Deposits Pending for Refund Request** only (per-company Sea Freight Settings).",
+   "description": "GL lines on **Deposits Pending for Refund Request** with **Container Deposit Charge** Items only (per-company Sea Freight Settings).",
    "fieldname": "deposits_gl_html",
    "fieldtype": "HTML",
-   "label": "Deposit GL entries",
+   "label": "",
    "read_only": 1
   },
   {

--- a/logistics/logistics/doctype/container/container.py
+++ b/logistics/logistics/doctype/container/container.py
@@ -16,6 +16,7 @@ from logistics.logistics.deposit_processing.container_deposit_gl import (
 )
 from logistics.logistics.deposit_processing.container_gl_service import (
 	get_charges_gl_html as build_charges_gl_html,
+	get_deposit_postings_data as build_deposit_postings_data,
 	get_deposits_gl_html as build_deposits_gl_html,
 	sync_deposit_header_from_gl,
 )
@@ -191,6 +192,11 @@ def get_linked_transport_jobs_html(container):
 @frappe.whitelist()
 def get_deposits_gl_html(container):
 	return build_deposits_gl_html(container)
+
+
+@frappe.whitelist()
+def get_deposit_postings_data(container):
+	return build_deposit_postings_data(container)
 
 
 @frappe.whitelist()

--- a/logistics/mice/doctype/docket/docket.py
+++ b/logistics/mice/doctype/docket/docket.py
@@ -30,6 +30,9 @@ class Docket(VirtualLinkedServicesMixin, Document):
 		self._sync_customer_from_exhibit_organizer()
 		self._sync_exhibitor_metadata()
 		self._validate_unique_booth_no_on_exhibit()
+		from logistics.utils.document_date_validation import validate_planned_date_range
+
+		validate_planned_date_range(self)
 		self.validate_accounts()
 		self._sync_charges()
 

--- a/logistics/mice/doctype/mice_job/mice_job.json
+++ b/logistics/mice/doctype/mice_job/mice_job.json
@@ -339,7 +339,7 @@
   },
   {
    "fieldname": "shipper_address_display",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Shipper Address Display",
    "read_only": 1
   },
@@ -356,7 +356,7 @@
   },
   {
    "fieldname": "consignee_address_display",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Consignee Address Display",
    "read_only": 1
   },

--- a/logistics/mice/doctype/mice_job/mice_job.py
+++ b/logistics/mice/doctype/mice_job/mice_job.py
@@ -8,6 +8,9 @@ from frappe.model.document import Document
 
 class MICEJob(Document):
 	def validate(self):
+		from logistics.utils.document_date_validation import validate_planned_date_range
+
+		validate_planned_date_range(self)
 		self._sync_from_exhibit()
 
 	def _sync_from_exhibit(self):

--- a/logistics/mice/doctype/mice_project/mice_project.json
+++ b/logistics/mice/doctype/mice_project/mice_project.json
@@ -180,6 +180,7 @@
    "fieldname": "project_type",
    "fieldtype": "Link",
    "label": "Project Type",
+   "link_filters": "[[\"Project Type\", \"is_active\", \"=\", 1]]",
    "options": "Project Type"
   },
   {
@@ -188,6 +189,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Type",
+   "link_filters": "[[\"MICE Type\",\"is_active\",\"=\",1]]",
    "options": "MICE Type"
   },
   {
@@ -738,7 +740,7 @@
    "link_fieldname": "exhibit"
   }
  ],
- "modified": "2026-07-07 16:38:12.792894",
+ "modified": "2026-07-13 07:04:41.163326",
  "modified_by": "dee.sambrano@agilasoft.com",
  "module": "MICE",
  "name": "MICE Project",

--- a/logistics/mice/doctype/mice_project/mice_project.py
+++ b/logistics/mice/doctype/mice_project/mice_project.py
@@ -177,6 +177,9 @@ class MICEProject(Document):
 		self._honour_linked_services_form_rows()
 		self._ensure_org_defaults()
 		self._validate_org_accounts()
+		from logistics.utils.document_date_validation import validate_planned_date_range
+
+		validate_planned_date_range(self)
 		validate_internal_job_activity_codes(self, module_filter=FOR_EXHIBITS)
 		validate_lifecycle_stage_advance(self)
 		self._recalculate_consolidation_charge_rows()

--- a/logistics/mice/doctype/mice_project_charges/mice_project_charges.json
+++ b/logistics/mice/doctype/mice_project_charges/mice_project_charges.json
@@ -82,9 +82,11 @@
   "calculation_notes_section",
   "selling_weight_break",
   "selling_qty_break",
+  "selling_percentage_break",
   "column_break_calc_notes",
   "cost_weight_break",
   "cost_qty_break",
+  "cost_percentage_break",
   "section_break_status",
   "sales_invoice",
   "sales_invoice_status",
@@ -420,10 +422,22 @@
    "label": "Manage Selling Qty Breaks"
   },
   {
+   "depends_on": "eval:doc.revenue_calculation_method=='Percentage Break'",
+   "fieldname": "selling_percentage_break",
+   "fieldtype": "Button",
+   "label": "Manage Selling Percentage Breaks"
+  },
+  {
    "depends_on": "eval:doc.cost_calculation_method=='Qty Break'",
    "fieldname": "cost_qty_break",
    "fieldtype": "Button",
    "label": "Manage Cost Qty Breaks"
+  },
+  {
+   "depends_on": "eval:doc.cost_calculation_method=='Percentage Break'",
+   "fieldname": "cost_percentage_break",
+   "fieldtype": "Button",
+   "label": "Manage Cost Percentage Breaks"
   },
   {
    "fieldname": "section_break_calc",
@@ -441,7 +455,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Revenue Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break",
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break",
    "read_only_depends_on": "eval:['Cost','Disbursement'].includes(doc.charge_type)"
   },
   {
@@ -536,7 +550,7 @@
    "fieldname": "cost_calculation_method",
    "fieldtype": "Select",
    "label": "Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break",
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break",
    "read_only_depends_on": "eval:doc.charge_type == 'Revenue'"
   },
   {
@@ -732,7 +746,7 @@
    "label": "Item Name"
   },
   {
-   "description": "When the Item is a container-deposit charge, shows per-company Sea Freight Settings \u201cDeposits Pending for Refund Request\u201d for GL alignment. Set the same account on the Item Group / Item defaults as needed.",
+   "description": "When the Item is a container-deposit charge, shows per-company Sea Freight Settings “Deposits Pending for Refund Request” for GL alignment. Set the same account on the Item Group / Item defaults as needed.",
    "fieldname": "container_deposit_pending_refund_gl",
    "fieldtype": "Data",
    "label": "Deposit pending refund GL",
@@ -741,7 +755,7 @@
   {
    "fetch_from": "item_code.description",
    "fieldname": "description",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Description"
   },
   {

--- a/logistics/mice/doctype/mice_project_consolidation_charges/mice_project_consolidation_charges.json
+++ b/logistics/mice/doctype/mice_project_consolidation_charges/mice_project_consolidation_charges.json
@@ -69,7 +69,7 @@
   {
    "fetch_from": "item_code.description",
    "fieldname": "description",
-   "fieldtype": "Long Text",
+   "fieldtype": "Text Editor",
    "label": "Description"
   },
   {
@@ -121,7 +121,7 @@
    "fieldname": "unit_of_measure",
    "fieldtype": "Select",
    "label": "Unit of Measure",
-   "options": "docket\nexhibit\nbooth\nm\u00b2\nday\npackage\npiece\nhour"
+   "options": "docket\nexhibit\nbooth\nm²\nday\npackage\npiece\nhour"
   },
   {
    "fieldname": "column_break_2",

--- a/logistics/mice/doctype/mice_type/mice_type.json
+++ b/logistics/mice/doctype/mice_type/mice_type.json
@@ -8,7 +8,8 @@
  "engine": "InnoDB",
  "field_order": [
   "exhibit_type",
-  "description"
+  "description",
+  "is_active"
  ],
  "fields": [
   {
@@ -23,6 +24,14 @@
    "fieldname": "description",
    "fieldtype": "Text",
    "label": "Description"
+  },
+  {
+   "default": "1",
+   "fieldname": "is_active",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Is Active"
   }
  ],
  "index_web_pages_for_search": 1,

--- a/logistics/patches.txt
+++ b/logistics/patches.txt
@@ -328,3 +328,8 @@ logistics.patches.v3_0_migrate_cash_advance_settings_per_company
 logistics.patches.v3_0_ensure_cash_advance_settings_company_records
 # Cash Advance: seed default due date extension reason codes
 logistics.patches.v3_0_seed_cash_advance_reason_codes
+logistics.patches.v1_0_unset_freight_container_deposit_charge
+# Project Type: Is Active checkbox for filtering inactive types
+logistics.patches.v1_0_add_project_type_is_active
+# Charge calculation methods: add Percentage Break option on charge/rate DocTypes
+logistics.patches.v1_0_add_percentage_break_option

--- a/logistics/patches/v1_0_add_percentage_break_option.py
+++ b/logistics/patches/v1_0_add_percentage_break_option.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026, www.agilasoft.com and contributors
+"""Add Percentage Break option to calculation method fields on charge and rate doctypes."""
+
+import frappe
+
+CHARGE_DOCTYPES = [
+	"Air Booking Charges",
+	"Air Shipment Charges",
+	"Sea Booking Charges",
+	"Sea Shipment Charges",
+	"Sea Consolidation Charges",
+	"Transport Order Charges",
+	"Transport Job Charges",
+	"Declaration Charges",
+	"Declaration Order Charges",
+	"Sales Quote Charge",
+	"Tariff Charge",
+	"Change Request Charge",
+	"Special Project Charges",
+	"MICE Project Charges",
+	"Exhibit Charges",
+	"Air Freight Rate",
+	"Sea Freight Rate",
+	"Transport Rate",
+	"Customs Rate",
+	"Warehouse Rate",
+]
+
+METHOD_FIELDS = (
+	"calculation_method",
+	"cost_calculation_method",
+	"revenue_calculation_method",
+)
+
+
+def execute():
+	for dt in CHARGE_DOCTYPES:
+		if not frappe.db.exists("DocType", dt):
+			continue
+		meta = frappe.get_meta(dt)
+		updated = False
+		for fieldname in METHOD_FIELDS:
+			field = meta.get_field(fieldname)
+			if not field or not field.options:
+				continue
+			opts = field.options or ""
+			if "Percentage Break" in opts:
+				continue
+			new_opts = opts.rstrip() + "\nPercentage Break"
+			frappe.db.set_value(
+				"DocField",
+				{"parent": dt, "fieldname": fieldname},
+				"options",
+				new_opts,
+			)
+			updated = True
+		if updated:
+			frappe.clear_cache(doctype=dt)
+	frappe.db.commit()

--- a/logistics/patches/v1_0_add_project_type_is_active.py
+++ b/logistics/patches/v1_0_add_project_type_is_active.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2026, Agilasoft and contributors
+# For license information, please see license.txt
+
+"""Add Is Active checkbox to ERPNext Project Type."""
+
+from __future__ import unicode_literals
+
+import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
+
+def execute():
+	if not frappe.db.exists("DocType", "Project Type"):
+		return
+
+	create_custom_fields(
+		{
+			"Project Type": [
+				{
+					"fieldname": "is_active",
+					"fieldtype": "Check",
+					"label": "Is Active",
+					"default": "1",
+					"insert_after": "description",
+					"in_list_view": 1,
+					"in_standard_filter": 1,
+				},
+			]
+		},
+		update=True,
+	)
+
+	frappe.db.sql(
+		"UPDATE `tabProject Type` SET is_active = 1 WHERE IFNULL(is_active, 0) = 0"
+	)
+	frappe.clear_cache(doctype="Project Type")

--- a/logistics/patches/v1_0_unset_freight_container_deposit_charge.py
+++ b/logistics/patches/v1_0_unset_freight_container_deposit_charge.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+"""Unset Container Deposit Charge on FREIGHT — sea freight cost item, not a container deposit."""
+
+from __future__ import unicode_literals
+
+import frappe
+
+
+def execute():
+	if not frappe.db.has_column("Item", "custom_container_deposit_charge"):
+		return
+	if not frappe.db.exists("Item", "FREIGHT"):
+		return
+	if not frappe.db.get_value("Item", "FREIGHT", "custom_container_deposit_charge"):
+		return
+	frappe.db.set_value("Item", "FREIGHT", "custom_container_deposit_charge", 0, update_modified=False)

--- a/logistics/pricing_center/doctype/air_freight_rate/air_freight_rate.json
+++ b/logistics/pricing_center/doctype/air_freight_rate/air_freight_rate.json
@@ -79,7 +79,7 @@
    "fieldname": "calculation_method",
    "fieldtype": "Select",
    "label": "Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break",
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break",
    "reqd": 1
   },
   {
@@ -159,7 +159,7 @@
   {
    "fieldname": "volume_m3",
    "fieldtype": "Float",
-   "label": "Volume (m\u00b3)"
+   "label": "Volume (m³)"
   },
   {
    "fieldname": "packages",

--- a/logistics/pricing_center/doctype/change_request_charge/change_request_charge.json
+++ b/logistics/pricing_center/doctype/change_request_charge/change_request_charge.json
@@ -124,7 +124,7 @@
   {
    "fetch_from": "item_code.description",
    "fieldname": "description",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Description"
   },
   {
@@ -483,7 +483,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break",
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break",
    "read_only_depends_on": "eval:doc.charge_type == \"Cost\""
   },
   {
@@ -575,7 +575,7 @@
    "fieldname": "cost_calculation_method",
    "fieldtype": "Select",
    "label": "Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break",
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break",
    "read_only_depends_on": "eval:doc.charge_type == \"Revenue\""
   },
   {

--- a/logistics/pricing_center/doctype/cost_sheet_charge/cost_sheet_charge.json
+++ b/logistics/pricing_center/doctype/cost_sheet_charge/cost_sheet_charge.json
@@ -83,7 +83,7 @@
   {
    "fetch_from": "item_code.description",
    "fieldname": "description",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Description"
   },
   {

--- a/logistics/pricing_center/doctype/customs_rate/customs_rate.json
+++ b/logistics/pricing_center/doctype/customs_rate/customs_rate.json
@@ -79,7 +79,7 @@
    "fieldname": "calculation_method",
    "fieldtype": "Select",
    "label": "Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break",
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break",
    "reqd": 1
   },
   {
@@ -159,7 +159,7 @@
   {
    "fieldname": "volume_m3",
    "fieldtype": "Float",
-   "label": "Volume (m\u00b3)"
+   "label": "Volume (m³)"
   },
   {
    "fieldname": "packages",

--- a/logistics/pricing_center/doctype/sales_quote/sales_quote.js
+++ b/logistics/pricing_center/doctype/sales_quote/sales_quote.js
@@ -45,10 +45,13 @@ function logistics_canonical_charge_service_type(st) {
 	return low;
 }
 
+/** Load Type module flags exist only for air/sea/transport/customs/warehousing. */
+const LOGISTICS_LOAD_TYPE_FLAGS_WITHOUT_MODULE = new Set(["special project", "exhibits"]);
+
 /** Load Type DocType checkbox field for service_type (custom → customs). */
 function logistics_load_type_flag_for_charge_service_type(st) {
 	const c = logistics_canonical_charge_service_type(st);
-	if (!c) return null;
+	if (!c || LOGISTICS_LOAD_TYPE_FLAGS_WITHOUT_MODULE.has(c)) return null;
 	if (c === "custom") return "customs";
 	return c;
 }
@@ -1099,10 +1102,12 @@ frappe.ui.form.on("Sales Quote", {
 			frm.set_df_property("quotation_type", "read_only", 0);
 		}
 		
-		// Delegated click handler for Weight/Qty Break buttons (bypasses form event system if needed)
+		// Delegated click handler for Weight/Qty/Percentage Break buttons (bypasses form event system if needed)
 		$(frm.wrapper).off("click.break_buttons").on("click.break_buttons", function (e) {
 			const $ctrl = $(e.target).closest(
-				'[data-fieldname="selling_qty_break"], [data-fieldname="cost_qty_break"]'
+				'[data-fieldname="selling_qty_break"], [data-fieldname="cost_qty_break"],' +
+					'[data-fieldname="selling_weight_break"], [data-fieldname="cost_weight_break"],' +
+					'[data-fieldname="selling_percentage_break"], [data-fieldname="cost_percentage_break"]'
 			);
 			if (!$ctrl.length) return;
 			const fieldname = $ctrl.attr("data-fieldname");
@@ -1133,6 +1138,16 @@ frappe.ui.form.on("Sales Quote", {
 			const record_type = fieldname.indexOf("cost_") === 0 ? "Cost" : "Selling";
 			if (fieldname.indexOf("qty_break") !== -1 && typeof window.open_qty_break_rate_dialog === "function") {
 				window.open_qty_break_rate_dialog(frm, row_doc, record_type);
+			} else if (
+				fieldname.indexOf("weight_break") !== -1 &&
+				typeof window.open_weight_break_rate_dialog === "function"
+			) {
+				window.open_weight_break_rate_dialog(frm, row_doc, record_type);
+			} else if (
+				fieldname.indexOf("percentage_break") !== -1 &&
+				typeof window.open_percentage_break_rate_dialog === "function"
+			) {
+				window.open_percentage_break_rate_dialog(frm, row_doc, record_type);
 			} else {
 				frappe.msgprint({ title: __("Error"), message: __("Dialog not loaded. Please refresh the page."), indicator: "red" });
 			}

--- a/logistics/pricing_center/doctype/sales_quote/sales_quote.json
+++ b/logistics/pricing_center/doctype/sales_quote/sales_quote.json
@@ -254,7 +254,7 @@
   },
   {
    "fieldname": "shipper_address_display",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Shipper Address Display",
    "read_only": 1
   },
@@ -282,7 +282,7 @@
   },
   {
    "fieldname": "consignee_address_display",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Consignee Address Display",
    "read_only": 1
   },
@@ -518,7 +518,7 @@
    "label": "Planned End"
   },
   {
-   "depends_on": "eval:doc.quotation_type == \"Project\" || doc.main_service == \"Special Project\"",
+   "depends_on": "eval:doc.quotation_type == \"Project\" || [\"Special Project\", \"MICE\"].includes(doc.main_service)",
    "fieldname": "sp_programme_details_section",
    "fieldtype": "Section Break",
    "label": "Details"
@@ -791,7 +791,6 @@
    "fieldtype": "Section Break",
    "label": "Terms and Conditions"
   },
-
   {
    "fieldname": "tc_name",
    "fieldtype": "Link",

--- a/logistics/pricing_center/doctype/sales_quote/sales_quote.py
+++ b/logistics/pricing_center/doctype/sales_quote/sales_quote.py
@@ -423,6 +423,7 @@ class SalesQuote(Document):
 		self.validate_direction_ports()
 		self.validate_freight_agent_locations()
 		self.validate_programme_required_parameters()
+		self.validate_planned_dates()
 		self.validate_additional_charge_job()
 		self.validate_load_type_matches_service()
 		self.validate_transport_mode_matches_service()
@@ -439,6 +440,20 @@ class SalesQuote(Document):
 		from logistics.utils.operational_exchange_rates import resolve_sales_quote_charge_exchange_rates
 
 		resolve_sales_quote_charge_exchange_rates(self)
+
+	def validate_planned_dates(self):
+		"""Hard-block inverted Planned Start/End; soft-warn when window ends before quote date."""
+		from logistics.utils.document_date_validation import (
+			validate_planned_date_range,
+			warn_if_planned_end_before_reference,
+		)
+
+		validate_planned_date_range(self)
+		warn_if_planned_end_before_reference(
+			self,
+			reference_field="date",
+			reference_label=_("Quote Date"),
+		)
 
 	def refresh_charge_parameters_display(self):
 		"""Populate read-only parameters text on charge rows from tagged services."""

--- a/logistics/pricing_center/doctype/sales_quote_charge/sales_quote_charge.json
+++ b/logistics/pricing_center/doctype/sales_quote_charge/sales_quote_charge.json
@@ -72,10 +72,12 @@
   "selling_unit_break",
   "selling_weight_break",
   "selling_qty_break",
+  "selling_percentage_break",
   "column_break_calc_notes",
   "cost_unit_break",
   "cost_weight_break",
-  "cost_qty_break"
+  "cost_qty_break",
+  "cost_percentage_break"
  ],
  "fields": [
   {
@@ -111,7 +113,7 @@
    "fetch_from": "item_code.description",
    "fetch_if_empty": 1,
    "fieldname": "description",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Description"
   },
   {
@@ -354,7 +356,7 @@
    "fieldname": "cost_calculation_method",
    "fieldtype": "Select",
    "label": "Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break",
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break",
    "read_only_depends_on": "eval:doc.charge_type == \"Revenue\""
   },
   {
@@ -465,6 +467,12 @@
    "label": "Manage Selling Qty Breaks"
   },
   {
+   "depends_on": "eval:doc.revenue_calculation_method=='Percentage Break'",
+   "fieldname": "selling_percentage_break",
+   "fieldtype": "Button",
+   "label": "Manage Selling Percentage Breaks"
+  },
+  {
    "fieldname": "column_break_calc_notes",
    "fieldtype": "Column Break"
   },
@@ -493,6 +501,12 @@
    "label": "Manage Cost Qty Breaks"
   },
   {
+   "depends_on": "eval:doc.cost_calculation_method=='Percentage Break'",
+   "fieldname": "cost_percentage_break",
+   "fieldtype": "Button",
+   "label": "Manage Cost Percentage Breaks"
+  },
+  {
    "fieldname": "cost_sheet_source",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -518,7 +532,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Revenue Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break",
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break",
    "read_only_depends_on": "eval:['Cost','Disbursement'].includes(doc.charge_type)"
   },
   {

--- a/logistics/pricing_center/doctype/sales_quote_percentage_break/sales_quote_percentage_break.js
+++ b/logistics/pricing_center/doctype/sales_quote_percentage_break/sales_quote_percentage_break.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2026, www.agilasoft.com and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Sales Quote Percentage Break", {
+// 	refresh(frm) {
+//
+// 	},
+// });

--- a/logistics/pricing_center/doctype/sales_quote_percentage_break/sales_quote_percentage_break.json
+++ b/logistics/pricing_center/doctype/sales_quote_percentage_break/sales_quote_percentage_break.json
@@ -1,0 +1,90 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-07-13 00:00:00",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "reference_doctype",
+  "reference_no",
+  "type",
+  "rate_type",
+  "value_break",
+  "percentage_rate",
+  "currency"
+ ],
+ "fields": [
+  {
+   "fieldname": "reference_doctype",
+   "fieldtype": "Link",
+   "label": "Reference Doctype",
+   "options": "DocType"
+  },
+  {
+   "fieldname": "reference_no",
+   "fieldtype": "Dynamic Link",
+   "label": "Reference No",
+   "options": "reference_doctype"
+  },
+  {
+   "fieldname": "type",
+   "fieldtype": "Select",
+   "label": "Type",
+   "options": "Selling\nCost"
+  },
+  {
+   "fieldname": "rate_type",
+   "fieldtype": "Select",
+   "label": "Break Type",
+   "options": "M (Minimum)\nN (Normal)\nQ (Quantity Break)",
+   "in_list_view": 1
+  },
+  {
+   "fieldname": "value_break",
+   "fieldtype": "Float",
+   "label": "Value Break",
+   "in_list_view": 1
+  },
+  {
+   "fieldname": "percentage_rate",
+   "fieldtype": "Float",
+   "label": "Percentage Rate",
+   "in_list_view": 1
+  },
+  {
+   "fieldname": "currency",
+   "fieldtype": "Link",
+   "label": "Currency",
+   "options": "Currency",
+   "in_list_view": 1,
+   "link_filters": "[[\"Currency\", \"enabled\", \"=\", 1]]"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-07-13 00:00:00",
+ "modified_by": "Administrator",
+ "module": "Pricing Center",
+ "name": "Sales Quote Percentage Break",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/logistics/pricing_center/doctype/sales_quote_percentage_break/sales_quote_percentage_break.py
+++ b/logistics/pricing_center/doctype/sales_quote_percentage_break/sales_quote_percentage_break.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026, www.agilasoft.com and contributors
+# For license information, please see license.txt
+
+import json
+
+import frappe
+from frappe.model.document import Document
+from frappe.utils import flt
+
+
+class SalesQuotePercentageBreak(Document):
+	pass
+
+
+@frappe.whitelist()
+def save_percentage_breaks_for_reference(reference_doctype, reference_no, percentage_breaks, record_type):
+	"""Save percentage break records for any charge reference doctype."""
+	try:
+		if not reference_doctype or not reference_no:
+			return {"success": False, "error": "Reference doctype and reference no are required"}
+
+		if isinstance(percentage_breaks, str):
+			percentage_breaks = json.loads(percentage_breaks) if percentage_breaks else []
+
+		frappe.db.delete(
+			"Sales Quote Percentage Break",
+			{"reference_doctype": reference_doctype, "reference_no": reference_no, "type": record_type},
+		)
+		for pb in percentage_breaks or []:
+			if not pb.get("value_break") and not pb.get("percentage_rate"):
+				continue
+			doc = frappe.new_doc("Sales Quote Percentage Break")
+			doc.reference_doctype = reference_doctype
+			doc.reference_no = reference_no
+			doc.type = record_type
+			doc.rate_type = pb.get("rate_type") or "N (Normal)"
+			doc.value_break = flt(pb.get("value_break", 0))
+			doc.percentage_rate = flt(pb.get("percentage_rate", 0))
+			doc.currency = pb.get("currency") or "USD"
+			doc.insert(ignore_permissions=True)
+		frappe.db.commit()
+		return {"success": True}
+	except Exception as e:
+		frappe.log_error(f"Error saving percentage breaks: {str(e)}")
+		return {"success": False, "error": str(e)}
+
+
+@frappe.whitelist()
+def get_percentage_breaks(reference_doctype, reference_no, record_type="Selling"):
+	"""Get list of percentage break records for a reference (for dialog editing)."""
+	try:
+		if not reference_doctype or not reference_no:
+			return {"success": False, "percentage_breaks": []}
+		percentage_breaks = frappe.get_all(
+			"Sales Quote Percentage Break",
+			filters={
+				"reference_doctype": reference_doctype,
+				"reference_no": reference_no,
+				"type": record_type,
+			},
+			fields=["value_break", "percentage_rate", "rate_type", "currency"],
+			order_by="value_break asc",
+		)
+		return {"success": True, "percentage_breaks": percentage_breaks or []}
+	except Exception as e:
+		frappe.log_error(f"Error getting percentage breaks: {str(e)}")
+		return {"success": False, "percentage_breaks": []}

--- a/logistics/pricing_center/doctype/sales_quote_percentage_break/test_sales_quote_percentage_break.py
+++ b/logistics/pricing_center/doctype/sales_quote_percentage_break/test_sales_quote_percentage_break.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026, www.agilasoft.com and Contributors
+# See license.txt
+
+from frappe.tests import IntegrationTestCase
+
+EXTRA_TEST_RECORD_DEPENDENCIES = []
+IGNORE_TEST_RECORD_DEPENDENCIES = []
+
+
+class IntegrationTestSalesQuotePercentageBreak(IntegrationTestCase):
+	"""Integration tests for SalesQuotePercentageBreak."""
+
+	pass

--- a/logistics/pricing_center/doctype/sea_freight_rate/sea_freight_rate.json
+++ b/logistics/pricing_center/doctype/sea_freight_rate/sea_freight_rate.json
@@ -79,7 +79,7 @@
    "fieldname": "calculation_method",
    "fieldtype": "Select",
    "label": "Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break",
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break",
    "reqd": 1
   },
   {
@@ -165,7 +165,7 @@
   {
    "fieldname": "volume_m3",
    "fieldtype": "Float",
-   "label": "Volume (m\u00b3)"
+   "label": "Volume (m³)"
   },
   {
    "fieldname": "packages",

--- a/logistics/pricing_center/doctype/tariff/tariff.js
+++ b/logistics/pricing_center/doctype/tariff/tariff.js
@@ -3,7 +3,7 @@
 
 // Aligned with Sales Quote Charge: revenue_calculation_method / cost_calculation_method (same order and labels).
 const SALES_QUOTE_CALCULATION_METHOD_OPTIONS =
-	"Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break";
+	"Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break";
 
 frappe.ui.form.on('Tariff', {
 	refresh: function (frm) {

--- a/logistics/pricing_center/doctype/tariff_charge/tariff_charge.json
+++ b/logistics/pricing_center/doctype/tariff_charge/tariff_charge.json
@@ -92,9 +92,11 @@
   "section_break_weight_breaks",
   "selling_weight_break",
   "selling_qty_break",
+  "selling_percentage_break",
   "column_break_calc_notes",
   "cost_weight_break",
-  "cost_qty_break"
+  "cost_qty_break",
+  "cost_percentage_break"
  ],
  "fields": [
   {
@@ -146,7 +148,7 @@
   {
    "fetch_from": "item_code.description",
    "fieldname": "description",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Description"
   },
   {
@@ -559,7 +561,7 @@
    "fieldname": "cost_calculation_method",
    "fieldtype": "Select",
    "label": "Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break",
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break",
    "read_only_depends_on": "eval:doc.charge_type == \"Revenue\""
   },
   {
@@ -658,6 +660,12 @@
    "label": "Manage Selling Qty Breaks"
   },
   {
+   "depends_on": "eval:doc.revenue_calculation_method=='Percentage Break'",
+   "fieldname": "selling_percentage_break",
+   "fieldtype": "Button",
+   "label": "Manage Selling Percentage Breaks"
+  },
+  {
    "fieldname": "column_break_calc_notes",
    "fieldtype": "Column Break"
   },
@@ -672,6 +680,12 @@
    "fieldname": "cost_qty_break",
    "fieldtype": "Button",
    "label": "Manage Cost Qty Breaks"
+  },
+  {
+   "depends_on": "eval:doc.cost_calculation_method=='Percentage Break'",
+   "fieldname": "cost_percentage_break",
+   "fieldtype": "Button",
+   "label": "Manage Cost Percentage Breaks"
   },
   {
    "fieldname": "cost_sheet_source",
@@ -699,7 +713,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Revenue Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break",
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break",
    "read_only_depends_on": "eval:['Cost','Disbursement'].includes(doc.charge_type)"
   }
  ],

--- a/logistics/pricing_center/doctype/transport_job_charges/transport_job_charges.json
+++ b/logistics/pricing_center/doctype/transport_job_charges/transport_job_charges.json
@@ -75,9 +75,11 @@
   "weight_breaks_section",
   "selling_weight_break",
   "selling_qty_break",
+  "selling_percentage_break",
   "column_break_calc_notes",
   "cost_weight_break",
   "cost_qty_break",
+  "cost_percentage_break",
   "section_break_status",
   "sales_invoice",
   "sales_invoice_status",
@@ -260,7 +262,7 @@
   {
    "fetch_from": "item_code.description",
    "fieldname": "description",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Description"
   },
   {
@@ -278,7 +280,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Revenue Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break",
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break",
    "read_only_depends_on": "eval:['Cost','Disbursement'].includes(doc.charge_type)",
    "reqd": 1
   },
@@ -419,7 +421,7 @@
    "fieldname": "cost_calculation_method",
    "fieldtype": "Select",
    "label": "Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break",
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break",
    "read_only_depends_on": "eval:doc.charge_type == 'Revenue'"
   },
   {
@@ -581,10 +583,22 @@
    "label": "Manage Selling Qty Breaks"
   },
   {
+   "depends_on": "eval:doc.revenue_calculation_method=='Percentage Break'",
+   "fieldname": "selling_percentage_break",
+   "fieldtype": "Button",
+   "label": "Manage Selling Percentage Breaks"
+  },
+  {
    "depends_on": "eval:doc.cost_calculation_method=='Qty Break'",
    "fieldname": "cost_qty_break",
    "fieldtype": "Button",
    "label": "Manage Cost Qty Breaks"
+  },
+  {
+   "depends_on": "eval:doc.cost_calculation_method=='Percentage Break'",
+   "fieldname": "cost_percentage_break",
+   "fieldtype": "Button",
+   "label": "Manage Cost Percentage Breaks"
   },
   {
    "default": "0",
@@ -727,7 +741,7 @@
    "read_only": 1
   },
   {
-   "description": "Total standard cost (quantity \u00d7 standard unit cost)",
+   "description": "Total standard cost (quantity × standard unit cost)",
    "fieldname": "total_standard_cost",
    "fieldtype": "Currency",
    "label": "Total Standard Cost",

--- a/logistics/pricing_center/doctype/transport_order_charges/transport_order_charges.json
+++ b/logistics/pricing_center/doctype/transport_order_charges/transport_order_charges.json
@@ -72,9 +72,11 @@
   "weight_breaks_section",
   "selling_weight_break",
   "selling_qty_break",
+  "selling_percentage_break",
   "column_break_calc_notes",
   "cost_weight_break",
   "cost_qty_break",
+  "cost_percentage_break",
   "other_services_section",
   "other_service_type",
   "date_started",
@@ -203,7 +205,7 @@
   {
    "fetch_from": "item_code.description",
    "fieldname": "description",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Description"
   },
   {
@@ -279,7 +281,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break",
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break",
    "read_only_depends_on": "eval:['Cost','Disbursement'].includes(doc.charge_type)"
   },
   {
@@ -362,7 +364,7 @@
    "fieldname": "cost_calculation_method",
    "fieldtype": "Select",
    "label": "Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break",
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break",
    "read_only_depends_on": "eval:doc.charge_type == 'Revenue'"
   },
   {
@@ -474,10 +476,22 @@
    "label": "Manage Selling Qty Breaks"
   },
   {
+   "depends_on": "eval:doc.revenue_calculation_method=='Percentage Break'",
+   "fieldname": "selling_percentage_break",
+   "fieldtype": "Button",
+   "label": "Manage Selling Percentage Breaks"
+  },
+  {
    "depends_on": "eval:doc.cost_calculation_method=='Qty Break'",
    "fieldname": "cost_qty_break",
    "fieldtype": "Button",
    "label": "Manage Cost Qty Breaks"
+  },
+  {
+   "depends_on": "eval:doc.cost_calculation_method=='Percentage Break'",
+   "fieldname": "cost_percentage_break",
+   "fieldtype": "Button",
+   "label": "Manage Cost Percentage Breaks"
   },
   {
    "fieldname": "revenue_column",

--- a/logistics/pricing_center/doctype/transport_rate/transport_rate.json
+++ b/logistics/pricing_center/doctype/transport_rate/transport_rate.json
@@ -62,7 +62,7 @@
    "fieldname": "calculation_method",
    "fieldtype": "Select",
    "label": "Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break",
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break",
    "reqd": 1
   },
   {

--- a/logistics/pricing_center/doctype/warehouse_rate/warehouse_rate.json
+++ b/logistics/pricing_center/doctype/warehouse_rate/warehouse_rate.json
@@ -153,7 +153,7 @@
    "fieldname": "calculation_method",
    "fieldtype": "Select",
    "label": "Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break",
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break",
    "reqd": 1
   },
   {

--- a/logistics/public/js/charge_break_buttons.js
+++ b/logistics/public/js/charge_break_buttons.js
@@ -1,6 +1,6 @@
 // Copyright (c) 2026, www.agilasoft.com and contributors
 // For license information, please see license.txt
-// Weight Break / Qty Break: grid toolbar buttons + row buttons → dialogs.
+// Weight Break / Qty Break / Percentage Break: grid toolbar buttons + row buttons → dialogs.
 // Child tables are detected via LOGISTICS_CHARGE_DOCTYPES_WITH_BREAKS and meta (see charge_break_dialogs.js).
 
 var CHARGE_DOCTYPES_WITH_BREAKS =
@@ -10,7 +10,10 @@ var CHARGE_DOCTYPES_WITH_BREAKS =
 		["Air Booking Charges", "Air Shipment Charges"],
 		["Declaration Charges", "Declaration Order Charges"],
 		["Transport Order Charges", "Transport Job Charges"],
-		["Special Project Charges"]
+		["Special Project Charges"],
+		["Sales Quote Charge", "Tariff Charge"],
+		["MICE Project Charges", "Exhibit Charges"],
+		["Change Request Charge"]
 	);
 
 var CHARGE_PARENT_DOCTYPES = [
@@ -27,6 +30,9 @@ var CHARGE_PARENT_DOCTYPES = [
 	"Special Project",
 	"Sales Quote",
 	"Tariff",
+	"MICE Project",
+	"Exhibit",
+	"Change Request",
 ];
 
 function _register_break_handlers(doctype) {
@@ -87,6 +93,36 @@ function _register_break_handlers(doctype) {
 				frappe.msgprint({
 					title: __("Error"),
 					message: __("Qty Break dialog is not loaded. Please refresh the page."),
+					indicator: "red",
+				});
+			}
+		},
+		selling_percentage_break: function(frm, cdt, cdn) {
+			var row = cdn && cdt ? frappe.get_doc(cdt, cdn) : frm && frm.selected_doc ? frm.selected_doc : null;
+			if (!row) {
+				return;
+			}
+			if (typeof window.open_percentage_break_rate_dialog === "function") {
+				window.open_percentage_break_rate_dialog(frm, row, "Selling");
+			} else {
+				frappe.msgprint({
+					title: __("Error"),
+					message: __("Percentage Break dialog is not loaded. Please refresh the page."),
+					indicator: "red",
+				});
+			}
+		},
+		cost_percentage_break: function(frm, cdt, cdn) {
+			var row = cdn && cdt ? frappe.get_doc(cdt, cdn) : frm && frm.selected_doc ? frm.selected_doc : null;
+			if (!row) {
+				return;
+			}
+			if (typeof window.open_percentage_break_rate_dialog === "function") {
+				window.open_percentage_break_rate_dialog(frm, row, "Cost");
+			} else {
+				frappe.msgprint({
+					title: __("Error"),
+					message: __("Percentage Break dialog is not loaded. Please refresh the page."),
 					indicator: "red",
 				});
 			}
@@ -185,6 +221,19 @@ function _qty_break_side_for_child_doctype(dt) {
 	return "Selling";
 }
 
+function _percentage_break_side_for_child_doctype(dt) {
+	if (!dt || !frappe.meta.docfield_map || !frappe.meta.docfield_map[dt]) {
+		return "Selling";
+	}
+	var m = frappe.meta.docfield_map[dt];
+	var sp = m.selling_percentage_break && m.selling_percentage_break.fieldtype === "Button";
+	var cp = m.cost_percentage_break && m.cost_percentage_break.fieldtype === "Button";
+	if (cp && !sp) {
+		return "Cost";
+	}
+	return "Selling";
+}
+
 function _unit_break_side_for_child_doctype(dt) {
 	if (!dt || !frappe.meta.docfield_map || !frappe.meta.docfield_map[dt]) {
 		return "Selling";
@@ -219,6 +268,12 @@ function _grid_is_logistics_charge_breaks_table(grid) {
 		return true;
 	}
 	if (
+		window.logistics_charge_child_doctype_has_percentage_break_buttons &&
+		window.logistics_charge_child_doctype_has_percentage_break_buttons(dt)
+	) {
+		return true;
+	}
+	if (
 		window.logistics_charge_child_doctype_has_unit_break_buttons &&
 		window.logistics_charge_child_doctype_has_unit_break_buttons(dt)
 	) {
@@ -243,8 +298,9 @@ function _add_break_buttons_to_charge_grid(frm) {
 		}
 		var $wb = $custom.find(".btn-weight-break-mgr");
 		var $qb = $custom.find(".btn-qty-break-mgr");
+		var $pb = $custom.find(".btn-percentage-break-mgr");
 		var $ub = $custom.find(".btn-unit-break-mgr");
-		if ($wb.length && $qb.length && $ub.length) {
+		if ($wb.length && $qb.length && $pb.length && $ub.length) {
 			return;
 		}
 		if (!$wb.length) {
@@ -280,6 +336,28 @@ function _add_break_buttons_to_charge_grid(frm) {
 				}
 			});
 			$custom.append($qb);
+		}
+		if (!$pb.length) {
+			$pb = $(
+				'<button type="button" class="btn btn-xs btn-default btn-percentage-break-mgr">' +
+					__("Manage Percentage Breaks") +
+					"</button>"
+			);
+			$pb.on("click", function() {
+				var row = _get_selected_charge_row(frm, item.fieldname);
+				if (row) {
+					var pbSide = _percentage_break_side_for_child_doctype(grid.doctype);
+					window.open_percentage_break_rate_dialog &&
+						window.open_percentage_break_rate_dialog(frm, row, pbSide);
+				} else {
+					frappe.msgprint({
+						title: __("Select Row"),
+						message: __("Please select a charge row first (click on the row)."),
+						indicator: "orange",
+					});
+				}
+			});
+			$custom.append($pb);
 		}
 		if (!$ub.length) {
 			$ub = $(

--- a/logistics/public/js/charge_break_dialogs.js
+++ b/logistics/public/js/charge_break_dialogs.js
@@ -1,6 +1,6 @@
 // Copyright (c) 2026, www.agilasoft.com and contributors
-// Weight Break and Qty Break dialogs - loaded first for Sales Quote and charge doctypes
-// Shared weight-break / qty-break editor markup and dialogs (see charge_break_buttons.js for grid + row buttons).
+// Weight Break, Qty Break, and Percentage Break dialogs - loaded first for Sales Quote and charge doctypes
+// Shared break editor markup and dialogs (see charge_break_buttons.js for grid + row buttons).
 
 (function() {
 	"use strict";
@@ -21,26 +21,28 @@
 	window.LOGISTICS_SPECIAL_PROJECT_CHARGE_DOCTYPES = ["Special Project Charges"];
 	/** Pricing — unified quote charge rows (same break UX as Sea Booking Charges). */
 	window.LOGISTICS_PRICING_CHARGE_DOCTYPES = ["Sales Quote Charge", "Tariff Charge"];
-
+	window.LOGISTICS_MICE_CHARGE_DOCTYPES = ["MICE Project Charges"];
+	window.LOGISTICS_EXHIBIT_CHARGE_DOCTYPES = ["Exhibit Charges"];
 	window.LOGISTICS_CHARGE_DOCTYPES_WITH_BREAKS = [].concat(
 		window.LOGISTICS_SEA_FREIGHT_CHARGE_DOCTYPES,
 		window.LOGISTICS_AIR_FREIGHT_CHARGE_DOCTYPES,
 		window.LOGISTICS_CUSTOMS_CHARGE_DOCTYPES,
 		window.LOGISTICS_TRANSPORT_CHARGE_DOCTYPES,
 		window.LOGISTICS_SPECIAL_PROJECT_CHARGE_DOCTYPES,
-		window.LOGISTICS_PRICING_CHARGE_DOCTYPES
+		window.LOGISTICS_PRICING_CHARGE_DOCTYPES,
+		window.LOGISTICS_MICE_CHARGE_DOCTYPES,
+		window.LOGISTICS_EXHIBIT_CHARGE_DOCTYPES,
+		["Change Request Charge"]
 	);
-	/** Warehousing / MICE charge child tables (linked_service scope, no break buttons). */
+	/** Warehousing charge child tables (linked_service scope). */
 	window.LOGISTICS_WAREHOUSING_CHARGE_DOCTYPES = [
 		"Warehouse Job Charges",
 		"Inbound Order Charges",
 		"Release Order Charges",
 	];
-	window.LOGISTICS_MICE_CHARGE_DOCTYPES = ["MICE Project Charges"];
 	window.LOGISTICS_CHARGE_DOCTYPES_WITH_LINKED_SCOPE = [].concat(
 		window.LOGISTICS_CHARGE_DOCTYPES_WITH_BREAKS,
-		window.LOGISTICS_WAREHOUSING_CHARGE_DOCTYPES,
-		window.LOGISTICS_MICE_CHARGE_DOCTYPES
+		window.LOGISTICS_WAREHOUSING_CHARGE_DOCTYPES
 	);
 
 	/** Any child DocType that ships freight-style weight-break row buttons (reference → Sales Quote Weight Break). */
@@ -63,6 +65,17 @@
 		var sq = m.selling_qty_break;
 		var cq = m.cost_qty_break;
 		return (sq && sq.fieldtype === "Button") || (cq && cq.fieldtype === "Button");
+	};
+
+	/** Same pattern for percentage-break row buttons. */
+	window.logistics_charge_child_doctype_has_percentage_break_buttons = function(dt) {
+		if (!dt || !frappe.meta.docfield_map || !frappe.meta.docfield_map[dt]) {
+			return false;
+		}
+		var m = frappe.meta.docfield_map[dt];
+		var sp = m.selling_percentage_break;
+		var cp = m.cost_percentage_break;
+		return (sp && sp.fieldtype === "Button") || (cp && cp.fieldtype === "Button");
 	};
 
 	/** Unit-break row buttons (checkbox-driven). */
@@ -504,6 +517,169 @@
 		});
 	};
 
+	window.open_percentage_break_rate_dialog = function(frm, row, record_type) {
+		record_type = record_type || "Selling";
+		var reference_doctype = _pricing_charge_reference_doctype_from_row(row);
+		var reference_no = row.name;
+		if (!reference_no || reference_no === "new" || String(reference_no).startsWith("new-")) {
+			frappe.msgprint({
+				title: __("Save Required"),
+				message: __("Please save the document first before managing percentage breaks."),
+				indicator: "orange",
+			});
+			return;
+		}
+		frappe.call({
+			method: "logistics.pricing_center.doctype.sales_quote_percentage_break.sales_quote_percentage_break.get_percentage_breaks",
+			args: { reference_doctype: reference_doctype, reference_no: reference_no, record_type: record_type },
+			callback: function(r) {
+				if (!r.message || !r.message.success) {
+					frappe.msgprint({ title: __("Error"), message: __("Could not load percentage breaks."), indicator: "red" });
+					return;
+				}
+				var percentage_breaks = r.message.percentage_breaks || [];
+				var currency =
+					record_type === "Cost"
+						? row.cost_currency || row.currency || "USD"
+						: row.currency || row.cost_currency || "USD";
+				var table_data =
+					percentage_breaks.length > 0
+						? percentage_breaks.map(function(pb) {
+								return {
+									rate_type: pb.rate_type || "N (Normal)",
+									value_break: pb.value_break,
+									percentage_rate: pb.percentage_rate,
+									currency: pb.currency || currency,
+								};
+						  })
+						: [{ rate_type: "N (Normal)", value_break: "", percentage_rate: "", currency: currency }];
+
+				var table_html = [
+					'<div class="percentage-break-dialog-table">',
+					'<table class="table table-bordered table-sm">',
+					"<thead><tr>",
+					"<th>" + __("Break Type") + "</th>",
+					"<th>" + __("Value Break") + "</th>",
+					"<th>" + __("Percentage Rate") + "</th>",
+					"<th>" + __("Currency") + "</th>",
+					'<th style="width:40px"></th>',
+					"</tr></thead>",
+					'<tbody id="percentage_break_tbody"></tbody>',
+					"</table>",
+					'<button type="button" class="btn btn-xs btn-secondary mt-2" id="percentage_break_add_row">' +
+						__("Add row") +
+						"</button>",
+					"</div>",
+				].join("");
+
+				var dialog = new frappe.ui.Dialog({
+					title:
+						record_type === "Cost"
+							? __("Manage Cost Percentage Breaks")
+							: __("Manage Selling Percentage Breaks"),
+					size: "large",
+					fields: [
+						{ fieldname: "percentage_breaks_section", fieldtype: "Section Break", label: __("Percentage Breaks") },
+						{ fieldname: "percentage_breaks_html", fieldtype: "HTML", options: table_html },
+					],
+					primary_action_label: __("Save"),
+					primary_action: function() {
+						var tbody = dialog.$wrapper.find("#percentage_break_tbody");
+						var to_save = [];
+						tbody.find("tr").each(function() {
+							var $row = $(this);
+							var value_break = parseFloat($row.find("input.value-break").val()) || 0;
+							var percentage_rate = parseFloat($row.find("input.percentage-rate").val()) || 0;
+							var curr = $row.find("input.currency-code").val() || currency;
+							var rate_type = $row.find("select.rate-type").val() || "N (Normal)";
+							if (value_break || percentage_rate) {
+								to_save.push({
+									rate_type: rate_type,
+									value_break: value_break,
+									percentage_rate: percentage_rate,
+									currency: curr,
+								});
+							}
+						});
+						frappe.call({
+							method:
+								"logistics.pricing_center.doctype.sales_quote_percentage_break.sales_quote_percentage_break.save_percentage_breaks_for_reference",
+							args: {
+								reference_doctype: reference_doctype,
+								reference_no: reference_no,
+								percentage_breaks: to_save,
+								record_type: record_type,
+							},
+							callback: function(save_r) {
+								if (save_r.message && save_r.message.success) {
+									frappe.show_alert({ message: __("Percentage breaks saved"), indicator: "green" });
+									dialog.hide();
+									if (frm && frm.doc) {
+										_refresh_charge_grids_on_parent(frm);
+									}
+								} else {
+									frappe.msgprint({
+										title: __("Error"),
+										message:
+											(save_r.message && save_r.message.error) ||
+											__("Failed to save percentage breaks"),
+										indicator: "red",
+									});
+								}
+							},
+						});
+					},
+				});
+				dialog.show();
+
+				var render_row = function(pb) {
+					return (
+						"<tr>" +
+						'<td><select class="form-control form-control-sm rate-type">' +
+						'<option value="M (Minimum)"' +
+						(pb.rate_type === "M (Minimum)" ? " selected" : "") +
+						">M (Minimum)</option>" +
+						'<option value="N (Normal)"' +
+						(!pb.rate_type || pb.rate_type === "N (Normal)" ? " selected" : "") +
+						">N (Normal)</option>" +
+						'<option value="Q (Quantity Break)"' +
+						(pb.rate_type === "Q (Quantity Break)" ? " selected" : "") +
+						">Q (Quantity Break)</option>" +
+						"</select></td>" +
+						'<td><input type="number" step="0.001" class="form-control form-control-sm value-break" value="' +
+						(pb.value_break != null ? frappe.utils.escape_html(pb.value_break) : "") +
+						'"></td>' +
+						'<td><input type="number" step="0.01" class="form-control form-control-sm percentage-rate" value="' +
+						(pb.percentage_rate != null ? frappe.utils.escape_html(pb.percentage_rate) : "") +
+						'"></td>' +
+						'<td><input type="text" class="form-control form-control-sm currency-code" value="' +
+						frappe.utils.escape_html(pb.currency || currency) +
+						'" placeholder="USD"></td>' +
+						'<td><button type="button" class="btn btn-xs btn-default btn-remove-row">&times;</button></td>' +
+						"</tr>"
+					);
+				};
+
+				dialog.$wrapper.one("shown.bs.modal", function() {
+					var tbody = dialog.$wrapper.find("#percentage_break_tbody");
+					table_data.forEach(function(pb) {
+						tbody.append(render_row(pb));
+					});
+
+					dialog.$wrapper.find("#percentage_break_add_row").on("click", function() {
+						tbody.append(
+							render_row({ rate_type: "N (Normal)", value_break: "", percentage_rate: "", currency: currency })
+						);
+					});
+
+					dialog.$wrapper.on("click", ".btn-remove-row", function() {
+						$(this).closest("tr").remove();
+					});
+				});
+			},
+		});
+	};
+
 	window.logistics_unit_break_label_for_row = function(row, record_type) {
 		var unit_type =
 			record_type === "Cost"
@@ -874,6 +1050,27 @@
 					ev.stopPropagation();
 					ev.stopImmediatePropagation();
 					window.open_qty_break_rate_dialog(fo.frm, row, fn === "cost_qty_break" ? "Cost" : "Selling");
+					return;
+				}
+				if (fn === "selling_percentage_break" || fn === "cost_percentage_break") {
+					var known_pb = (window.LOGISTICS_CHARGE_DOCTYPES_WITH_BREAKS || []).indexOf(fo.doctype) !== -1;
+					var meta_pb =
+						window.logistics_charge_child_doctype_has_percentage_break_buttons &&
+						window.logistics_charge_child_doctype_has_percentage_break_buttons(fo.doctype);
+					if (!known_pb && !meta_pb) {
+						return;
+					}
+					if (typeof window.open_percentage_break_rate_dialog !== "function") {
+						return;
+					}
+					ev.preventDefault();
+					ev.stopPropagation();
+					ev.stopImmediatePropagation();
+					window.open_percentage_break_rate_dialog(
+						fo.frm,
+						row,
+						fn === "cost_percentage_break" ? "Cost" : "Selling"
+					);
 				}
 			},
 			true

--- a/logistics/public/js/container_deposit_postings.js
+++ b/logistics/public/js/container_deposit_postings.js
@@ -1,0 +1,483 @@
+// Copyright (c) 2026, Logistics Team and contributors
+// Filterable Transaction Postings grid for Container → Container Deposit tab.
+
+(function () {
+	const PAGE_LENGTH_OPTIONS = [10, 25, 50, 100];
+
+	function inject_styles() {
+		if (document.getElementById("cd-postings-styles")) {
+			return;
+		}
+		const css =
+			".cd-postings{margin-top:4px;}" +
+			".cd-postings-header{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;margin-bottom:12px;}" +
+			".cd-postings-header h6{margin:0;font-size:13px;font-weight:600;}" +
+			".cd-postings-header .cd-subtitle{font-size:12px;color:var(--text-muted,#64748b);margin-top:2px;}" +
+			".cd-postings-actions{display:flex;gap:8px;flex-shrink:0;}" +
+			".cd-filter-bar{display:flex;align-items:flex-end;flex-wrap:wrap;gap:12px;padding:12px;background:var(--fg-color,#fff);border:1px solid var(--border-color,#e2e8f0);border-radius:8px;margin-bottom:12px;}" +
+			".cd-filter-field{display:flex;flex-direction:column;gap:4px;min-width:140px;}" +
+			".cd-filter-field label{font-size:11px;font-weight:600;color:var(--text-muted,#64748b);margin:0;}" +
+			".cd-filter-field select,.cd-filter-field input{font-size:12px;padding:5px 8px;border-radius:6px;border:1px solid var(--border-color,#e2e8f0);background:var(--control-bg,#fff);min-height:30px;}" +
+			".cd-filter-field.cd-date-range{min-width:260px;}" +
+			".cd-date-inputs{display:flex;align-items:center;gap:6px;}" +
+			".cd-summary-row{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px;margin-bottom:12px;}" +
+			".cd-summary-card{display:flex;align-items:center;gap:12px;padding:14px 16px;border-radius:10px;border:1px solid var(--border-color,#e2e8f0);background:var(--fg-color,#fff);box-shadow:0 1px 2px rgba(15,23,42,0.04);}" +
+			".cd-summary-icon{width:36px;height:36px;border-radius:8px;display:flex;align-items:center;justify-content:center;font-size:16px;flex-shrink:0;}" +
+			".cd-summary-card.deposited .cd-summary-icon{background:#eff6ff;color:#2563eb;}" +
+			".cd-summary-card.refunded .cd-summary-icon{background:#ecfdf5;color:#059669;}" +
+			".cd-summary-card.pending .cd-summary-icon{background:#fff7ed;color:#ea580c;}" +
+			".cd-summary-label{font-size:11px;color:var(--text-muted,#64748b);}" +
+			".cd-summary-value{font-size:18px;font-weight:700;line-height:1.2;}" +
+			".cd-summary-caption{font-size:11px;color:var(--text-muted,#64748b);margin-bottom:10px;}" +
+			".cd-table-wrap{border:1px solid var(--border-color,#e2e8f0);border-radius:8px;overflow:hidden;background:var(--fg-color,#fff);}" +
+			".cd-table{width:100%;margin:0;font-size:12px;}" +
+			".cd-table thead th{background:var(--subtle-fg,#f8fafc);font-weight:600;white-space:nowrap;}" +
+			".cd-table td,.cd-table th{padding:8px 10px;vertical-align:middle;}" +
+			".cd-table tbody tr:hover{background:var(--subtle-fg,#f8fafc);}" +
+			".cd-voucher-link{font-weight:500;}" +
+			".cd-badge{display:inline-block;padding:2px 8px;border-radius:999px;font-size:11px;font-weight:600;}" +
+			".cd-badge.open{background:#fef3c7;color:#b45309;}" +
+			".cd-badge.refunded{background:#dcfce7;color:#15803d;}" +
+			".cd-table-footer{display:flex;align-items:center;justify-content:space-between;gap:10px;flex-wrap:wrap;padding:10px 12px;border-top:1px solid var(--border-color,#e2e8f0);font-size:12px;color:var(--text-muted,#64748b);}" +
+			".cd-pagination{display:flex;align-items:center;gap:4px;}" +
+			".cd-pagination button{min-width:28px;height:28px;padding:0 6px;border:1px solid var(--border-color,#e2e8f0);border-radius:6px;background:var(--control-bg,#fff);font-size:12px;}" +
+			".cd-pagination button.active{background:var(--primary,#171717);color:#fff;border-color:var(--primary,#171717);}" +
+			".cd-pagination button:disabled{opacity:0.45;cursor:not-allowed;}" +
+			".cd-info-note{margin-top:12px;padding:10px 12px;border-radius:8px;background:#eff6ff;border:1px solid #bfdbfe;font-size:12px;color:#1e40af;}" +
+			".cd-empty{padding:24px;text-align:center;color:var(--text-muted,#64748b);font-size:12px;}" +
+			"@media (max-width:900px){.cd-summary-row{grid-template-columns:1fr;}}";
+		$("head").append(`<style id="cd-postings-styles">${css}</style>`);
+	}
+
+	function voucher_route(voucher_type, voucher_no) {
+		const map = {
+			"Purchase Invoice": "purchase-invoice",
+			"Journal Entry": "journal-entry",
+		};
+		const slug = map[voucher_type];
+		if (!slug || !voucher_no) {
+			return null;
+		}
+		return `/app/${slug}/${encodeURIComponent(voucher_no)}`;
+	}
+
+		function default_filters(items) {
+		return {
+			items: items.slice(),
+			voucher_types: ["Purchase Invoice", "Journal Entry"],
+			from_date: "",
+			to_date: "",
+			refund_statuses: ["Open", "Refunded"],
+			page: 1,
+			page_length: 10,
+		};
+	}
+
+	function row_matches_filters(row, filters) {
+		if (filters.items.length && row.item_code && filters.items.indexOf(row.item_code) === -1) {
+			return false;
+		}
+		if (
+			filters.voucher_types.length &&
+			filters.voucher_types.indexOf(row.voucher_type) === -1
+		) {
+			return false;
+		}
+		if (filters.from_date && row.posting_date && row.posting_date < filters.from_date) {
+			return false;
+		}
+		if (filters.to_date && row.posting_date && row.posting_date > filters.to_date) {
+			return false;
+		}
+		if (filters.refund_statuses.length) {
+			const status = row.refund_status || "";
+			if (status && filters.refund_statuses.indexOf(status) === -1) {
+				return false;
+			}
+			if (!status && filters.refund_statuses.length < 2) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	class ContainerDepositPostings {
+		constructor(frm) {
+			this.frm = frm;
+			this.$wrapper = frm.fields_dict.deposits_gl_html.$wrapper;
+			this.data = { rows: [], items: [], currency: null, error: null };
+			this.filters = default_filters([]);
+			this.sort = { field: "posting_date", asc: false };
+		}
+
+		refresh() {
+			inject_styles();
+			this.$wrapper.empty().append(`<div class="cd-postings"><div class="text-muted small">${__(
+				"Loading transaction postings…"
+			)}</div></div>`);
+			frappe.call({
+				method: "logistics.logistics.doctype.container.container.get_deposit_postings_data",
+				args: { container: this.frm.doc.name },
+				callback: (r) => {
+					this.data = r.message || { rows: [], items: [], currency: null, error: null };
+					this.filters = default_filters(this.data.items || []);
+					this.render();
+				},
+			});
+		}
+
+		render() {
+			const $root = $('<div class="cd-postings"></div>');
+			if (this.data.error) {
+				$root.append(`<p class="text-muted">${frappe.utils.escape_html(this.data.error)}</p>`);
+				this.$wrapper.empty().append($root);
+				return;
+			}
+			$root.append(this._render_header());
+			$root.append(this._render_filters());
+			$root.append(this._render_summary());
+			$root.append(this._render_table());
+			$root.append(this._render_info_note());
+			this.$wrapper.empty().append($root);
+		}
+
+		_render_header() {
+			const $header = $(`
+				<div class="cd-postings-header">
+					<div>
+						<h6>${__("Transaction Postings")}</h6>
+						<div class="cd-subtitle">${__(
+							"Container deposit transaction postings — deposit charges only."
+						)}</div>
+					</div>
+					<div class="cd-postings-actions">
+						<button type="button" class="btn btn-default btn-sm btn-refresh">${__("Refresh")}</button>
+					</div>
+				</div>
+			`);
+			$header.find(".btn-refresh").on("click", () => this.refresh());
+			return $header;
+		}
+
+		_render_filters() {
+			const items = this.data.items || [];
+			const $bar = $('<div class="cd-filter-bar"></div>');
+
+			const $item = $(`
+				<div class="cd-filter-field">
+					<label>${__("Item")}</label>
+					<select class="cd-filter-items"></select>
+				</div>
+			`);
+			$item.find("select").append(`<option value="__all__">${__("All Container Deposit Items")}</option>`);
+			items.forEach((code) => {
+				$item.find("select").append(
+					`<option value="${frappe.utils.escape_html(code)}">${frappe.utils.escape_html(code)}</option>`
+				);
+			});
+			$item.find("select").val(
+				this.filters.items.length === 1 && items.indexOf(this.filters.items[0]) !== -1
+					? this.filters.items[0]
+					: "__all__"
+			);
+
+			const $voucher = $(`
+				<div class="cd-filter-field">
+					<label>${__("Voucher Type")}</label>
+					<select class="cd-filter-voucher" multiple size="2">
+						<option value="Purchase Invoice">${__("Purchase Invoice")}</option>
+						<option value="Journal Entry">${__("Journal Entry")}</option>
+					</select>
+				</div>
+			`);
+			$voucher.find("select").val(this.filters.voucher_types);
+
+			const $dates = $(`
+				<div class="cd-filter-field cd-date-range">
+					<label>${__("Date Range")}</label>
+					<div class="cd-date-inputs">
+						<input type="date" class="cd-filter-from" />
+						<span>–</span>
+						<input type="date" class="cd-filter-to" />
+					</div>
+				</div>
+			`);
+			$dates.find(".cd-filter-from").val(this.filters.from_date || "");
+			$dates.find(".cd-filter-to").val(this.filters.to_date || "");
+
+			const $status = $(`
+				<div class="cd-filter-field">
+					<label>${__("Refund Status")}</label>
+					<select class="cd-filter-status" multiple size="2">
+						<option value="Open">${__("Open")}</option>
+						<option value="Refunded">${__("Refunded")}</option>
+					</select>
+				</div>
+			`);
+			$status.find("select").val(this.filters.refund_statuses);
+
+			const $clear = $(`
+				<div class="cd-filter-field">
+					<label>&nbsp;</label>
+					<button type="button" class="btn btn-default btn-sm">${__("Clear Filters")}</button>
+				</div>
+			`);
+
+			$bar.append($item, $voucher, $dates, $status, $clear);
+
+			const apply = () => {
+				const selectedItem = $item.find("select").val() || "__all__";
+				this.filters.items =
+					selectedItem === "__all__" ? (this.data.items || []).slice() : [selectedItem];
+				this.filters.voucher_types = $voucher.find("select").val() || [];
+				this.filters.from_date = $dates.find(".cd-filter-from").val() || "";
+				this.filters.to_date = $dates.find(".cd-filter-to").val() || "";
+				this.filters.refund_statuses = $status.find("select").val() || [];
+				this.filters.page = 1;
+				this._rerender_body();
+			};
+
+			$bar.find("select, input").on("change", apply);
+			$clear.find("button").on("click", () => {
+				this.filters = default_filters(this.data.items || []);
+				this.render();
+			});
+
+			return $bar;
+		}
+
+		_filtered_rows() {
+			let rows = (this.data.rows || []).filter((row) => row_matches_filters(row, this.filters));
+			const field = this.sort.field;
+			const dir = this.sort.asc ? 1 : -1;
+			rows.sort((a, b) => {
+				const av = a[field];
+				const bv = b[field];
+				if (field === "debit" || field === "credit") {
+					return (flt(av) - flt(bv)) * dir;
+				}
+				return String(av || "").localeCompare(String(bv || "")) * dir;
+			});
+			return rows;
+		}
+
+		_format_currency(amount) {
+			const currency = this.data.currency || frappe.defaults.get_default("currency");
+			return format_currency(flt(amount), currency);
+		}
+
+		_render_summary() {
+			const rows = this._filtered_rows();
+			const total_deposited = rows.reduce((sum, row) => sum + flt(row.debit), 0);
+			const total_refunded = rows.reduce((sum, row) => sum + flt(row.credit), 0);
+			const net_pending = total_deposited - total_refunded;
+			const $wrap = $(`
+				<div>
+					<div class="cd-summary-row">
+						<div class="cd-summary-card deposited">
+							<div class="cd-summary-icon">↓</div>
+							<div>
+								<div class="cd-summary-label">${__("Total Deposited")}</div>
+								<div class="cd-summary-value">${this._format_currency(total_deposited)}</div>
+							</div>
+						</div>
+						<div class="cd-summary-card refunded">
+							<div class="cd-summary-icon">↻</div>
+							<div>
+								<div class="cd-summary-label">${__("Total Refunded")}</div>
+								<div class="cd-summary-value">${this._format_currency(total_refunded)}</div>
+							</div>
+						</div>
+						<div class="cd-summary-card pending">
+							<div class="cd-summary-icon">⊟</div>
+							<div>
+								<div class="cd-summary-label">${__("Net Pending")}</div>
+								<div class="cd-summary-value">${this._format_currency(net_pending)}</div>
+							</div>
+						</div>
+					</div>
+					<div class="cd-summary-caption">${__("Summary is based on the selected filters.")}</div>
+				</div>
+			`);
+			$wrap.find(".cd-summary-row").attr("data-cd-part", "summary");
+			return $wrap;
+		}
+
+		_render_table() {
+			const rows = this._filtered_rows();
+			const page_length = cint(this.filters.page_length) || 10;
+			const total = rows.length;
+			const total_pages = Math.max(1, Math.ceil(total / page_length));
+			if (this.filters.page > total_pages) {
+				this.filters.page = total_pages;
+			}
+			const start = (this.filters.page - 1) * page_length;
+			const page_rows = rows.slice(start, start + page_length);
+
+			const $wrap = $('<div class="cd-table-wrap" data-cd-part="table"></div>');
+			if (!total) {
+				$wrap.append(`<div class="cd-empty">${__("No transaction postings match the selected filters.")}</div>`);
+				return $wrap;
+			}
+
+			const $table = $(`
+				<table class="table cd-table">
+					<thead>
+						<tr>
+							<th>#</th>
+							<th class="cd-sort" data-field="posting_date">${__("Date")}</th>
+							<th class="cd-sort" data-field="voucher_type">${__("Voucher Type")}</th>
+							<th>${__("Voucher No.")}</th>
+							<th class="cd-sort" data-field="item_code">${__("Item")}</th>
+							<th>${__("Account")}</th>
+							<th class="cd-sort text-right" data-field="debit">${__("Debit")}</th>
+							<th class="cd-sort text-right" data-field="credit">${__("Credit")}</th>
+							<th>${__("Party")}</th>
+							<th>${__("Refund Status")}</th>
+						</tr>
+					</thead>
+					<tbody></tbody>
+				</table>
+			`);
+
+			const $tbody = $table.find("tbody");
+			page_rows.forEach((row, idx) => {
+				const route = voucher_route(row.voucher_type, row.voucher_no);
+				const voucher_html = route
+					? `<a class="cd-voucher-link" href="${route}">${frappe.utils.escape_html(
+							row.voucher_no
+					  )}</a>`
+					: frappe.utils.escape_html(row.voucher_no || "");
+				let badge = "";
+				if (row.refund_status === "Open") {
+					badge = `<span class="cd-badge open">${__("Open")}</span>`;
+				} else if (row.refund_status === "Refunded") {
+					badge = `<span class="cd-badge refunded">${__("Refunded")}</span>`;
+				}
+				$tbody.append(`
+					<tr>
+						<td>${start + idx + 1}</td>
+						<td>${row.posting_date ? frappe.datetime.str_to_user(row.posting_date) : ""}</td>
+						<td>${frappe.utils.escape_html(row.voucher_type || "")}</td>
+						<td>${voucher_html}</td>
+						<td>${frappe.utils.escape_html(row.item_code || "")}</td>
+						<td>${frappe.utils.escape_html(row.account_label || row.account || "")}</td>
+						<td class="text-right">${row.debit ? this._format_currency(row.debit) : ""}</td>
+						<td class="text-right">${row.credit ? this._format_currency(row.credit) : ""}</td>
+						<td>${frappe.utils.escape_html(row.party || "")}</td>
+						<td>${badge}</td>
+					</tr>
+				`);
+			});
+
+			$table.find(".cd-sort").on("click", (e) => {
+				const field = $(e.currentTarget).data("field");
+				if (this.sort.field === field) {
+					this.sort.asc = !this.sort.asc;
+				} else {
+					this.sort.field = field;
+					this.sort.asc = true;
+				}
+				this._rerender_body();
+			});
+
+			$wrap.append($table);
+			$wrap.append(this._render_footer(total, start, page_rows.length, total_pages));
+			return $wrap;
+		}
+
+		_render_footer(total, start, shown, total_pages) {
+			const $footer = $(`
+				<div class="cd-table-footer">
+					<div>${__(
+						"Showing {0} to {1} of {2} entries",
+						[total ? start + 1 : 0, start + shown, total]
+					)}</div>
+					<div class="cd-pagination"></div>
+					<div>
+						<select class="cd-page-length">
+							${PAGE_LENGTH_OPTIONS.map(
+								(n) =>
+									`<option value="${n}" ${
+										cint(this.filters.page_length) === n ? "selected" : ""
+									}>${n} / ${__("page")}</option>`
+							).join("")}
+						</select>
+					</div>
+				</div>
+			`);
+
+			const $pagination = $footer.find(".cd-pagination");
+			const page = cint(this.filters.page) || 1;
+			$pagination.append(
+				`<button type="button" data-page="prev" ${page <= 1 ? "disabled" : ""}>&lt;</button>`
+			);
+			for (let p = 1; p <= total_pages && p <= 7; p += 1) {
+				$pagination.append(
+					`<button type="button" data-page="${p}" class="${p === page ? "active" : ""}">${p}</button>`
+				);
+			}
+			if (total_pages > 7) {
+				$pagination.append(`<span>…</span>`);
+				$pagination.append(
+					`<button type="button" data-page="${total_pages}" class="${
+						total_pages === page ? "active" : ""
+					}">${total_pages}</button>`
+				);
+			}
+			$pagination.append(
+				`<button type="button" data-page="next" ${
+					page >= total_pages ? "disabled" : ""
+				}>&gt;</button>`
+			);
+
+			$pagination.find("button[data-page]").on("click", (e) => {
+				const target = $(e.currentTarget).data("page");
+				if (target === "prev") {
+					this.filters.page = Math.max(1, page - 1);
+				} else if (target === "next") {
+					this.filters.page = Math.min(total_pages, page + 1);
+				} else {
+					this.filters.page = cint(target);
+				}
+				this._rerender_body();
+			});
+
+			$footer.find(".cd-page-length").on("change", (e) => {
+				this.filters.page_length = cint(e.target.value) || 10;
+				this.filters.page = 1;
+				this._rerender_body();
+			});
+
+			return $footer;
+		}
+
+		_render_info_note() {
+			return $(`
+				<div class="cd-info-note" data-cd-part="info">
+					${__(
+						"Only container deposit charges (e.g. CONDEP and other deposit items) are included in this view."
+					)}
+				</div>
+			`);
+		}
+
+		_rerender_body() {
+			this.$wrapper.find("[data-cd-part=summary]").parent().replaceWith(this._render_summary());
+			this.$wrapper.find("[data-cd-part=table]").replaceWith(this._render_table());
+		}
+	}
+
+	window.logistics = window.logistics || {};
+	window.logistics.container_deposit_postings = {
+		render(frm) {
+			if (!frm.fields_dict.deposits_gl_html) {
+				return;
+			}
+			if (!frm._cd_postings_widget) {
+				frm._cd_postings_widget = new ContainerDepositPostings(frm);
+			}
+			frm._cd_postings_widget.refresh();
+		},
+	};
+})();

--- a/logistics/public/js/exhibit_booking_dialog.js
+++ b/logistics/public/js/exhibit_booking_dialog.js
@@ -246,7 +246,7 @@
 		return $block;
 	}
 
-	function _buildCards(choices) {
+	function _buildCards(choices, frm) {
 		const $wrap = $("<div class='ex-cards-wrap'>");
 		$wrap.append(
 			$("<p>")
@@ -453,7 +453,7 @@
 				if ($cardsRoot && $cardsRoot.length) {
 					$cardsRoot.empty();
 					$cardsRoot.append(_styles());
-					$cardsRoot.append(_buildCards(choices));
+					$cardsRoot.append(_buildCards(choices, frm));
 					_bindCards($cardsRoot, frm, d);
 				}
 				d.show();

--- a/logistics/sea_freight/doctype/sea_booking/sea_booking.json
+++ b/logistics/sea_freight/doctype/sea_booking/sea_booking.json
@@ -374,8 +374,9 @@
   },
   {
    "fieldname": "shipper_address_display",
-   "fieldtype": "Small Text",
-   "label": "Shipper Address Display"
+   "fieldtype": "Text Editor",
+   "label": "Shipper Address Display",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_addr",
@@ -389,8 +390,9 @@
   },
   {
    "fieldname": "consignee_address_display",
-   "fieldtype": "Small Text",
-   "label": "Consignee Address Display"
+   "fieldtype": "Text Editor",
+   "label": "Consignee Address Display",
+   "read_only": 1
   },
   {
    "fieldname": "shipper_contact",

--- a/logistics/sea_freight/doctype/sea_booking/sea_booking.py
+++ b/logistics/sea_freight/doctype/sea_booking/sea_booking.py
@@ -1509,7 +1509,7 @@ class SeaBooking(VirtualLinkedServicesMixin, Document):
 			sqsf_calc_method = _quote_rev_method()
 			valid_calc_methods = [
 				"Per Unit", "Fixed Amount", "Flat Rate", "Base Plus Additional",
-				"First Plus Additional", "Percentage", "Location-based", "Weight Break", "Qty Break"
+				"First Plus Additional", "Percentage", "Location-based", "Weight Break", "Qty Break", "Percentage Break"
 			]
 			
 			# Invalid calculation methods that should be converted
@@ -2552,6 +2552,48 @@ class SeaBooking(VirtualLinkedServicesMixin, Document):
 						new_qb.unit_rate = qb.get("unit_rate", 0)
 						new_qb.currency = qb.get("currency") or "USD"
 						new_qb.insert(ignore_permissions=True)
+
+					# Copy percentage breaks (Selling)
+					old_pct_breaks = frappe.get_all(
+						"Sales Quote Percentage Break",
+						filters={
+							"reference_doctype": "Sea Booking Charges",
+							"reference_no": old_charge_name,
+							"type": "Selling",
+						},
+						fields=["rate_type", "value_break", "percentage_rate", "currency"],
+					)
+					for pb in old_pct_breaks:
+						new_pb = frappe.new_doc("Sales Quote Percentage Break")
+						new_pb.reference_doctype = "Sea Shipment Charges"
+						new_pb.reference_no = new_charge_name
+						new_pb.type = "Selling"
+						new_pb.rate_type = pb.get("rate_type") or "N (Normal)"
+						new_pb.value_break = pb.get("value_break", 0)
+						new_pb.percentage_rate = pb.get("percentage_rate", 0)
+						new_pb.currency = pb.get("currency") or "USD"
+						new_pb.insert(ignore_permissions=True)
+
+					# Copy percentage breaks (Cost)
+					old_cost_pct_breaks = frappe.get_all(
+						"Sales Quote Percentage Break",
+						filters={
+							"reference_doctype": "Sea Booking Charges",
+							"reference_no": old_charge_name,
+							"type": "Cost",
+						},
+						fields=["rate_type", "value_break", "percentage_rate", "currency"],
+					)
+					for pb in old_cost_pct_breaks:
+						new_pb = frappe.new_doc("Sales Quote Percentage Break")
+						new_pb.reference_doctype = "Sea Shipment Charges"
+						new_pb.reference_no = new_charge_name
+						new_pb.type = "Cost"
+						new_pb.rate_type = pb.get("rate_type") or "N (Normal)"
+						new_pb.value_break = pb.get("value_break", 0)
+						new_pb.percentage_rate = pb.get("percentage_rate", 0)
+						new_pb.currency = pb.get("currency") or "USD"
+						new_pb.insert(ignore_permissions=True)
 			
 			# Ensure commit before client navigates to the new doc (avoids "not found" on form load)
 			frappe.db.commit()

--- a/logistics/sea_freight/doctype/sea_booking_charges/sea_booking_charges.json
+++ b/logistics/sea_freight/doctype/sea_booking_charges/sea_booking_charges.json
@@ -75,9 +75,11 @@
   "section_break_weight_breaks",
   "selling_weight_break",
   "selling_qty_break",
+  "selling_percentage_break",
   "column_break_calc_notes",
   "cost_weight_break",
   "cost_qty_break",
+  "cost_percentage_break",
   "other_services_section",
   "other_service_type",
   "date_started",
@@ -363,10 +365,22 @@
    "label": "Manage Selling Qty Breaks"
   },
   {
+   "depends_on": "eval:doc.revenue_calculation_method=='Percentage Break'",
+   "fieldname": "selling_percentage_break",
+   "fieldtype": "Button",
+   "label": "Manage Selling Percentage Breaks"
+  },
+  {
    "depends_on": "eval:doc.cost_calculation_method=='Qty Break'",
    "fieldname": "cost_qty_break",
    "fieldtype": "Button",
    "label": "Manage Cost Qty Breaks"
+  },
+  {
+   "depends_on": "eval:doc.cost_calculation_method=='Percentage Break'",
+   "fieldname": "cost_percentage_break",
+   "fieldtype": "Button",
+   "label": "Manage Cost Percentage Breaks"
   },
   {
    "fieldname": "revenue_column",
@@ -379,7 +393,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break",
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break",
    "read_only_depends_on": "eval:['Cost','Disbursement'].includes(doc.charge_type)"
   },
   {
@@ -475,7 +489,7 @@
    "fieldname": "cost_calculation_method",
    "fieldtype": "Select",
    "label": "Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break",
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break",
    "read_only_depends_on": "eval:doc.charge_type == 'Revenue'"
   },
   {
@@ -593,7 +607,7 @@
   {
    "fetch_from": "item_code.description",
    "fieldname": "description",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Description"
   },
   {

--- a/logistics/sea_freight/doctype/sea_consolidation_charges/sea_consolidation_charges.json
+++ b/logistics/sea_freight/doctype/sea_consolidation_charges/sea_consolidation_charges.json
@@ -22,6 +22,7 @@
   "column_break_calc_notes",
   "cost_weight_break",
   "cost_qty_break",
+  "cost_percentage_break",
   "section_break_calc",
   "cost_calculation_method",
   "cost_quantity",
@@ -80,7 +81,7 @@
   {
    "fetch_from": "charge_item.description",
    "fieldname": "charge_description",
-   "fieldtype": "Long Text",
+   "fieldtype": "Text Editor",
    "label": "Charge Description"
   },
   {
@@ -142,6 +143,12 @@
    "label": "Manage Cost Qty Breaks"
   },
   {
+   "depends_on": "eval:doc.cost_calculation_method=='Percentage Break'",
+   "fieldname": "cost_percentage_break",
+   "fieldtype": "Button",
+   "label": "Manage Cost Percentage Breaks"
+  },
+  {
    "fieldname": "section_break_calc",
    "fieldtype": "Section Break"
   },
@@ -150,7 +157,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break"
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break"
   },
   {
    "fieldname": "cost_quantity",

--- a/logistics/sea_freight/doctype/sea_shipment/sea_shipment.json
+++ b/logistics/sea_freight/doctype/sea_shipment/sea_shipment.json
@@ -1226,8 +1226,9 @@
   },
   {
    "fieldname": "shipper_address_display",
-   "fieldtype": "Small Text",
-   "label": "Shipper Address Display"
+   "fieldtype": "Text Editor",
+   "label": "Shipper Address Display",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_dzim",
@@ -1246,8 +1247,9 @@
   },
   {
    "fieldname": "consignee_address_display",
-   "fieldtype": "Small Text",
-   "label": "Consignee Address Display"
+   "fieldtype": "Text Editor",
+   "label": "Consignee Address Display",
+   "read_only": 1
   },
   {
    "fieldname": "notify_party",

--- a/logistics/sea_freight/doctype/sea_shipment_charges/sea_shipment_charges.json
+++ b/logistics/sea_freight/doctype/sea_shipment_charges/sea_shipment_charges.json
@@ -82,9 +82,11 @@
   "calculation_notes_section",
   "selling_weight_break",
   "selling_qty_break",
+  "selling_percentage_break",
   "column_break_calc_notes",
   "cost_weight_break",
   "cost_qty_break",
+  "cost_percentage_break",
   "section_break_status",
   "sales_invoice",
   "sales_invoice_status",
@@ -420,10 +422,22 @@
    "label": "Manage Selling Qty Breaks"
   },
   {
+   "depends_on": "eval:doc.revenue_calculation_method=='Percentage Break'",
+   "fieldname": "selling_percentage_break",
+   "fieldtype": "Button",
+   "label": "Manage Selling Percentage Breaks"
+  },
+  {
    "depends_on": "eval:doc.cost_calculation_method=='Qty Break'",
    "fieldname": "cost_qty_break",
    "fieldtype": "Button",
    "label": "Manage Cost Qty Breaks"
+  },
+  {
+   "depends_on": "eval:doc.cost_calculation_method=='Percentage Break'",
+   "fieldname": "cost_percentage_break",
+   "fieldtype": "Button",
+   "label": "Manage Cost Percentage Breaks"
   },
   {
    "fieldname": "section_break_calc",
@@ -441,7 +455,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Revenue Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break",
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break",
    "read_only_depends_on": "eval:['Cost','Disbursement'].includes(doc.charge_type)"
   },
   {
@@ -536,7 +550,7 @@
    "fieldname": "cost_calculation_method",
    "fieldtype": "Select",
    "label": "Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break",
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break",
    "read_only_depends_on": "eval:doc.charge_type == 'Revenue'"
   },
   {
@@ -732,7 +746,7 @@
    "label": "Item Name"
   },
   {
-   "description": "When the Item is a container-deposit charge, shows per-company Sea Freight Settings \u201cDeposits Pending for Refund Request\u201d for GL alignment. Set the same account on the Item Group / Item defaults as needed.",
+   "description": "When the Item is a container-deposit charge, shows per-company Sea Freight Settings “Deposits Pending for Refund Request” for GL alignment. Set the same account on the Item Group / Item defaults as needed.",
    "fieldname": "container_deposit_pending_refund_gl",
    "fieldtype": "Data",
    "label": "Deposit pending refund GL",
@@ -741,7 +755,7 @@
   {
    "fetch_from": "item_code.description",
    "fieldname": "description",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Description"
   },
   {

--- a/logistics/special_projects/doctype/project_job/project_job.json
+++ b/logistics/special_projects/doctype/project_job/project_job.json
@@ -367,7 +367,7 @@
   },
   {
    "fieldname": "shipper_address_display",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Shipper Address Display",
    "read_only": 1
   },
@@ -384,7 +384,7 @@
   },
   {
    "fieldname": "consignee_address_display",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Consignee Address Display",
    "read_only": 1
   },

--- a/logistics/special_projects/doctype/project_job/project_job.py
+++ b/logistics/special_projects/doctype/project_job/project_job.py
@@ -9,6 +9,9 @@ from frappe.model.document import Document
 
 class ProjectJob(Document):
 	def validate(self):
+		from logistics.utils.document_date_validation import validate_planned_date_range
+
+		validate_planned_date_range(self)
 		if self.special_project:
 			row = frappe.db.get_value(
 				"Special Project",

--- a/logistics/special_projects/doctype/special_project/special_project.py
+++ b/logistics/special_projects/doctype/special_project/special_project.py
@@ -236,6 +236,9 @@ class SpecialProject(Document):
 
 	def validate(self):
 		self._honour_special_project_services_form_rows()
+		from logistics.utils.document_date_validation import validate_planned_date_range
+
+		validate_planned_date_range(self)
 		validate_internal_job_activity_codes(self, module_filter=FOR_SPECIAL_PROJECT)
 		validate_special_project_lifecycle_stage_advance(self)
 		self._ensure_charges_tab_defaults()

--- a/logistics/special_projects/doctype/special_project_charges/special_project_charges.json
+++ b/logistics/special_projects/doctype/special_project_charges/special_project_charges.json
@@ -84,9 +84,11 @@
   "calculation_notes_section",
   "selling_weight_break",
   "selling_qty_break",
+  "selling_percentage_break",
   "column_break_calc_notes",
   "cost_weight_break",
   "cost_qty_break",
+  "cost_percentage_break",
   "section_break_status",
   "sales_invoice",
   "sales_invoice_status",
@@ -439,10 +441,22 @@
    "label": "Manage Selling Qty Breaks"
   },
   {
+   "depends_on": "eval:doc.revenue_calculation_method=='Percentage Break'",
+   "fieldname": "selling_percentage_break",
+   "fieldtype": "Button",
+   "label": "Manage Selling Percentage Breaks"
+  },
+  {
    "depends_on": "eval:doc.cost_calculation_method=='Qty Break'",
    "fieldname": "cost_qty_break",
    "fieldtype": "Button",
    "label": "Manage Cost Qty Breaks"
+  },
+  {
+   "depends_on": "eval:doc.cost_calculation_method=='Percentage Break'",
+   "fieldname": "cost_percentage_break",
+   "fieldtype": "Button",
+   "label": "Manage Cost Percentage Breaks"
   },
   {
    "fieldname": "section_break_calc",
@@ -460,7 +474,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Revenue Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break",
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break",
    "read_only_depends_on": "eval:['Cost','Disbursement'].includes(doc.charge_type)"
   },
   {
@@ -555,7 +569,7 @@
    "fieldname": "cost_calculation_method",
    "fieldtype": "Select",
    "label": "Calculation Method",
-   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break",
+   "options": "Per Unit\nFixed Amount\nFlat Rate\nBase Plus Additional\nFirst Plus Additional\nPercentage\nLocation-based\nWeight Break\nQty Break\nPercentage Break",
    "read_only_depends_on": "eval:doc.charge_type == 'Revenue'"
   },
   {
@@ -751,7 +765,7 @@
    "label": "Item Name"
   },
   {
-   "description": "When the Item is a container-deposit charge, shows per-company Sea Freight Settings \u201cDeposits Pending for Refund Request\u201d for GL alignment. Set the same account on the Item Group / Item defaults as needed.",
+   "description": "When the Item is a container-deposit charge, shows per-company Sea Freight Settings “Deposits Pending for Refund Request” for GL alignment. Set the same account on the Item Group / Item defaults as needed.",
    "fieldname": "container_deposit_pending_refund_gl",
    "fieldtype": "Data",
    "label": "Deposit pending refund GL",
@@ -760,7 +774,7 @@
   {
    "fetch_from": "item_code.description",
    "fieldname": "description",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Description"
   },
   {

--- a/logistics/transport/doctype/transport_job/transport_job.json
+++ b/logistics/transport/doctype/transport_job/transport_job.json
@@ -220,7 +220,7 @@
   },
   {
    "fieldname": "shipper_address_display",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Shipper Address Display",
    "read_only": 1
   },
@@ -248,7 +248,7 @@
   },
   {
    "fieldname": "consignee_address_display",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Consignee Address Display",
    "read_only": 1
   },

--- a/logistics/transport/doctype/transport_order/transport_order.json
+++ b/logistics/transport/doctype/transport_order/transport_order.json
@@ -192,7 +192,7 @@
   },
   {
    "fieldname": "shipper_address_display",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Shipper Address Display",
    "read_only": 1
   },
@@ -220,7 +220,7 @@
   },
   {
    "fieldname": "consignee_address_display",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Consignee Address Display",
    "read_only": 1
   },

--- a/logistics/utils/charge_service_type.py
+++ b/logistics/utils/charge_service_type.py
@@ -175,10 +175,13 @@ def programme_charge_service_type_label(value, charge_doctype=None, default=None
 	)
 
 
+_LOAD_TYPE_FLAGS_WITHOUT_MODULE = frozenset({"special project", "exhibits"})
+
+
 def charge_service_type_to_load_type_flag_field(service_type):
 	"""Load Type DocType checkbox fieldname for this charge service_type (uses 'customs' on Load Type, not 'custom')."""
 	c = canonical_charge_service_type_for_storage(service_type)
-	if not c:
+	if not c or c in _LOAD_TYPE_FLAGS_WITHOUT_MODULE:
 		return None
 	if c == "custom":
 		return "customs"

--- a/logistics/utils/charges_calculation.py
+++ b/logistics/utils/charges_calculation.py
@@ -5,7 +5,7 @@
 Centralized charge calculation for Air, Sea, Transport, and Declaration charges.
 
 Follows the Sales Quote charge calculation pattern using RateCalculationEngine.
-Supports Weight Break and Qty Break methods via Sales Quote Weight Break / Qty Break tables.
+Supports Weight Break, Qty Break, and Percentage Break methods via Sales Quote break tables.
 Unit Breaks (checkbox) tier rates by charge row unit_type via Charge Unit Break (#1126).
 Uses calculation_method and unit_type for engine; legacy values (e.g. Per kg) are normalized via mapping.
 """
@@ -75,6 +75,7 @@ METHOD_TO_ENGINE = {
     "Flat rate": ("Flat Rate", None),
     "Weight Break": ("Weight Break", "Weight"),
     "Qty Break": ("Qty Break", "Piece"),
+    "Percentage Break": ("Percentage Break", "Value"),
     "Per Day": ("Per Unit", "Day"),
     "Per TEU": ("Per Unit", "TEU"),
     "Per container": ("Per Unit", "Container"),
@@ -439,6 +440,9 @@ def _get_quantity_for_calculation_method(
         return flt(
             actual_data.get("actual_pieces") or actual_data.get("actual_weight") or 1
         )
+    if method == "Percentage Break":
+        # Tier comparison uses quantity; goods value is resolved separately for the amount.
+        return flt(actual_data.get("actual_quantity") or 0)
     # Per Unit, Base Plus Additional, First Plus Additional, Location-based
     ut = (unit_type or "Weight").strip().lower()
     if ut == "weight":
@@ -951,8 +955,8 @@ def _prepare_rate_data(
     # Map legacy method values to engine format
     method, unit_type = _normalize_calculation_method(method, unit_type)
 
-    # Weight Break and Qty Break are handled separately
-    if method in ("Weight Break", "Qty Break"):
+    # Weight Break, Qty Break, and Percentage Break are handled separately
+    if method in ("Weight Break", "Qty Break", "Percentage Break"):
         return None
 
     uom = getattr(charge_doc, "uom", None) or getattr(charge_doc, f"{prefix}uom", None)
@@ -1044,6 +1048,40 @@ def _resolve_qty_break_rate(
         if flt(actual_qty) >= flt(qb.get("qty_break", 0)):
             return qb
     return sorted(qty_breaks, key=lambda x: flt(x.get("qty_break", 0)))[0]
+
+
+def _resolve_percentage_break_rate(
+    charge_doc: Any,
+    comparison_qty: float,
+    record_type: str = "Selling",
+) -> Optional[Dict]:
+    """Resolve applicable percentage from Sales Quote Percentage Break by Quantity tier."""
+    ref_name = getattr(charge_doc, "name", None)
+    if not ref_name or ref_name == "new":
+        return None
+
+    percentage_breaks = frappe.get_all(
+        "Sales Quote Percentage Break",
+        filters={
+            "reference_doctype": charge_doc.doctype,
+            "reference_no": ref_name,
+            "type": record_type,
+        },
+        fields=["value_break", "percentage_rate", "rate_type", "currency"],
+        order_by="value_break asc",
+    )
+    if not percentage_breaks:
+        return None
+
+    sorted_breaks = sorted(
+        percentage_breaks,
+        key=lambda x: flt(x.get("value_break", 0)),
+        reverse=True,
+    )
+    for pb in sorted_breaks:
+        if flt(comparison_qty) >= flt(pb.get("value_break", 0)):
+            return pb
+    return sorted(percentage_breaks, key=lambda x: flt(x.get("value_break", 0)))[0]
 
 
 def _charge_side_uses_unit_breaks(charge_doc: Any, is_revenue: bool) -> bool:
@@ -1442,6 +1480,70 @@ def _calculate_charge_amount(
         result["success"] = True
         return result
 
+    # Percentage Break: tier by Quantity; amount = (goods_value × %) + minimum_charge (additive)
+    if method == "Percentage Break":
+        if is_revenue:
+            qty = flt(getattr(charge_doc, "quantity", None) or result.get("quantity") or derived_qty or 0)
+        else:
+            qty = flt(
+                getattr(charge_doc, "cost_quantity", None)
+                or result.get("cost_quantity")
+                or derived_qty
+                or 0
+            )
+        applicable = _resolve_percentage_break_rate(charge_doc, qty, record_type)
+        if not applicable:
+            result["calc_notes"] = "Percentage Break: No percentage break rates defined for this charge"
+            return result
+        percentage_rate = flt(applicable.get("percentage_rate", 0))
+        # Quantity selects the tier; do not use quantity-spread Value as goods value.
+        goods_value = 0.0
+        if parent_doc:
+            goods_value = flt(
+                getattr(parent_doc, "goods_value", None)
+                or getattr(parent_doc, "declared_value", None)
+                or 0
+            )
+        if not goods_value:
+            prefix = "" if is_revenue else "cost_"
+            goods_value = flt(getattr(charge_doc, f"{prefix}base_amount", None) or 0)
+        pct_amount = goods_value * (percentage_rate / 100.0)
+        min_charge = (
+            flt(_get_field(charge_doc, "minimum_charge") or 0)
+            if is_revenue
+            else flt(_get_field(charge_doc, "cost_minimum_charge") or 0)
+        )
+        max_charge = (
+            flt(_get_field(charge_doc, "maximum_charge") or 0)
+            if is_revenue
+            else flt(_get_field(charge_doc, "cost_maximum_charge") or 0)
+        )
+        # Minimum charge is additive for Percentage Break (not a floor clamp).
+        calc_base = pct_amount + min_charge
+        amount = calc_base
+        if max_charge > 0 and amount > max_charge:
+            amount = max_charge
+        if is_revenue:
+            row_currency = getattr(charge_doc, "currency", None) or "USD"
+        else:
+            row_currency = getattr(charge_doc, "cost_currency", None) or getattr(charge_doc, "currency", None) or "USD"
+        currency = applicable.get("currency") or row_currency
+        value_break = flt(applicable.get("value_break", 0))
+        detail = (
+            f"Percentage Break: Qty {qty} ≥ break {value_break} → {percentage_rate}%; "
+            f"{percentage_rate}% × goods {goods_value} = {pct_amount}"
+        )
+        if min_charge:
+            detail += f" + minimum {min_charge} = {calc_base} {currency}"
+        else:
+            detail += f" = {calc_base} {currency}"
+        if max_charge > 0 and calc_base > max_charge and amount == max_charge:
+            detail += f"; Maximum charge {max_charge} {currency} applied (Final: {amount} {currency})"
+        result["amount"] = amount
+        result["calc_notes"] = detail
+        result["success"] = True
+        return result
+
     # Standard methods via engine
     rate_data = _prepare_rate_data(charge_doc, is_revenue=is_revenue)
     if not rate_data:
@@ -1647,7 +1749,12 @@ CHARGE_REVENUE_SIDE_CLEAR_FIELDS = (
     "actual_revenue",
 )
 
-_CHARGE_BREAK_DOCTYPES = ("Sales Quote Weight Break", "Sales Quote Qty Break", "Charge Unit Break")
+_CHARGE_BREAK_DOCTYPES = (
+    "Sales Quote Weight Break",
+    "Sales Quote Qty Break",
+    "Sales Quote Percentage Break",
+    "Charge Unit Break",
+)
 
 
 def _reset_charge_field_for_cleanup(meta: Any, fieldname: str) -> Any:

--- a/logistics/utils/document_date_validation.py
+++ b/logistics/utils/document_date_validation.py
@@ -1,5 +1,13 @@
 import frappe
-from frappe.utils import getdate, today
+from frappe import _
+from frappe.utils import get_datetime, getdate, today
+
+from logistics.utils.validation_user_messages import (
+	planned_date_range_invalid_message,
+	planned_date_range_title,
+	planned_window_before_reference_warning_message,
+	planned_window_before_reference_warning_title,
+)
 
 
 def throw_if_left_date_after_right(left_value, right_value, message_getter, title_getter):
@@ -8,6 +16,83 @@ def throw_if_left_date_after_right(left_value, right_value, message_getter, titl
 		return
 	if getdate(left_value) > getdate(right_value):
 		frappe.throw(message_getter(), title=title_getter())
+
+
+def throw_if_start_after_end(
+	start_value,
+	end_value,
+	message_getter,
+	title_getter,
+	*,
+	use_datetime=False,
+):
+	"""Throw when both values exist and start is after end (date or datetime)."""
+	if not start_value or not end_value:
+		return
+	if use_datetime:
+		if get_datetime(start_value) > get_datetime(end_value):
+			frappe.throw(message_getter(), title=title_getter())
+	elif getdate(start_value) > getdate(end_value):
+		frappe.throw(message_getter(), title=title_getter())
+
+
+def validate_planned_date_range(
+	doc,
+	start_field="planned_start",
+	end_field="planned_end",
+	*,
+	use_datetime=False,
+	message_getter=None,
+	title_getter=None,
+):
+	"""Hard-block when Planned Start is after Planned End (both must be set)."""
+	if not doc:
+		return
+	throw_if_start_after_end(
+		doc.get(start_field),
+		doc.get(end_field),
+		message_getter or planned_date_range_invalid_message,
+		title_getter or planned_date_range_title,
+		use_datetime=use_datetime,
+	)
+
+
+def warn_if_planned_end_before_reference(
+	doc,
+	reference_field=None,
+	*,
+	reference_value=None,
+	reference_label=None,
+):
+	"""Soft-warn when Planned End is before a reference date (e.g. quote date)."""
+	if not doc:
+		return
+	planned_end = doc.get("planned_end")
+	ref = reference_value
+	if ref is None and reference_field:
+		ref = doc.get(reference_field)
+	if not planned_end or not ref:
+		return
+	if getdate(planned_end) >= getdate(ref):
+		return
+
+	label = reference_label or _(
+		(reference_field or "reference").replace("_", " ").title()
+	)
+	message = planned_window_before_reference_warning_message(label, getdate(ref))
+	cache = getattr(frappe.flags, "_planned_window_warnings_shown", None)
+	if cache is None:
+		cache = set()
+		frappe.flags._planned_window_warnings_shown = cache
+	if message in cache:
+		return
+	cache.add(message)
+	frappe.msgprint(
+		message,
+		title=planned_window_before_reference_warning_title(),
+		indicator="orange",
+		alert=True,
+	)
 
 
 def is_future_date(value):

--- a/logistics/utils/milestone_status_utils.py
+++ b/logistics/utils/milestone_status_utils.py
@@ -9,6 +9,7 @@ import frappe
 from frappe import _
 from frappe.utils import get_datetime, now_datetime
 
+from logistics.utils.document_date_validation import validate_planned_date_range
 from logistics.utils.validation_user_messages import (
 	milestone_actual_end_without_start_message,
 	milestone_actual_future_dates_message,
@@ -65,11 +66,12 @@ def validate_milestone_date_ranges(milestone_doc):
 	planned_start = _dt(milestone_doc.get("planned_start"))
 	planned_end = _dt(milestone_doc.get("planned_end"))
 
-	if planned_start and planned_end and planned_start > planned_end:
-		frappe.throw(
-			milestone_planned_range_invalid_message(),
-			title=milestone_date_validation_title(),
-		)
+	validate_planned_date_range(
+		milestone_doc,
+		use_datetime=True,
+		message_getter=milestone_planned_range_invalid_message,
+		title_getter=milestone_date_validation_title,
+	)
 
 	actual_start = _dt(milestone_doc.get("actual_start"))
 	actual_end = _dt(milestone_doc.get("actual_end"))

--- a/logistics/utils/sales_quote_programme_charges.py
+++ b/logistics/utils/sales_quote_programme_charges.py
@@ -108,6 +108,11 @@ _CHARGE_BREAK_SPECS = (
 		"Qty Break",
 	),
 	(
+		"Sales Quote Percentage Break",
+		("rate_type", "value_break", "percentage_rate", "currency"),
+		"N (Normal)",
+	),
+	(
 		"Charge Unit Break",
 		("unit_type", "unit_break", "unit_rate", "currency"),
 		None,
@@ -295,7 +300,14 @@ def copy_charge_breaks_for_reference(
 					val = row.get(fieldname)
 					if fieldname == "rate_type":
 						val = val or default_rate_type
-					elif fieldname in ("weight_break", "qty_break", "unit_break", "unit_rate"):
+					elif fieldname in (
+						"weight_break",
+						"qty_break",
+						"unit_break",
+						"unit_rate",
+						"value_break",
+						"percentage_rate",
+					):
 						val = flt(val or 0)
 					elif fieldname == "currency":
 						val = val or "USD"

--- a/logistics/utils/test_document_date_validation.py
+++ b/logistics/utils/test_document_date_validation.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2026, www.agilasoft.com and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from logistics.utils.document_date_validation import (
+	validate_planned_date_range,
+	warn_if_planned_end_before_reference,
+)
+
+
+class TestDocumentDateValidation(FrappeTestCase):
+	def test_validate_planned_date_range_allows_equal_and_ordered(self):
+		doc = frappe._dict(planned_start="2026-07-01", planned_end="2026-07-01")
+		validate_planned_date_range(doc)
+		doc.planned_end = "2026-07-10"
+		validate_planned_date_range(doc)
+
+	def test_validate_planned_date_range_blocks_inverted(self):
+		doc = frappe._dict(planned_start="2026-07-13", planned_end="2026-07-01")
+		with self.assertRaises(frappe.ValidationError):
+			validate_planned_date_range(doc)
+
+	def test_validate_planned_date_range_datetime(self):
+		doc = frappe._dict(
+			planned_start="2026-07-01 12:00:00",
+			planned_end="2026-07-01 11:00:00",
+		)
+		with self.assertRaises(frappe.ValidationError):
+			validate_planned_date_range(doc, use_datetime=True)
+
+	def test_warn_if_planned_end_before_reference(self):
+		doc = frappe._dict(
+			planned_start="2026-07-01",
+			planned_end="2026-07-10",
+			date="2026-07-13",
+		)
+		# Should not raise — soft warning only.
+		warn_if_planned_end_before_reference(
+			doc, reference_field="date", reference_label="Quote Date"
+		)

--- a/logistics/utils/test_percentage_break.py
+++ b/logistics/utils/test_percentage_break.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2026, www.agilasoft.com and contributors
+# For license information, please see license.txt
+
+"""Unit tests for Percentage Break tier resolution and amount formula."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import UnitTestCase
+from frappe.utils import flt
+
+from logistics.utils.charges_calculation import (
+	_resolve_percentage_break_rate,
+	calculate_charge_revenue,
+)
+
+
+class TestPercentageBreakCalculation(UnitTestCase):
+	def test_resolve_highest_qualifying_break(self):
+		charge = SimpleNamespace(name="PB-TEST-1", doctype="Sales Quote Charge")
+		breaks = [
+			{"value_break": 1000, "percentage_rate": 3, "currency": "USD"},
+			{"value_break": 2000, "percentage_rate": 5, "currency": "USD"},
+			{"value_break": 3000, "percentage_rate": 10, "currency": "USD"},
+		]
+		with patch("logistics.utils.charges_calculation.frappe.get_all", return_value=breaks):
+			applicable = _resolve_percentage_break_rate(charge, 3000, "Selling")
+		self.assertEqual(flt(applicable["percentage_rate"]), 10)
+		self.assertEqual(flt(applicable["value_break"]), 3000)
+
+	def test_resolve_mid_tier(self):
+		charge = SimpleNamespace(name="PB-TEST-2", doctype="Sales Quote Charge")
+		breaks = [
+			{"value_break": 1000, "percentage_rate": 3, "currency": "USD"},
+			{"value_break": 2000, "percentage_rate": 5, "currency": "USD"},
+			{"value_break": 3000, "percentage_rate": 10, "currency": "USD"},
+		]
+		with patch("logistics.utils.charges_calculation.frappe.get_all", return_value=breaks):
+			applicable = _resolve_percentage_break_rate(charge, 2500, "Selling")
+		self.assertEqual(flt(applicable["percentage_rate"]), 5)
+
+	def test_amount_goods_value_times_percent_plus_minimum(self):
+		"""Value=200, 5%, minimum=100 → total 110."""
+		charge = SimpleNamespace(
+			name="PB-TEST-3",
+			doctype="Sales Quote Charge",
+			parenttype="Sales Quote",
+			revenue_calculation_method="Percentage Break",
+			unit_type="Value",
+			quantity=2000,
+			minimum_charge=100,
+			maximum_charge=0,
+			currency="USD",
+			base_amount=0,
+			uom=None,
+			use_tariff_in_revenue=0,
+			tariff=None,
+		)
+		parent = SimpleNamespace(doctype="Sales Quote", goods_value=200, declared_value=0)
+		breaks = [
+			{"value_break": 1000, "percentage_rate": 3, "currency": "USD"},
+			{"value_break": 2000, "percentage_rate": 5, "currency": "USD"},
+			{"value_break": 3000, "percentage_rate": 10, "currency": "USD"},
+		]
+		with patch("logistics.utils.charges_calculation.frappe.get_all", return_value=breaks):
+			with patch(
+				"logistics.utils.charges_calculation._fetch_rates_from_tariff_if_needed",
+				return_value=None,
+			):
+				result = calculate_charge_revenue(charge, parent)
+		self.assertTrue(result.get("success"), result.get("calc_notes"))
+		self.assertEqual(flt(result.get("amount")), 110)
+		self.assertIn("5.0%", result.get("calc_notes") or "")
+		self.assertIn("minimum 100", result.get("calc_notes") or "")

--- a/logistics/utils/test_sales_quote_programme_charges.py
+++ b/logistics/utils/test_sales_quote_programme_charges.py
@@ -187,7 +187,7 @@ class TestSalesQuoteProgrammeCharges(FrappeTestCase):
 			self.assertEqual(frappe.utils.flt(weight_rows[0].unit_rate), 12.5)
 		finally:
 			if target_name:
-				for break_dt in ("Sales Quote Weight Break", "Sales Quote Qty Break"):
+				for break_dt in ("Sales Quote Weight Break", "Sales Quote Qty Break", "Sales Quote Percentage Break"):
 					if frappe.db.exists("DocType", break_dt):
 						frappe.db.delete(
 							break_dt,

--- a/logistics/utils/validation_user_messages.py
+++ b/logistics/utils/validation_user_messages.py
@@ -54,6 +54,30 @@ def milestone_planned_range_invalid_message():
 	)
 
 
+def planned_date_range_invalid_message():
+	return _(
+		"Planned Start is after Planned End. The planned window must start on or before it ends.\n\n"
+		"What to do: Set Planned Start to the same day as Planned End or earlier, "
+		"or move Planned End later. Then save again."
+	)
+
+
+def planned_date_range_title():
+	return _("Invalid planned dates")
+
+
+def planned_window_before_reference_warning_message(reference_label, reference_value):
+	return _(
+		"Planned End is before {0} ({1}). The planned window has already ended relative to that date.\n\n"
+		"What to do: If this is intentional (historical or backdated work), you can continue. "
+		"Otherwise update Planned Start and Planned End to the correct programme window."
+	).format(reference_label, reference_value)
+
+
+def planned_window_before_reference_warning_title():
+	return _("Planned window already ended")
+
+
 def milestone_actual_range_invalid_message():
 	return _(
 		"Actual Start is after Actual End. Actual times must show the milestone began on or before it finished.\n\n"

--- a/logistics/warehousing/doctype/inbound_order_charges/inbound_order_charges.json
+++ b/logistics/warehousing/doctype/inbound_order_charges/inbound_order_charges.json
@@ -80,7 +80,7 @@
   {
    "fetch_from": "item_code.description",
    "fieldname": "description",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Description"
   },
   {

--- a/logistics/warehousing/doctype/periodic_billing_charges/periodic_billing_charges.json
+++ b/logistics/warehousing/doctype/periodic_billing_charges/periodic_billing_charges.json
@@ -45,7 +45,7 @@
   {
    "fetch_from": "item.description",
    "fieldname": "description",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Description"
   },
   {

--- a/logistics/warehousing/doctype/release_order_charges/release_order_charges.json
+++ b/logistics/warehousing/doctype/release_order_charges/release_order_charges.json
@@ -41,7 +41,7 @@
   {
    "fetch_from": "item_code.description",
    "fieldname": "description",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Description"
   },
   {

--- a/logistics/warehousing/doctype/stocktake_order_charges/stocktake_order_charges.json
+++ b/logistics/warehousing/doctype/stocktake_order_charges/stocktake_order_charges.json
@@ -36,7 +36,7 @@
   {
    "fetch_from": "item_code.description",
    "fieldname": "description",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Description"
   },
   {

--- a/logistics/warehousing/doctype/transfer_order_charges/transfer_order_charges.json
+++ b/logistics/warehousing/doctype/transfer_order_charges/transfer_order_charges.json
@@ -38,7 +38,7 @@
   {
    "fetch_from": "item_code.description",
    "fieldname": "description",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Description"
   },
   {

--- a/logistics/warehousing/doctype/var_order_charges/var_order_charges.json
+++ b/logistics/warehousing/doctype/var_order_charges/var_order_charges.json
@@ -30,7 +30,7 @@
   {
    "fetch_from": "item_code.description",
    "fieldname": "description",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Description"
   },
   {

--- a/logistics/warehousing/doctype/vas_order_charges/vas_order_charges.json
+++ b/logistics/warehousing/doctype/vas_order_charges/vas_order_charges.json
@@ -38,7 +38,7 @@
   {
    "fetch_from": "item_code.description",
    "fieldname": "description",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Description"
   },
   {

--- a/logistics/warehousing/doctype/warehouse_job_charges/warehouse_job_charges.json
+++ b/logistics/warehousing/doctype/warehouse_job_charges/warehouse_job_charges.json
@@ -116,7 +116,7 @@
   {
    "fetch_from": "item_code.description",
    "fieldname": "description",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Description"
   },
   {
@@ -171,7 +171,7 @@
    "read_only": 1
   },
   {
-   "description": "Total standard cost (Quantity \u00d7 Standard Unit Cost)",
+   "description": "Total standard cost (Quantity × Standard Unit Cost)",
    "fieldname": "total_standard_cost",
    "fieldtype": "Currency",
    "label": "Total Standard Cost",

--- a/logistics/wiki_content/sales_quote.md
+++ b/logistics/wiki_content/sales_quote.md
@@ -86,6 +86,7 @@ Each charge line (Air Freight, Sea Freight, Transport) uses a **Calculation Meth
 | Percentage | `(unit_rate / 100) × base_amount` |
 | Weight Break | `weight × unit_rate` (tier from weight break table) |
 | Qty Break | `quantity × unit_rate` (tier from qty break table) |
+| Percentage Break | `(goods_value × percentage / 100) + minimum_charge` (tier % from percentage break table by Quantity; goods value from parent or Base Amount) |
 | Location-based | Same as Per Unit |
 
 ### 4.2 Unit Types

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ dependencies = [
     "frappe",
     "zeep>=4.2",
     "xmltodict>=0.13",
+    # Direct git URL pins required by uv when resolving frappe; must match frappe's pyproject.toml
+    "PyPika @ git+https://github.com/frappe/pypika@2c50e6142b2d61d2d243e466fdd5dc03b3d918f2",
+    "gunicorn @ git+https://github.com/frappe/gunicorn@54b59ca884c79dcf04d4882658a32bbaf17e999f",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,12 +12,8 @@ requires-python = ">=3.14,<3.15"
 readme = "README.md"
 dynamic = ["version"]
 dependencies = [
-    "frappe",
     "zeep>=4.2",
     "xmltodict>=0.13",
-    # Direct git URL pins required by uv when resolving frappe; must match frappe's pyproject.toml
-    "PyPika @ git+https://github.com/frappe/pypika@2c50e6142b2d61d2d243e466fdd5dc03b3d918f2",
-    "gunicorn @ git+https://github.com/frappe/gunicorn@54b59ca884c79dcf04d4882658a32bbaf17e999f",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -31,6 +27,10 @@ classifiers = [
 Homepage = "https://github.com/agilasoft/logistics"
 Repository = "https://github.com/agilasoft/logistics"
 Issues = "https://github.com/agilasoft/logistics/issues"
+
+[tool.bench.frappe-dependencies]
+frappe = ">=16.0.0,<17.0.0"
+erpnext = ">=16.0.0,<17.0.0"
 
 [tool.setuptools]
 packages = ["logistics"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,6 @@ dependencies = [
     "frappe",
     "zeep>=4.2",
     "xmltodict>=0.13",
-    # URL dependencies required for Frappe v16+ with uv installer
-    # Dependency resolver will handle version conflicts with v15
-    "PyPika @ git+https://github.com/frappe/pypika@2c50e6142b2d61d2d243e466fdd5dc03b3d918f2",
-    "gunicorn @ git+https://github.com/frappe/gunicorn@bb554053bb87218120d76ab6676af7015680e8b6"
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/workflow_center/pyproject.toml
+++ b/workflow_center/pyproject.toml
@@ -11,9 +11,7 @@ description = "Workflow Center — unified cockpit for pending workflow actions 
 requires-python = ">=3.14,<3.15"
 readme = "README.md"
 dynamic = ["version"]
-dependencies = [
-    "frappe",
-]
+dependencies = []
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -26,6 +24,9 @@ classifiers = [
 Homepage = "https://github.com/agilasoft/logistics"
 Repository = "https://github.com/agilasoft/logistics"
 Issues = "https://github.com/agilasoft/logistics/issues"
+
+[tool.bench.frappe-dependencies]
+frappe = ">=16.0.0,<17.0.0"
 
 [tool.setuptools]
 packages = ["workflow_center"]


### PR DESCRIPTION
## Summary
- Add Percentage Break as a charge calculation method across charge doctypes and Sales Quote
- Improve internal billing / cross-module billing for linked and operational jobs (revenue and cost accuracy)
- Harden container deposit GL posting/reversal and related UI
- Replace Small Text with Text Editor for address/description fields where needed
- Validate planned date ranges on exhibit/MICE-related documents

## Test plan
- [ ] Create/edit charges with Percentage Break and confirm sell/buy amounts calculate correctly
- [ ] Run Sales Quote with percentage breaks and verify programme charges
- [ ] Exercise internal billing for linked jobs and confirm revenue/cost postings
- [ ] Post and reverse container deposits; confirm GL entries
- [ ] Confirm planned date validation on Exhibit / MICE / Project Job docs
- [ ] Smoke-check address/description Text Editor fields render and save