### PR TITLE
feat(jobs): two-tier submit/complete/close readiness validations

### DIFF
--- a/logistics/air_freight/doctype/air_shipment/air_shipment.py
+++ b/logistics/air_freight/doctype/air_shipment/air_shipment.py
@@ -39,7 +39,56 @@ class AirShipment(VirtualLinkedServicesMixin, Document):
 	def after_submit(self):
 		"""Record sustainability metrics after shipment submission"""
 		self.record_sustainability_metrics()
-	
+
+	def before_submit(self):
+		"""Validate required data and destination service charges before submit."""
+		self.validate_required_fields_for_submit()
+		from logistics.utils.charge_service_type import (
+			assert_destination_service_charges_on_submit_unless_internal_job,
+		)
+
+		assert_destination_service_charges_on_submit_unless_internal_job(self)
+		try:
+			contains_dg = bool(getattr(self, "contains_dangerous_goods", 0))
+			dg_status = (getattr(self, "dg_compliance_status", "") or "").strip()
+			if contains_dg and dg_status == "Non-Compliant":
+				frappe.throw(
+					_(
+						"Cannot submit Air Shipment: DG Compliance Status is Non-Compliant while "
+						"this shipment contains dangerous goods. Please resolve compliance first."
+					),
+					title=_("Dangerous Goods Non-Compliant"),
+				)
+		except frappe.ValidationError:
+			raise
+		except Exception:
+			frappe.throw(
+				_(
+					"Submission blocked due to Dangerous Goods compliance validation error. "
+					"Please review DG fields."
+				),
+				title=_("Dangerous Goods Validation"),
+			)
+
+	def validate_required_fields_for_submit(self):
+		"""Enforce party/routing/booking links when submitting (draft saves may omit them)."""
+		if not self.booking_date:
+			frappe.throw(_("Booking Date is required"))
+		if not self.air_booking:
+			frappe.throw(_("Air Booking is required. Shipments can only be created by converting an Air Booking."))
+		if not self.shipper:
+			frappe.throw(_("Shipper is required"))
+		if not self.consignee:
+			frappe.throw(_("Consignee is required"))
+		if not self.origin_port:
+			frappe.throw(_("Origin Port is required"))
+		if not self.destination_port:
+			frappe.throw(_("Destination Port is required"))
+		if not self.direction:
+			frappe.throw(_("Direction is required"))
+		if not self.local_customer:
+			frappe.throw(_("Local Customer is required for billing"))
+
 	def calculate_sustainability_metrics(self):
 		"""Calculate sustainability metrics for this air shipment"""
 		try:

--- a/logistics/document_management/api.py
+++ b/logistics/document_management/api.py
@@ -363,6 +363,22 @@ def update_job_document_status_on_parent_before_save(doc, method=None):
 _JOB_DOCUMENT_COMPLETE_STATUSES = frozenset(("Received", "Verified", "Done"))
 
 
+def get_incomplete_required_documents(doc):
+	"""Return labels for required Job Document rows not in Received/Verified/Done."""
+	if not doc or not hasattr(doc, "documents"):
+		return []
+	incomplete = []
+	for row in doc.get("documents") or []:
+		if not cint(row.get("is_required")):
+			continue
+		status = (row.get("status") or "").strip()
+		if status in _JOB_DOCUMENT_COMPLETE_STATUSES:
+			continue
+		label = row.get("document_type") or row.get("document_name") or _("Document")
+		incomplete.append("{0} ({1})".format(label, status or _("Pending")))
+	return incomplete
+
+
 def enforce_required_job_documents_before_submit(doc, method=None):
 	"""Optional gate from Logistics Settings: block submit when required Job Document rows are incomplete."""
 	if not doc or getattr(doc, "flags", None) and doc.flags.get("skip_required_documents_submit_check"):
@@ -373,18 +389,7 @@ def enforce_required_job_documents_before_submit(doc, method=None):
 		return
 	if not cint(getattr(settings, "block_submit_if_required_documents_pending", 0)):
 		return
-	if not hasattr(doc, "documents"):
-		return
-	rows = doc.get("documents") or []
-	incomplete = []
-	for row in rows:
-		if not cint(row.get("is_required")):
-			continue
-		status = (row.get("status") or "").strip()
-		if status in _JOB_DOCUMENT_COMPLETE_STATUSES:
-			continue
-		label = row.get("document_type") or row.get("document_name") or _("Document")
-		incomplete.append("{0} ({1})".format(label, status or _("Pending")))
+	incomplete = get_incomplete_required_documents(doc)
 	if not incomplete:
 		return
 	msg = _("Cannot submit: required document(s) are not complete. Complete or update the Documents table first.") + "\n\n" + "\n".join(

--- a/logistics/hooks.py
+++ b/logistics/hooks.py
@@ -144,6 +144,7 @@ doctype_js = {
 		"logistics/job_management/recognition_client.js",
 		"logistics/job_management/recognition_policy_fields.js",
 		"logistics/job_management/job_charge_reopen.js",
+		"logistics/job_management/job_readiness.js",
 	],
 	"Air Consolidation": [
 		"public/js/charge_break_dialogs.js",
@@ -180,6 +181,7 @@ doctype_js = {
 		"logistics/job_management/recognition_client.js",
 		"logistics/job_management/recognition_policy_fields.js",
 		"logistics/job_management/job_charge_reopen.js",
+		"logistics/job_management/job_readiness.js",
 	],
 	"Sea Consolidation": [
 		"public/js/charge_break_dialogs.js",
@@ -203,6 +205,7 @@ doctype_js = {
 		"logistics/job_management/recognition_client.js",
 		"logistics/job_management/recognition_policy_fields.js",
 		"logistics/job_management/job_charge_reopen.js",
+		"logistics/job_management/job_readiness.js",
 	],
 	"Declaration Order": [
 		"logistics/public/js/transport_mode_default_document_type.js",
@@ -237,6 +240,7 @@ doctype_js = {
 		"logistics/job_management/recognition_client.js",
 		"logistics/job_management/recognition_policy_fields.js",
 		"logistics/job_management/job_charge_reopen.js",
+		"logistics/job_management/job_readiness.js",
 	],
 	"Transport Consolidation": [
 		"logistics/public/js/document_alerts_dialog.js",
@@ -248,6 +252,7 @@ doctype_js = {
 		"logistics/job_management/recognition_client.js",
 		"logistics/job_management/recognition_policy_fields.js",
 		"logistics/job_management/job_charge_reopen.js",
+		"logistics/job_management/job_readiness.js",
 	],
 	"Warehouse Contract": [
 		"public/js/charge_break_dialogs.js",
@@ -529,6 +534,39 @@ for _dt in (
 			doc_events[_dt]["validate"] = list(_v) + [_CHARGE_REOPEN_VALIDATE]
 	elif _v != _CHARGE_REOPEN_VALIDATE:
 		doc_events[_dt]["validate"] = [_v, _CHARGE_REOPEN_VALIDATE]
+
+# Job readiness: block Complete/Close when documents, milestones, or charges fail settings gates
+_JOB_READINESS_VALIDATE = "logistics.job_management.job_readiness.validate_job_readiness_on_status_change"
+for _dt in (
+	"Transport Job",
+	"Sea Shipment",
+	"Air Shipment",
+	"Warehouse Job",
+	"Declaration",
+):
+	if _dt not in doc_events:
+		doc_events[_dt] = {}
+	_v = doc_events[_dt].get("validate")
+	if not _v:
+		doc_events[_dt]["validate"] = _JOB_READINESS_VALIDATE
+	elif isinstance(_v, list):
+		if _JOB_READINESS_VALIDATE not in _v:
+			doc_events[_dt]["validate"] = list(_v) + [_JOB_READINESS_VALIDATE]
+	elif _v != _JOB_READINESS_VALIDATE:
+		doc_events[_dt]["validate"] = [_v, _JOB_READINESS_VALIDATE]
+
+# Warehouse Job completeness / capacity before submit (was defined but unwired)
+_WAREHOUSE_JOB_BEFORE_SUBMIT = "logistics.warehousing.api.warehouse_job_before_submit"
+if "Warehouse Job" not in doc_events:
+	doc_events["Warehouse Job"] = {}
+_wj_bs = doc_events["Warehouse Job"].get("before_submit")
+if not _wj_bs:
+	doc_events["Warehouse Job"]["before_submit"] = _WAREHOUSE_JOB_BEFORE_SUBMIT
+elif isinstance(_wj_bs, list):
+	if _WAREHOUSE_JOB_BEFORE_SUBMIT not in _wj_bs:
+		doc_events["Warehouse Job"]["before_submit"] = list(_wj_bs) + [_WAREHOUSE_JOB_BEFORE_SUBMIT]
+elif _wj_bs != _WAREHOUSE_JOB_BEFORE_SUBMIT:
+	doc_events["Warehouse Job"]["before_submit"] = [_wj_bs, _WAREHOUSE_JOB_BEFORE_SUBMIT]
 
 append_hook(
 	doc_events,

--- a/logistics/job_management/charge_reopen.py
+++ b/logistics/job_management/charge_reopen.py
@@ -132,9 +132,14 @@ def close_job_for_charges(doctype, name):
 			)
 		)
 
+	from logistics.job_management.job_readiness import enforce_job_readiness
+
+	enforce_job_readiness(doc, gate="close")
+
 	setattr(doc, field, "Closed")
 	if cfg.get("uses_transition_flags"):
 		doc.flags.allow_charge_close_transition = True
 	doc.flags.skip_job_status_sync = True
+	doc.flags.enforce_job_readiness_close = True
 	doc.save()
 	return {"ok": 1, "doctype": doctype, "name": name, field: "Closed"}

--- a/logistics/job_management/job_readiness.js
+++ b/logistics/job_management/job_readiness.js
@@ -1,0 +1,146 @@
+// Copyright (c) 2026, Agilasoft and contributors
+// For license information, please see license.txt
+//
+// Action → Check Job Readiness — structured checklist for submit / complete / close gates.
+
+frappe.provide("logistics.job_readiness");
+
+var JOB_READINESS_DOCTYPES = [
+	"Transport Job",
+	"Sea Shipment",
+	"Air Shipment",
+	"Warehouse Job",
+	"Declaration",
+];
+
+function _jr_escape(s) {
+	return frappe.utils.escape_html(String(s == null ? "" : s));
+}
+
+function _jr_infer_gate(frm) {
+	var d = frm.doc;
+	if (!d) {
+		return "submit";
+	}
+	var statusField =
+		frm.doctype === "Transport Job" ? "status" : "job_status";
+	var cur = (d[statusField] || "").toString().trim().toLowerCase();
+	if (cur === "completed" || cur === "reopened" || cur === "closed") {
+		return "close";
+	}
+	if (cint(d.docstatus) === 1) {
+		return "complete";
+	}
+	return "submit";
+}
+
+function _jr_build_html(result) {
+	var errors = result.errors || [];
+	var warnings = result.warnings || [];
+	var parts = [];
+	parts.push(
+		"<p><strong>" +
+			__("Gate") +
+			":</strong> " +
+			_jr_escape(result.gate) +
+			" &nbsp;|&nbsp; " +
+			(result.ok
+				? "<span class='text-success'>" + __("Ready") + "</span>"
+				: "<span class='text-danger'>" + __("Not ready") + "</span>") +
+			"</p>"
+	);
+	if (result.would_block) {
+		parts.push(
+			"<p class='text-muted'>" +
+				__("Current Logistics Settings would block this transition.") +
+				"</p>"
+		);
+	}
+	if (errors.length) {
+		parts.push("<h5>" + __("Issues") + "</h5><ul>");
+		errors.forEach(function (e) {
+			parts.push("<li>" + _jr_escape(e.message || e.code) + "</li>");
+		});
+		parts.push("</ul>");
+	}
+	if (warnings.length) {
+		parts.push("<h5>" + __("Warnings") + "</h5><ul>");
+		warnings.forEach(function (w) {
+			parts.push("<li>" + _jr_escape(w.message || w.code) + "</li>");
+		});
+		parts.push("</ul>");
+	}
+	if (!errors.length && !warnings.length) {
+		parts.push(
+			"<p class='text-success'>" +
+				__("All checked items look good for this gate.") +
+				"</p>"
+		);
+	}
+	return parts.join("");
+}
+
+logistics.job_readiness.show = function (frm, gate) {
+	gate = gate || _jr_infer_gate(frm);
+	frappe.call({
+		method: "logistics.job_management.job_readiness.get_job_readiness_summary",
+		args: {
+			doctype: frm.doctype,
+			name: frm.doc.name,
+			gate: gate,
+		},
+		freeze: true,
+		callback: function (r) {
+			if (r.exc || !r.message) {
+				return;
+			}
+			var result = r.message;
+			var d = new frappe.ui.Dialog({
+				title: __("Job Readiness"),
+				size: "large",
+				fields: [
+					{
+						fieldtype: "HTML",
+						fieldname: "readiness_html",
+					},
+				],
+				primary_action_label: __("Close"),
+				primary_action: function () {
+					d.hide();
+				},
+			});
+			d.fields_dict.readiness_html.$wrapper.html(_jr_build_html(result));
+			d.show();
+		},
+	});
+};
+
+logistics.job_readiness.setup = function (frm) {
+	if (!frm || !frm.doc || frm.is_new()) {
+		return;
+	}
+	if (typeof frm.remove_custom_button === "function") {
+		frm.remove_custom_button(__("Check Job Readiness"), __("Action"));
+	}
+	frm.add_custom_button(
+		__("Check Job Readiness"),
+		function () {
+			logistics.job_readiness.show(frm);
+		},
+		__("Action")
+	);
+};
+
+(function () {
+	if (logistics.job_readiness._handlers_registered) {
+		return;
+	}
+	logistics.job_readiness._handlers_registered = true;
+	JOB_READINESS_DOCTYPES.forEach(function (dt) {
+		frappe.ui.form.on(dt, {
+			refresh: function (frm) {
+				logistics.job_readiness.setup(frm);
+			},
+		});
+	});
+})();

--- a/logistics/job_management/job_readiness.py
+++ b/logistics/job_management/job_readiness.py
@@ -1,0 +1,458 @@
+# Copyright (c) 2026, Agilasoft and contributors
+# For license information, please see license.txt
+
+"""Two-tier job/shipment readiness: submit, complete, and close gates."""
+
+from __future__ import unicode_literals
+
+import frappe
+from frappe import _
+from frappe.utils import cint, flt
+
+from logistics.job_management.charge_reopen import CHARGE_REOPEN_CONFIG
+from logistics.job_management.recognition_engine import (
+	resolve_charge_row_cost,
+	resolve_charge_row_selling,
+)
+
+GATES = ("submit", "complete", "close")
+
+READINESS_DOCTYPES = frozenset(CHARGE_REOPEN_CONFIG.keys())
+
+POSTED_INVOICE_STATUSES = frozenset(("Posted", "Paid"))
+
+# Settings field → check code for complete/close hard blocks
+_GATE_SETTING_MAP = {
+	"complete": {
+		"documents": "block_complete_if_required_documents_pending",
+		"milestones": "block_complete_if_milestones_incomplete",
+		"charges": "block_complete_if_charges_not_posted",
+	},
+	"close": {
+		"documents": "block_close_if_required_documents_pending",
+		"milestones": "block_close_if_milestones_incomplete",
+		"charges": "block_close_if_charges_not_posted",
+	},
+}
+
+_OPS_TERMINAL = {
+	"Air Shipment": {
+		"field": "tracking_status",
+		"ok": frozenset(("Delivered",)),
+	},
+	"Sea Shipment": {
+		"field": "shipping_status",
+		"ok": frozenset(("Delivered", "Empty Container Returned", "Closed")),
+	},
+	"Declaration": {
+		"field": "status",
+		"ok": frozenset(("Cleared", "Released")),
+	},
+}
+
+
+def _issue(code, message, severity="error", **extra):
+	row = {"code": code, "message": message, "severity": severity}
+	row.update(extra)
+	return row
+
+
+def _settings():
+	try:
+		return frappe.get_single("Logistics Settings")
+	except Exception:
+		return None
+
+
+def _setting_on(settings, fieldname, default=0):
+	if not settings:
+		return cint(default)
+	return cint(getattr(settings, fieldname, default))
+
+
+def _charge_label(ch, idx):
+	item = getattr(ch, "item_code", None) or getattr(ch, "charge_item", None) or _("Charge")
+	name = getattr(ch, "item_name", None) or getattr(ch, "charge_name", None) or ""
+	if name and name != item:
+		return "#{0} {1} ({2})".format(idx + 1, item, name)
+	return "#{0} {1}".format(idx + 1, item)
+
+
+def _invoice_submitted(doctype, name):
+	"""True only when the linked invoice exists and is submitted (docstatus=1)."""
+	if not name:
+		return False
+	try:
+		return cint(frappe.db.get_value(doctype, name, "docstatus")) == 1
+	except Exception:
+		return False
+
+
+def _charge_item_code(ch):
+	return getattr(ch, "item_code", None) or getattr(ch, "charge_item", None)
+
+
+def check_charges_posted(doc):
+	"""Return issues for billable/cost charges not posted to a submitted SI/PI."""
+	issues = []
+	charges = list(doc.get("charges") or [])
+	for idx, ch in enumerate(charges):
+		item_code = _charge_item_code(ch)
+		label = _charge_label(ch, idx)
+
+		revenue = flt(resolve_charge_row_selling(ch, prefer_actual=True))
+		if revenue > 0 and item_code:
+			si = getattr(ch, "sales_invoice", None)
+			si_status = (getattr(ch, "sales_invoice_status", None) or "").strip()
+			si_ok = (
+				si_status in POSTED_INVOICE_STATUSES
+				and si
+				and _invoice_submitted("Sales Invoice", si)
+			)
+			if not si_ok:
+				issues.append(
+					_issue(
+						"charge_not_posted_si",
+						_("Revenue charge {0} is not posted to a submitted Sales Invoice (status: {1}).").format(
+							label, si_status or _("Not Requested")
+						),
+						charge_idx=idx + 1,
+						sales_invoice=si,
+						sales_invoice_status=si_status,
+					)
+				)
+
+		cost = flt(resolve_charge_row_cost(ch, prefer_actual=True))
+		if cost > 0 and item_code:
+			pi = getattr(ch, "purchase_invoice", None)
+			pi_status = (getattr(ch, "purchase_invoice_status", None) or "").strip()
+			pi_ok = (
+				pi_status in POSTED_INVOICE_STATUSES
+				and pi
+				and _invoice_submitted("Purchase Invoice", pi)
+			)
+			if not pi_ok:
+				issues.append(
+					_issue(
+						"charge_not_posted_pi",
+						_("Cost charge {0} is not posted to a submitted Purchase Invoice (status: {1}).").format(
+							label, pi_status or _("Not Requested")
+						),
+						charge_idx=idx + 1,
+						purchase_invoice=pi,
+						purchase_invoice_status=pi_status,
+					)
+				)
+	return issues
+
+
+def check_required_documents(doc):
+	"""Return issues for required Job Document rows that are incomplete."""
+	from logistics.document_management.api import get_incomplete_required_documents
+
+	incomplete = get_incomplete_required_documents(doc)
+	issues = []
+	for label in incomplete:
+		issues.append(
+			_issue(
+				"document_incomplete",
+				_("Required document incomplete: {0}").format(label),
+				document=label,
+			)
+		)
+	return issues
+
+
+def _row_get(row, key, default=None):
+	if isinstance(row, dict):
+		return row.get(key, default)
+	if hasattr(row, "get"):
+		try:
+			return row.get(key, default)
+		except Exception:
+			pass
+	return getattr(row, key, default)
+
+
+def check_milestones_complete(doc):
+	"""Return issues for milestones that are not Completed."""
+	if not hasattr(doc, "milestones"):
+		return []
+	issues = []
+	for idx, row in enumerate(doc.get("milestones") or []):
+		status = (_row_get(row, "status") or "").strip()
+		if status == "Completed":
+			continue
+		label = (
+			_row_get(row, "milestone")
+			or _row_get(row, "milestone_name")
+			or _row_get(row, "description")
+			or _("Milestone #{0}").format(idx + 1)
+		)
+		issues.append(
+			_issue(
+				"milestone_incomplete",
+				_("Milestone incomplete: {0} ({1})").format(label, status or _("Planned")),
+				milestone=label,
+				status=status,
+			)
+		)
+	return issues
+
+
+def check_submit_master_data(doc):
+	"""Submit-tier soft checklist for missing master data (hard blocks stay on DocType before_submit)."""
+	issues = []
+	dt = doc.doctype
+	if dt == "Air Shipment":
+		required = [
+			("booking_date", _("Booking Date")),
+			("air_booking", _("Air Booking")),
+			("shipper", _("Shipper")),
+			("consignee", _("Consignee")),
+			("origin_port", _("Origin Port")),
+			("destination_port", _("Destination Port")),
+			("direction", _("Direction")),
+			("local_customer", _("Local Customer")),
+		]
+		for field, label in required:
+			if not getattr(doc, field, None):
+				issues.append(
+					_issue("missing_party", _("{0} is required").format(label), field=field)
+				)
+		if not getattr(doc, "airline", None):
+			# Soft warning — airline often filled later via MAWB
+			issues.append(
+				_issue(
+					"missing_carrier",
+					_("Airline is not set"),
+					severity="warning",
+					field="airline",
+				)
+			)
+	elif dt == "Sea Shipment":
+		required = [
+			("booking_date", _("Booking Date")),
+			("sea_booking", _("Sea Booking")),
+			("shipper", _("Shipper")),
+			("consignee", _("Consignee")),
+			("origin_port", _("Origin Port")),
+			("destination_port", _("Destination Port")),
+			("direction", _("Direction")),
+			("local_customer", _("Local Customer")),
+		]
+		for field, label in required:
+			if not getattr(doc, field, None):
+				issues.append(
+					_issue("missing_party", _("{0} is required").format(label), field=field)
+				)
+	return issues
+
+
+def check_ops_terminal_status(doc):
+	"""Warning when operational status has not reached a terminal value."""
+	spec = _OPS_TERMINAL.get(doc.doctype)
+	if not spec:
+		if doc.doctype == "Transport Job":
+			return _check_transport_legs_terminal(doc)
+		return []
+	field = spec["field"]
+	cur = (getattr(doc, field, None) or "").strip()
+	if cur in spec["ok"]:
+		return []
+	return [
+		_issue(
+			"ops_not_terminal",
+			_("{0} is {1}; expected a terminal status before close.").format(
+				_(frappe.unscrub(field)), cur or _("(empty)")
+			),
+			severity="warning",
+			field=field,
+			status=cur,
+		)
+	]
+
+
+def _check_transport_legs_terminal(doc):
+	legs = list(doc.get("legs") or doc.get("transport_legs") or [])
+	if not legs:
+		return []
+	bad = []
+	for idx, leg in enumerate(legs):
+		status = (getattr(leg, "status", None) or "").strip()
+		if status not in ("Completed", "Billed"):
+			bad.append("#{0} ({1})".format(idx + 1, status or _("empty")))
+	if not bad:
+		return []
+	return [
+		_issue(
+			"ops_not_terminal",
+			_("Transport leg(s) not Completed/Billed: {0}").format(", ".join(bad)),
+			severity="warning",
+		)
+	]
+
+
+def get_job_readiness(doc, gate="close"):
+	"""
+	Build readiness checklist for a gate.
+
+	Returns dict: { ok, gate, doctype, name, errors[], warnings[], checks{} }
+	``ok`` is True when there are no error-severity issues (warnings allowed).
+	"""
+	gate = (gate or "close").strip().lower()
+	if gate not in GATES:
+		frappe.throw(_("Invalid readiness gate: {0}").format(gate))
+
+	errors = []
+	warnings = []
+	checks = {}
+
+	if gate == "submit":
+		master = check_submit_master_data(doc)
+		docs = check_required_documents(doc)
+		checks["master_data"] = master
+		checks["documents"] = docs
+		for issue in master + docs:
+			(errors if issue["severity"] == "error" else warnings).append(issue)
+	else:
+		docs = check_required_documents(doc)
+		milestones = check_milestones_complete(doc)
+		charges = check_charges_posted(doc)
+		ops = check_ops_terminal_status(doc)
+		checks["documents"] = docs
+		checks["milestones"] = milestones
+		checks["charges"] = charges
+		checks["ops_terminal"] = ops
+		for issue in docs + milestones + charges:
+			# Severity for enforce is decided by settings; checklist always reports as error potential
+			errors.append(issue)
+		for issue in ops:
+			warnings.append(issue)
+
+	return {
+		"ok": not errors,
+		"gate": gate,
+		"doctype": getattr(doc, "doctype", None),
+		"name": getattr(doc, "name", None),
+		"errors": errors,
+		"warnings": warnings,
+		"checks": checks,
+	}
+
+
+def _blocking_issues_for_gate(doc, gate, settings=None):
+	"""Return list of issues that should hard-block for this gate given settings."""
+	settings = settings if settings is not None else _settings()
+	gate = (gate or "").strip().lower()
+	blocking = []
+
+	if gate == "submit":
+		# Document submit block remains in document_management.api (settings already there).
+		# Master-data hard blocks stay on DocType before_submit.
+		return blocking
+
+	field_map = _GATE_SETTING_MAP.get(gate) or {}
+	if _setting_on(settings, field_map.get("documents"), 0 if gate == "complete" else 1):
+		blocking.extend(check_required_documents(doc))
+	if _setting_on(settings, field_map.get("milestones"), 0 if gate == "complete" else 1):
+		blocking.extend(check_milestones_complete(doc))
+	if _setting_on(settings, field_map.get("charges"), 0 if gate == "complete" else 1):
+		blocking.extend(check_charges_posted(doc))
+	return blocking
+
+
+def enforce_job_readiness(doc, gate="close"):
+	"""Throw when settings require blocking issues for the gate."""
+	if not doc or getattr(doc, "flags", None) and doc.flags.get("skip_job_readiness"):
+		return
+	if doc.doctype not in READINESS_DOCTYPES:
+		return
+
+	blocking = _blocking_issues_for_gate(doc, gate)
+	if not blocking:
+		return
+
+	lines = [frappe.utils.escape_html(i.get("message") or i.get("code") or "") for i in blocking]
+	title = {
+		"complete": _("Job not ready to Complete"),
+		"close": _("Job not ready to Close"),
+		"submit": _("Job not ready to Submit"),
+	}.get(gate, _("Job readiness"))
+	msg = _("Cannot set Job Status to {0}: resolve the following first.").format(
+		_("Completed") if gate == "complete" else _("Closed") if gate == "close" else gate
+	)
+	frappe.throw(msg + "\n\n" + "\n".join(lines), title=title)
+
+
+def _status_field_for(doc):
+	cfg = CHARGE_REOPEN_CONFIG.get(doc.doctype)
+	return cfg["status_field"] if cfg else None
+
+
+def validate_job_readiness_on_status_change(doc, method=None):
+	"""DocType validate hook: enforce complete/close readiness when Job Status transitions."""
+	if not doc or doc.doctype not in READINESS_DOCTYPES:
+		return
+	if getattr(doc, "flags", None) and doc.flags.get("skip_job_readiness"):
+		return
+	if cint(getattr(doc, "docstatus", 0)) != 1:
+		return
+
+	field = _status_field_for(doc)
+	if not field:
+		return
+
+	new_val = (getattr(doc, field, None) or "").strip()
+	if new_val not in ("Completed", "Closed"):
+		return
+
+	# Only enforce when status is changing into the target (or first save into it)
+	changed = False
+	try:
+		changed = doc.has_value_changed(field)
+	except Exception:
+		changed = True
+	if not changed and not doc.is_new():
+		# Still enforce Closed path when Close Job API sets flag then saves
+		if not getattr(doc.flags, "enforce_job_readiness_close", False):
+			return
+
+	if new_val == "Completed":
+		enforce_job_readiness(doc, gate="complete")
+	elif new_val == "Closed":
+		enforce_job_readiness(doc, gate="close")
+
+
+@frappe.whitelist()
+def get_job_readiness_summary(doctype, name, gate=None):
+	"""Whitelist: structured readiness checklist for desk Action menu."""
+	if doctype not in READINESS_DOCTYPES:
+		frappe.throw(_("Job readiness is not available for {0}.").format(doctype))
+	if not frappe.db.exists(doctype, name):
+		frappe.throw(_("{0} {1} does not exist.").format(doctype, name))
+
+	doc = frappe.get_doc(doctype, name)
+	doc.check_permission("read")
+
+	if not gate:
+		# Infer useful default from current status
+		field = _status_field_for(doc)
+		cur = (getattr(doc, field, None) or "").strip() if field else ""
+		if cur in ("Completed", "Reopened", "Closed"):
+			gate = "close"
+		elif cint(doc.docstatus) == 1:
+			gate = "complete"
+		else:
+			gate = "submit"
+
+	result = get_job_readiness(doc, gate=gate)
+
+	# Annotate which checks would hard-block under current settings
+	settings = _settings()
+	blocking_codes = set()
+	for issue in _blocking_issues_for_gate(doc, gate, settings=settings):
+		blocking_codes.add(issue.get("code"))
+	result["would_block"] = bool(blocking_codes)
+	result["blocking_codes"] = sorted(blocking_codes)
+	return result

--- a/logistics/job_management/tests/test_job_readiness.py
+++ b/logistics/job_management/tests/test_job_readiness.py
@@ -1,0 +1,295 @@
+# Copyright (c) 2026, Agilasoft and contributors
+# For license information, please see license.txt
+
+"""Unit tests for two-tier job readiness (charges, documents, milestones, settings)."""
+
+from __future__ import unicode_literals
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import frappe
+
+from logistics.job_management import job_readiness
+
+
+def _charge(**kwargs):
+	defaults = {
+		"item_code": "FRT",
+		"item_name": "Freight",
+		"estimated_revenue": 0,
+		"actual_revenue": 0,
+		"estimated_cost": 0,
+		"actual_cost": 0,
+		"sales_invoice": None,
+		"sales_invoice_status": "Not Requested",
+		"purchase_invoice": None,
+		"purchase_invoice_status": "Not Requested",
+		"charge_type": "",
+	}
+	defaults.update(kwargs)
+	return SimpleNamespace(**defaults)
+
+
+def _doc(doctype="Sea Shipment", **kwargs):
+	data = {
+		"doctype": doctype,
+		"name": "TEST-JOB-001",
+		"docstatus": 1,
+		"job_status": "Reopened",
+		"charges": [],
+		"documents": [],
+		"milestones": [],
+		"flags": frappe._dict(),
+	}
+	data.update(kwargs)
+	doc = SimpleNamespace(**data)
+	doc.get = lambda key, default=None: getattr(doc, key, default)
+	return doc
+
+
+class TestJobReadinessCharges(unittest.TestCase):
+	@patch("logistics.job_management.job_readiness._invoice_submitted")
+	def test_revenue_requires_submitted_si(self, mock_sub):
+		mock_sub.return_value = True
+		doc = _doc(
+			charges=[
+				_charge(
+					estimated_revenue=100,
+					sales_invoice="SI-1",
+					sales_invoice_status="Posted",
+				)
+			]
+		)
+		self.assertEqual(job_readiness.check_charges_posted(doc), [])
+
+	@patch("logistics.job_management.job_readiness._invoice_submitted")
+	def test_draft_si_does_not_count(self, mock_sub):
+		mock_sub.return_value = False
+		doc = _doc(
+			charges=[
+				_charge(
+					estimated_revenue=100,
+					sales_invoice="SI-DRAFT",
+					sales_invoice_status="Requested",
+				)
+			]
+		)
+		issues = job_readiness.check_charges_posted(doc)
+		self.assertEqual(len(issues), 1)
+		self.assertEqual(issues[0]["code"], "charge_not_posted_si")
+
+	@patch("logistics.job_management.job_readiness._invoice_submitted")
+	def test_posted_status_but_draft_docstatus_fails(self, mock_sub):
+		# Inconsistent: status says Posted but invoice not submitted
+		mock_sub.return_value = False
+		doc = _doc(
+			charges=[
+				_charge(
+					estimated_revenue=100,
+					sales_invoice="SI-X",
+					sales_invoice_status="Posted",
+				)
+			]
+		)
+		issues = job_readiness.check_charges_posted(doc)
+		self.assertEqual(len(issues), 1)
+		self.assertEqual(issues[0]["code"], "charge_not_posted_si")
+
+	@patch("logistics.job_management.job_readiness._invoice_submitted")
+	def test_cost_requires_submitted_pi(self, mock_sub):
+		mock_sub.return_value = True
+		doc = _doc(
+			charges=[
+				_charge(
+					estimated_cost=50,
+					purchase_invoice="PI-1",
+					purchase_invoice_status="Paid",
+				)
+			]
+		)
+		self.assertEqual(job_readiness.check_charges_posted(doc), [])
+
+	def test_zero_amount_skipped(self):
+		doc = _doc(charges=[_charge(estimated_revenue=0, estimated_cost=0)])
+		self.assertEqual(job_readiness.check_charges_posted(doc), [])
+
+	def test_no_item_code_skipped(self):
+		doc = _doc(
+			charges=[_charge(item_code=None, charge_item=None, estimated_revenue=100)]
+		)
+		self.assertEqual(job_readiness.check_charges_posted(doc), [])
+
+	@patch("logistics.job_management.job_readiness._invoice_submitted")
+	def test_both_si_and_pi_required(self, mock_sub):
+		mock_sub.return_value = True
+		doc = _doc(
+			charges=[
+				_charge(
+					estimated_revenue=100,
+					estimated_cost=40,
+					sales_invoice="SI-1",
+					sales_invoice_status="Posted",
+					# PI missing
+				)
+			]
+		)
+		issues = job_readiness.check_charges_posted(doc)
+		self.assertEqual(len(issues), 1)
+		self.assertEqual(issues[0]["code"], "charge_not_posted_pi")
+
+
+class TestJobReadinessDocumentsAndMilestones(unittest.TestCase):
+	@patch("logistics.document_management.api.get_incomplete_required_documents")
+	def test_documents_incomplete(self, mock_inc):
+		mock_inc.return_value = ["Bill of Lading (Pending)"]
+		doc = _doc()
+		issues = job_readiness.check_required_documents(doc)
+		self.assertEqual(len(issues), 1)
+		self.assertEqual(issues[0]["code"], "document_incomplete")
+
+	def test_milestones_incomplete(self):
+		doc = _doc(
+			milestones=[
+				{"milestone": "ATD", "status": "Completed"},
+				{"milestone": "ATA", "status": "Planned"},
+			]
+		)
+		issues = job_readiness.check_milestones_complete(doc)
+		self.assertEqual(len(issues), 1)
+		self.assertIn("ATA", issues[0]["message"])
+
+	def test_milestones_all_complete(self):
+		doc = _doc(
+			milestones=[
+				{"milestone": "ATD", "status": "Completed"},
+				{"milestone": "ATA", "status": "Completed"},
+			]
+		)
+		self.assertEqual(job_readiness.check_milestones_complete(doc), [])
+
+
+class TestJobReadinessSettings(unittest.TestCase):
+	@patch("logistics.job_management.job_readiness.check_charges_posted")
+	@patch("logistics.job_management.job_readiness.check_milestones_complete")
+	@patch("logistics.job_management.job_readiness.check_required_documents")
+	@patch("logistics.job_management.job_readiness._settings")
+	def test_close_defaults_block_all_three(self, mock_settings, mock_docs, mock_ms, mock_ch):
+		mock_settings.return_value = SimpleNamespace(
+			block_close_if_required_documents_pending=1,
+			block_close_if_milestones_incomplete=1,
+			block_close_if_charges_not_posted=1,
+			block_complete_if_required_documents_pending=0,
+			block_complete_if_milestones_incomplete=0,
+			block_complete_if_charges_not_posted=0,
+		)
+		mock_docs.return_value = [job_readiness._issue("document_incomplete", "doc")]
+		mock_ms.return_value = [job_readiness._issue("milestone_incomplete", "ms")]
+		mock_ch.return_value = [job_readiness._issue("charge_not_posted_si", "ch")]
+		doc = _doc()
+		blocking = job_readiness._blocking_issues_for_gate(doc, "close")
+		self.assertEqual(len(blocking), 3)
+
+	@patch("logistics.job_management.job_readiness.check_charges_posted")
+	@patch("logistics.job_management.job_readiness.check_milestones_complete")
+	@patch("logistics.job_management.job_readiness.check_required_documents")
+	@patch("logistics.job_management.job_readiness._settings")
+	def test_complete_defaults_do_not_block(self, mock_settings, mock_docs, mock_ms, mock_ch):
+		mock_settings.return_value = SimpleNamespace(
+			block_close_if_required_documents_pending=1,
+			block_close_if_milestones_incomplete=1,
+			block_close_if_charges_not_posted=1,
+			block_complete_if_required_documents_pending=0,
+			block_complete_if_milestones_incomplete=0,
+			block_complete_if_charges_not_posted=0,
+		)
+		mock_docs.return_value = [job_readiness._issue("document_incomplete", "doc")]
+		mock_ms.return_value = [job_readiness._issue("milestone_incomplete", "ms")]
+		mock_ch.return_value = [job_readiness._issue("charge_not_posted_si", "ch")]
+		doc = _doc(job_status="In Progress")
+		blocking = job_readiness._blocking_issues_for_gate(doc, "complete")
+		self.assertEqual(blocking, [])
+		# helpers should not be called when settings off
+		mock_docs.assert_not_called()
+		mock_ms.assert_not_called()
+		mock_ch.assert_not_called()
+
+	@patch("logistics.job_management.job_readiness._blocking_issues_for_gate")
+	def test_enforce_throws(self, mock_block):
+		mock_block.return_value = [
+			job_readiness._issue("charge_not_posted_si", "Charge #1 not posted")
+		]
+		doc = _doc()
+		with self.assertRaises(frappe.ValidationError):
+			job_readiness.enforce_job_readiness(doc, gate="close")
+
+
+class TestJobReadinessOpsWarning(unittest.TestCase):
+	def test_sea_ops_terminal_warning(self):
+		doc = _doc(shipping_status="In Transit")
+		issues = job_readiness.check_ops_terminal_status(doc)
+		self.assertEqual(len(issues), 1)
+		self.assertEqual(issues[0]["severity"], "warning")
+		self.assertEqual(issues[0]["code"], "ops_not_terminal")
+
+	def test_sea_delivered_ok(self):
+		doc = _doc(shipping_status="Delivered")
+		self.assertEqual(job_readiness.check_ops_terminal_status(doc), [])
+
+
+class TestGetJobReadiness(unittest.TestCase):
+	@patch("logistics.job_management.job_readiness.check_ops_terminal_status", return_value=[])
+	@patch("logistics.job_management.job_readiness.check_charges_posted", return_value=[])
+	@patch("logistics.job_management.job_readiness.check_milestones_complete", return_value=[])
+	@patch("logistics.job_management.job_readiness.check_required_documents", return_value=[])
+	def test_close_ok(self, *mocks):
+		doc = _doc()
+		result = job_readiness.get_job_readiness(doc, gate="close")
+		self.assertTrue(result["ok"])
+		self.assertEqual(result["gate"], "close")
+		self.assertEqual(result["errors"], [])
+
+	@patch("logistics.document_management.api.get_incomplete_required_documents")
+	def test_submit_master_data(self, mock_docs):
+		mock_docs.return_value = []
+		doc = _doc(
+			doctype="Air Shipment",
+			booking_date=None,
+			air_booking=None,
+			shipper=None,
+			consignee="C",
+			origin_port="AAA",
+			destination_port="BBB",
+			direction="Export",
+			local_customer="CUST",
+			airline=None,
+		)
+		result = job_readiness.get_job_readiness(doc, gate="submit")
+		codes = {e["code"] for e in result["errors"]}
+		self.assertIn("missing_party", codes)
+		warn_codes = {w["code"] for w in result["warnings"]}
+		self.assertIn("missing_carrier", warn_codes)
+
+
+class TestIncompleteDocumentsHelper(unittest.TestCase):
+	def test_get_incomplete_required_documents(self):
+		from logistics.document_management.api import get_incomplete_required_documents
+
+		doc = _doc(
+			documents=[
+				{"is_required": 1, "document_type": "BL", "status": "Pending"},
+				{"is_required": 1, "document_type": "CI", "status": "Received"},
+				{"is_required": 0, "document_type": "POD", "status": "Pending"},
+			]
+		)
+		# row.get for SimpleNamespace — documents need dict-like get
+		# rebuild with frappe._dict rows
+		doc.documents = [
+			frappe._dict({"is_required": 1, "document_type": "BL", "status": "Pending"}),
+			frappe._dict({"is_required": 1, "document_type": "CI", "status": "Received"}),
+			frappe._dict({"is_required": 0, "document_type": "POD", "status": "Pending"}),
+		]
+		incomplete = get_incomplete_required_documents(doc)
+		self.assertEqual(len(incomplete), 1)
+		self.assertIn("BL", incomplete[0])

--- a/logistics/logistics/doctype/logistics_settings/logistics_settings.json
+++ b/logistics/logistics/doctype/logistics_settings/logistics_settings.json
@@ -60,6 +60,14 @@
   "document_expiring_soon_days",
   "document_informational_days",
   "block_submit_if_required_documents_pending",
+  "job_readiness_section",
+  "block_complete_if_required_documents_pending",
+  "block_complete_if_milestones_incomplete",
+  "block_complete_if_charges_not_posted",
+  "column_break_job_readiness",
+  "block_close_if_required_documents_pending",
+  "block_close_if_milestones_incomplete",
+  "block_close_if_charges_not_posted",
   "milestones_section",
   "milestone_impending_days",
   "milestone_informational_days",
@@ -419,6 +427,52 @@
    "fieldtype": "Check",
    "label": "Prevent submit if required document incomplete",
    "description": "When enabled, submit is blocked on logistics forms that use the Documents table until every required row reaches Received, Verified, or Done (Pending, Uploaded, Overdue, Expired, and Rejected count as incomplete)."
+  },
+  {
+   "fieldname": "job_readiness_section",
+   "fieldtype": "Section Break",
+   "label": "Job Readiness (Complete / Close)",
+   "description": "Optional hard blocks when Job Status moves to Completed or Closed. Close gates default on. Completed gates default off so operational Delivered sync is not blocked by billing lag. Charge posting requires a submitted Sales/Purchase Invoice (Draft invoices do not count)."
+  },
+  {
+   "default": "0",
+   "fieldname": "block_complete_if_required_documents_pending",
+   "fieldtype": "Check",
+   "label": "Prevent Complete if required document incomplete"
+  },
+  {
+   "default": "0",
+   "fieldname": "block_complete_if_milestones_incomplete",
+   "fieldtype": "Check",
+   "label": "Prevent Complete if milestones incomplete"
+  },
+  {
+   "default": "0",
+   "fieldname": "block_complete_if_charges_not_posted",
+   "fieldtype": "Check",
+   "label": "Prevent Complete if charges not posted to SI/PI"
+  },
+  {
+   "fieldname": "column_break_job_readiness",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "1",
+   "fieldname": "block_close_if_required_documents_pending",
+   "fieldtype": "Check",
+   "label": "Prevent Close if required document incomplete"
+  },
+  {
+   "default": "1",
+   "fieldname": "block_close_if_milestones_incomplete",
+   "fieldtype": "Check",
+   "label": "Prevent Close if milestones incomplete"
+  },
+  {
+   "default": "1",
+   "fieldname": "block_close_if_charges_not_posted",
+   "fieldtype": "Check",
+   "label": "Prevent Close if charges not posted to SI/PI"
   },
   {
    "fieldname": "milestones_section",

--- a/logistics/sea_freight/doctype/sea_shipment/sea_shipment.py
+++ b/logistics/sea_freight/doctype/sea_shipment/sea_shipment.py
@@ -181,6 +181,11 @@ class SeaShipment(VirtualLinkedServicesMixin, Document):
         """Validate required data before submit; block DG non-compliance."""
         self.validate_required_fields_for_submit()
         validate_fcl_container_numbers_required(self)
+        from logistics.utils.charge_service_type import (
+            assert_destination_service_charges_on_submit_unless_internal_job,
+        )
+
+        assert_destination_service_charges_on_submit_unless_internal_job(self)
         try:
             contains_dg = bool(getattr(self, "contains_dangerous_goods", 0))
             dg_status = (getattr(self, "dg_compliance_status", "") or "").strip()
@@ -192,6 +197,8 @@ class SeaShipment(VirtualLinkedServicesMixin, Document):
                     ),
                     title=_("Dangerous Goods Non-Compliant"),
                 )
+        except frappe.ValidationError:
+            raise
         except Exception:
             # If any unexpected error occurs while checking, fail safe by throwing a clear message
             frappe.throw(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a shared **job readiness** framework so shipments/jobs can be gated consistently at **Submit** (start of ops) and **Complete/Close** (finish).

### Tier 1 — Submit
- **Air Shipment** `before_submit`: required parties/routing/booking + DG non-compliance block (parity with Sea)
- Destination service charge assert on **Air/Sea Shipment** (non-internal jobs)
- Wire **Warehouse Job** `warehouse_job_before_submit` in hooks (was defined but unwired)
- Existing required-documents submit gate unchanged

### Tier 2 — Complete / Close
- New [`job_readiness.py`](logistics/job_management/job_readiness.py): documents, milestones, charges ↔ SI/PI
- Charges count only when linked SI/PI is **submitted** (`docstatus=1`) and status is `Posted`/`Paid` (draft/`Requested` does not count)
- **Close** gates default **on**; **Complete** gates default **off** (so Delivered → Completed sync is not blocked by billing lag)
- Enforced on Job Status transition + `close_job_for_charges`
- Logistics Settings toggles under **Job Readiness (Complete / Close)**
- Desk **Action → Check Job Readiness** checklist

### Tests
- Unit coverage in `logistics/job_management/tests/test_job_readiness.py` (charge matrix, docs/milestones, settings defaults)

## Settings (defaults)

| Setting | Default |
|---|---|
| Prevent Complete if required document / milestones / charges | Off |
| Prevent Close if required document / milestones / charges | On |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-afea5e1d-7efb-49b8-b5b1-80e57ff568ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afea5e1d-7efb-49b8-b5b1-80e57ff568ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

