### PR TITLE
v1.0-update: fix(charges): clear stale Estimated fields in charge row UI (#1252)

### DIFF
--- a/logistics/pricing_center/doctype/change_request/change_request.js
+++ b/logistics/pricing_center/doctype/change_request/change_request.js
@@ -197,24 +197,14 @@ function _calculate_change_request_charge_row(frm, cdt, cdn) {
 			row_data: JSON.stringify(row),
 		},
 		callback: function (r) {
-			if (r.message && r.message.success) {
-				if ("estimated_revenue" in r.message) {
-					frappe.model.set_value(cdt, cdn, "estimated_revenue", r.message.estimated_revenue);
-				}
-				if ("estimated_cost" in r.message) {
-					frappe.model.set_value(cdt, cdn, "estimated_cost", r.message.estimated_cost);
-				}
-				if (r.message.quantity != null) {
-					frappe.model.set_value(cdt, cdn, "quantity", r.message.quantity);
-				}
-				if (r.message.cost_quantity != null) {
-					frappe.model.set_value(cdt, cdn, "cost_quantity", r.message.cost_quantity);
-				}
-				frappe.model.set_value(cdt, cdn, "revenue_calc_notes", r.message.revenue_calc_notes || "");
-				frappe.model.set_value(cdt, cdn, "cost_calc_notes", r.message.cost_calc_notes || "");
-				if (logistics.charges_disbursement && logistics.charges_disbursement.apply_charge_row_response) {
-					logistics.charges_disbursement.apply_charge_row_response(cdt, cdn, r);
-				}
+			if (logistics.charge_type_cleanup && logistics.charge_type_cleanup.apply_calculate_charge_row_response) {
+				logistics.charge_type_cleanup.apply_calculate_charge_row_response(
+					frm,
+					cdt,
+					cdn,
+					r,
+					"charges"
+				);
 			}
 		},
 	});

--- a/logistics/pricing_center/doctype/sales_quote/sales_quote.js
+++ b/logistics/pricing_center/doctype/sales_quote/sales_quote.js
@@ -790,6 +790,23 @@ frappe.ui.form.on("Sales Quote", {
 		// Sync quotation_type to child table rows so Charge Parameters show when Regular
 		frm.events._sync_quotation_type_to_children(frm);
 
+		if (
+			!frm.is_new() &&
+			frm.doc.charges &&
+			frm.doc.charges.length &&
+			logistics.charge_type_cleanup &&
+			logistics.charge_type_cleanup.recalculate_stale_charge_estimates
+		) {
+			setTimeout(function () {
+				logistics.charge_type_cleanup.recalculate_stale_charge_estimates(
+					frm,
+					"Sales Quote Charge",
+					"charges",
+					_calculate_sales_quote_charge_row
+				);
+			}, 0);
+		}
+
 		// One-off: back-fill Converted To / Status from linked bookings when missing
 		if (
 			frm.doc.quotation_type === "One-off" &&
@@ -2218,43 +2235,14 @@ function _calculate_sales_quote_charge_row(frm, cdt, cdn) {
 			row_data: JSON.stringify(row)
 		},
 		callback: function(r) {
-			if (r.message && r.message.success) {
-				if (r.message.row_updates && typeof r.message.row_updates === "object") {
-					frm._syncing_sq_charge_from_tariff = true;
-					try {
-						$.each(r.message.row_updates, function (key, v) {
-							if (v !== undefined && v !== null) {
-								frappe.model.set_value(cdt, cdn, key, v);
-							}
-						});
-					} finally {
-						frm._syncing_sq_charge_from_tariff = false;
-					}
-				}
-				if ("estimated_revenue" in r.message) {
-					frappe.model.set_value(cdt, cdn, "estimated_revenue", r.message.estimated_revenue);
-				}
-				if ("estimated_cost" in r.message) {
-					frappe.model.set_value(cdt, cdn, "estimated_cost", r.message.estimated_cost);
-				}
-				if (r.message.quantity != null) {
-					frappe.model.set_value(cdt, cdn, "quantity", r.message.quantity);
-				}
-				if (r.message.cost_quantity != null) {
-					frappe.model.set_value(cdt, cdn, "cost_quantity", r.message.cost_quantity);
-				}
-				frappe.model.set_value(cdt, cdn, "revenue_calc_notes", r.message.revenue_calc_notes || "");
-				frappe.model.set_value(cdt, cdn, "cost_calc_notes", r.message.cost_calc_notes || "");
-				if (frm.fields_dict.charges && frm.fields_dict.charges.grid) {
-					var grid_row = frm.fields_dict.charges.grid.grid_rows_by_docname[cdn];
-					if (grid_row && grid_row.grid_form) {
-						grid_row.grid_form.refresh_field("estimated_revenue");
-						grid_row.grid_form.refresh_field("estimated_cost");
-					}
-				}
-				if (logistics.charges_disbursement && logistics.charges_disbursement.apply_charge_row_response) {
-					logistics.charges_disbursement.apply_charge_row_response(cdt, cdn, r);
-				}
+			if (logistics.charge_type_cleanup && logistics.charge_type_cleanup.apply_calculate_charge_row_response) {
+				logistics.charge_type_cleanup.apply_calculate_charge_row_response(
+					frm,
+					cdt,
+					cdn,
+					r,
+					"charges"
+				);
 			}
 		}
 	});

--- a/logistics/public/js/charge_type_cleanup.js
+++ b/logistics/public/js/charge_type_cleanup.js
@@ -103,7 +103,84 @@ frappe.provide("logistics.charge_type_cleanup");
 		_clear_fields_on_row(cdt, cdn, REVENUE_CLEAR_FIELDS);
 	};
 
-	logistics.charge_type_cleanup.apply_calculate_charge_row_response = function (frm, cdt, cdn, r) {
+	function _charge_side_has_billable_rate(row, isRevenue) {
+		if (!row) {
+			return false;
+		}
+		var method = (
+			isRevenue
+				? row.revenue_calculation_method || row.calculation_method
+				: row.cost_calculation_method
+		);
+		method = (method || "").trim();
+		if (!method) {
+			return false;
+		}
+		if (["Weight Break", "Qty Break", "Percentage Break"].indexOf(method) !== -1) {
+			return true;
+		}
+		if (method === "Percentage") {
+			var baseField = isRevenue ? "base_amount" : "cost_base_amount";
+			var rateField = isRevenue ? "unit_rate" : "unit_cost";
+			return flt(row[rateField]) > 0 && flt(row[baseField]) > 0;
+		}
+		return flt(isRevenue ? row.unit_rate : row.unit_cost) > 0;
+	}
+
+	function _refresh_charge_row_field_controls(frm, cdt, cdn, fieldnames, tableFieldname) {
+		if (!frm || !frm.fields_dict) {
+			return;
+		}
+		var grid = frm.fields_dict[tableFieldname || "charges"];
+		grid = grid && grid.grid;
+		if (!grid) {
+			return;
+		}
+		var grid_row = grid.grid_rows_by_docname && grid.grid_rows_by_docname[cdn];
+		if (!grid_row) {
+			return;
+		}
+		fieldnames.forEach(function (fieldname) {
+			if (grid_row.refresh_field) {
+				grid_row.refresh_field(fieldname);
+			}
+			if (grid_row.grid_form && grid_row.grid_form.fields_dict[fieldname]) {
+				var control = grid_row.grid_form.fields_dict[fieldname];
+				var row = locals[cdt] && locals[cdt][cdn];
+				if (control.set_value && row) {
+					control.set_value(row[fieldname]);
+				}
+				if (control.refresh) {
+					control.refresh();
+				}
+			}
+		});
+	}
+
+	logistics.charge_type_cleanup.charge_row_has_billable_rate = _charge_side_has_billable_rate;
+
+	logistics.charge_type_cleanup.refresh_charge_row_estimate_controls = function (
+		frm,
+		cdt,
+		cdn,
+		tableFieldname
+	) {
+		_refresh_charge_row_field_controls(
+			frm,
+			cdt,
+			cdn,
+			["estimated_revenue", "estimated_cost"],
+			tableFieldname
+		);
+	};
+
+	logistics.charge_type_cleanup.apply_calculate_charge_row_response = function (
+		frm,
+		cdt,
+		cdn,
+		r,
+		tableFieldname
+	) {
 		if (!r || !r.message || !r.message.success) {
 			return;
 		}
@@ -138,12 +215,41 @@ frappe.provide("logistics.charge_type_cleanup");
 		if (frappe.meta.get_docfield(cdt, "cost_calc_notes")) {
 			frappe.model.set_value(cdt, cdn, "cost_calc_notes", r.message.cost_calc_notes || "");
 		}
+		logistics.charge_type_cleanup.refresh_charge_row_estimate_controls(
+			frm,
+			cdt,
+			cdn,
+			tableFieldname
+		);
 		if (logistics.charges_disbursement && logistics.charges_disbursement.apply_charge_row_response) {
 			logistics.charges_disbursement.apply_charge_row_response(cdt, cdn, r);
 		}
 	};
 
-	logistics.charge_type_cleanup.recalculate_charge_row = function (frm, cdt, cdn) {
+	logistics.charge_type_cleanup.recalculate_stale_charge_estimates = function (
+		frm,
+		cdt,
+		tableFieldname,
+		recalculateFn
+	) {
+		if (!frm || !frm.doc || frm.is_new() || typeof recalculateFn !== "function") {
+			return;
+		}
+		(frm.doc[tableFieldname || "charges"] || []).forEach(function (row) {
+			if (!row || !row.name) {
+				return;
+			}
+			var staleRevenue =
+				!_charge_side_has_billable_rate(row, true) && flt(row.estimated_revenue) > 0;
+			var staleCost =
+				!_charge_side_has_billable_rate(row, false) && flt(row.estimated_cost) > 0;
+			if (staleRevenue || staleCost) {
+				recalculateFn(frm, cdt, row.name);
+			}
+		});
+	};
+
+	logistics.charge_type_cleanup.recalculate_charge_row = function (frm, cdt, cdn, tableFieldname) {
 		if (!cdn || !frm || !frm.doc) {
 			return;
 		}
@@ -164,7 +270,13 @@ frappe.provide("logistics.charge_type_cleanup");
 						: null,
 			},
 			callback: function (r) {
-				logistics.charge_type_cleanup.apply_calculate_charge_row_response(frm, cdt, cdn, r);
+				logistics.charge_type_cleanup.apply_calculate_charge_row_response(
+					frm,
+					cdt,
+					cdn,
+					r,
+					tableFieldname
+				);
 			},
 		});
 	};
@@ -185,7 +297,7 @@ frappe.provide("logistics.charge_type_cleanup");
 			frm.refresh_field(table);
 		}
 		if (ct === "Revenue" || ct === "Cost" || ct === "Disbursement") {
-			logistics.charge_type_cleanup.recalculate_charge_row(frm, cdt, cdn);
+			logistics.charge_type_cleanup.recalculate_charge_row(frm, cdt, cdn, tableFieldname);
 		}
 	};
 

--- a/logistics/utils/test_charges_calculation_estimated.py
+++ b/logistics/utils/test_charges_calculation_estimated.py
@@ -78,6 +78,59 @@ class TestChargesCalculationEstimated(UnitTestCase):
 		self.assertEqual(_estimated_display_amount(charge, rev.get("amount"), is_revenue=True), 5000)
 		self.assertEqual(_estimated_display_amount(charge, cost.get("amount"), is_revenue=False), 5000)
 
+	def test_calculate_charge_row_returns_null_estimates_without_rate(self):
+		import json
+		from unittest.mock import MagicMock, patch
+
+		from logistics.utils.charges_calculation import calculate_charge_row
+
+		class _Doc(dict):
+			def __init__(self, doctype):
+				super().__init__()
+				self.doctype = doctype
+
+			def update(self, row_dict):
+				for key, val in row_dict.items():
+					setattr(self, key, val)
+
+		row = dict(
+			name="sqc-test",
+			doctype="Sales Quote Charge",
+			parenttype="Sales Quote",
+			parent="new-OOQ-TEST",
+			revenue_calculation_method="Flat Rate",
+			cost_calculation_method="Flat Rate",
+			unit_rate=0,
+			unit_cost=0,
+			minimum_charge=5000,
+			cost_minimum_charge=5000,
+			currency="PHP",
+			cost_currency="PHP",
+			estimated_revenue=5000,
+			estimated_cost=5000,
+		)
+		with patch(
+			"logistics.utils.charges_calculation._fetch_rates_from_tariff_if_needed",
+			return_value=None,
+		), patch(
+			"logistics.utils.charges_calculation.frappe.new_doc",
+			side_effect=lambda dt: _Doc(dt),
+		), patch(
+			"logistics.utils.charges_calculation.frappe.get_meta",
+			return_value=MagicMock(has_field=lambda _n: True, get_field=lambda _n: None),
+		):
+			out = calculate_charge_row(
+				"Sales Quote Charge",
+				"Sales Quote",
+				"new-OOQ-TEST",
+				json.dumps(row),
+			)
+		self.assertTrue(out.get("success"))
+		self.assertIn("estimated_revenue", out)
+		self.assertIn("estimated_cost", out)
+		self.assertIsNone(out.get("estimated_revenue"))
+		self.assertIsNone(out.get("estimated_cost"))
+
 	def test_per_unit_with_rate_shows_calculated_amount(self):
 		charge = self._flat_rate_charge(
 			revenue_calculation_method="Per Unit",


### PR DESCRIPTION
## Summary
- Clears stale Estimated Revenue/Cost values on Sales Quote charge rows after item `minimum_charge` left ghost amounts (e.g. ₱5,000) in the UI
- Follow-up to the server-side fix in #1268: Desk now handles null API estimates correctly, refreshes expanded grid Currency controls, and recalculates stale estimate rows on form load when no unit rate/cost was entered

## Test plan
- [ ] Open a Sales Quote with charge rows that previously showed stale Estimated Revenue/Cost from item minimum charge
- [ ] Confirm Estimated fields clear/update correctly after charge type cleanup
- [ ] Expand a charge row and verify Currency controls no longer show ghost amounts
- [ ] Reload an existing quote with no unit rate/cost and confirm stale estimates recalculate on form load

Fixes #1252