### PR TITLE
 fix(sales-quote): load charge_type_cleanup and add estimate fallback

### DIFF
--- a/logistics/air_freight/doctype/air_booking/air_booking.js
+++ b/logistics/air_freight/doctype/air_booking/air_booking.js
@@ -803,6 +803,9 @@ frappe.ui.form.on('Air Booking', {
 			if (window.logistics && logistics.add_get_charges_from_quotation_button_if_allowed) {
 				logistics.add_get_charges_from_quotation_button_if_allowed(frm);
 			}
+			if (window.logistics && logistics.add_get_charges_from_tariff_button_if_allowed) {
+				logistics.add_get_charges_from_tariff_button_if_allowed(frm);
+			}
 			frm.add_custom_button(__('Get Milestones'), function() {
 				frappe.call({
 					method: 'logistics.document_management.api.populate_milestones_from_template',

--- a/logistics/air_freight/doctype/air_booking/air_booking.py
+++ b/logistics/air_freight/doctype/air_booking/air_booking.py
@@ -508,6 +508,9 @@ class AirBooking(VirtualLinkedServicesMixin, Document):
 		)
 
 		assert_sales_quote_customer_matches_job_before_submit(self)
+		from logistics.utils.get_charges_from_tariff import assert_tariff_customer_matches_job_before_submit
+
+		assert_tariff_customer_matches_job_before_submit(self)
 		self._require_positive_booking_volume(
 			_("Volume must be greater than 0 before submitting the Air Booking")
 		)
@@ -1382,6 +1385,49 @@ class AirBooking(VirtualLinkedServicesMixin, Document):
 				"Air Booking - Charges Population Error"
 			)
 			raise
+
+	def _build_charge_dicts_from_tariff(self, tariff_name, filter_overrides=None):
+		"""Map Tariff Charge rows to Air Booking charge dicts (preview / apply)."""
+		from logistics.utils.charge_service_type import implied_service_type_for_doctype
+		from logistics.utils.tariff_charge_copy import (
+			effective_booking_corridor,
+			filter_tariff_charge_rows_for_booking,
+			parse_gcft_filter_overrides,
+			tariff_charge_row_as_quote_like_dict,
+		)
+
+		ov = parse_gcft_filter_overrides(self.doctype, filter_overrides)
+		service_type = implied_service_type_for_doctype(self.doctype) or "Air"
+		origin, dest, airline, shipping_line = effective_booking_corridor(self, ov)
+		tariff_doc = frappe.get_doc("Tariff", tariff_name)
+		rows = filter_tariff_charge_rows_for_booking(
+			self,
+			tariff_doc,
+			service_type,
+			origin=origin,
+			destination=dest,
+			airline=airline,
+			shipping_line=shipping_line,
+		)
+		charges = []
+		for row in rows:
+			quote_like = tariff_charge_row_as_quote_like_dict(row, tariff_name)
+			charge_row = self._map_sales_quote_air_freight_to_charge(quote_like)
+			if not charge_row:
+				continue
+			charge_row["revenue_tariff"] = tariff_name
+			charge_row["cost_tariff"] = tariff_name
+			charge_row.pop("sales_quote_link", None)
+			charges.append(charge_row)
+		if charges:
+			self._apply_actuals_to_charge_dicts(charges)
+		return charges
+
+	def _populate_charges_from_tariff(self, tariff_name, filter_overrides=None):
+		"""Replace charge lines from an active Tariff (Action → Get Charges from Tariff)."""
+		self.set("charges", [])
+		for charge_row in self._build_charge_dicts_from_tariff(tariff_name, filter_overrides):
+			self.append("charges", charge_row)
 	
 	def _populate_charges_from_one_off_quote(self):
 		"""Populate charges from One-Off Quote (which is a Sales Quote with quotation_type='One-off').
@@ -2974,6 +3020,41 @@ def populate_charges_from_sales_quote(
 			"error": f"Error populating charges: {str(e)}",
 			"charges": []
 		}
+
+
+@frappe.whitelist()
+def populate_charges_from_tariff(docname: str = None, tariff_name: str = None, filter_overrides=None):
+	"""Preview charge lines from a tariff without saving the Air Booking."""
+	if not tariff_name:
+		return {"charges": []}
+	try:
+		if not frappe.db.exists("Tariff", tariff_name):
+			return {"error": _("Tariff {0} does not exist").format(tariff_name), "charges": []}
+		doc = None
+		if docname:
+			try:
+				doc = frappe.get_doc("Air Booking", docname)
+			except Exception:
+				pass
+		temp_doc = doc if doc else frappe.new_doc("Air Booking")
+		charges = temp_doc._build_charge_dicts_from_tariff(tariff_name, filter_overrides)
+		if not charges:
+			return {
+				"charges": [],
+				"message": _("No matching charge lines on tariff {0}.").format(tariff_name),
+				"tariff": tariff_name,
+			}
+		return {
+			"charges": charges,
+			"charges_count": len(charges),
+			"tariff": tariff_name,
+		}
+	except Exception as e:
+		frappe.log_error(
+			f"Error populating Air Booking charges from tariff {tariff_name}: {str(e)}",
+			"Air Booking Tariff Charges Population Error",
+		)
+		return {"error": _("Error populating charges: {0}").format(str(e)), "charges": []}
 
 
 @frappe.whitelist()

--- a/logistics/air_freight/doctype/air_shipment/air_shipment.py
+++ b/logistics/air_freight/doctype/air_shipment/air_shipment.py
@@ -31,6 +31,14 @@ _MAWB_VIRTUAL_FIELD_SOURCES = (
 
 
 class AirShipment(VirtualLinkedServicesMixin, Document):
+	def before_insert(self):
+		self.set_new_name()
+		from logistics.utils.house_document_defaults import (
+			auto_populate_export_house_document_from_shipment_id,
+		)
+
+		auto_populate_export_house_document_from_shipment_id(self)
+
 	def before_save(self):
 		"""Calculate sustainability metrics before saving"""
 		super().before_save()
@@ -1657,6 +1665,12 @@ class AirShipment(VirtualLinkedServicesMixin, Document):
 		# Apply settings defaults if this is a new document
 		if self.is_new():
 			self.apply_settings_defaults()
+
+		from logistics.utils.house_document_defaults import (
+			auto_populate_export_house_document_from_shipment_id,
+		)
+
+		auto_populate_export_house_document_from_shipment_id(self)
 		
 		# Update DG compliance status before saving
 		self.update_dg_compliance_status()

--- a/logistics/hooks.py
+++ b/logistics/hooks.py
@@ -60,6 +60,7 @@ app_include_js = [
 	"/assets/logistics/js/sea_consolidation_matching_shipments.js?v=3",
 	"/assets/logistics/js/air_consolidation_matching_shipments.js?v=5",
 	"/assets/logistics/js/charges_disbursement_sync.js",
+	"/assets/logistics/js/charge_type_cleanup.js",
 	"/assets/logistics/js/charge_break_dialogs.js",
 	"/assets/logistics/js/volume_from_dimensions.js",
 	"/assets/logistics/js/density_factor.js?v=2",
@@ -98,6 +99,7 @@ doctype_js = {
 	# sales_quote.js is omitted: it loads via the DocType's own __js; listing it here would double-bind.
 	"Sales Quote": [
 		"public/js/operational_exchange_rate_grid.js",
+		"public/js/charge_type_cleanup.js",
 		"public/js/charge_break_dialogs.js",
 		"public/js/charge_break_buttons.js",
 		"pricing_center/doctype/sales_quote_charge/sales_quote_charge.js",

--- a/logistics/hooks.py
+++ b/logistics/hooks.py
@@ -56,6 +56,7 @@ app_include_js = [
 	"/assets/logistics/js/service_role.js?v=3",
 	"/assets/logistics/js/internal_job_detail_grid_delete_fix.js",
 	"/assets/logistics/js/get_charges_from_quotation.js?v=18",
+	"/assets/logistics/js/get_charges_from_tariff.js?v=1",
 	"/assets/logistics/js/sea_consolidation_matching_shipments.js?v=3",
 	"/assets/logistics/js/air_consolidation_matching_shipments.js?v=5",
 	"/assets/logistics/js/charges_disbursement_sync.js",
@@ -128,6 +129,7 @@ doctype_js = {
 		"public/js/charge_break_buttons.js",
 		# Same Get Charges from Quotation UI as Sea Booking / Transport Order (list criteria, search, cards, Apply).
 		"logistics/public/js/get_charges_from_quotation.js",
+		"logistics/public/js/get_charges_from_tariff.js",
 	],
 	"Air Shipment": [
 		"logistics/public/js/operational_exchange_rate_grid.js",

--- a/logistics/pricing_center/doctype/sales_quote/sales_quote.js
+++ b/logistics/pricing_center/doctype/sales_quote/sales_quote.js
@@ -2244,6 +2244,20 @@ function _calculate_sales_quote_charge_row(frm, cdt, cdn) {
 					r,
 					"charges"
 				);
+				return;
+			}
+			// Fallback when charge_type_cleanup.js is not loaded (estimates would otherwise stay blank)
+			if (!r || !r.message || !r.message.success) return;
+			["estimated_revenue", "estimated_cost", "quantity", "cost_quantity"].forEach(function (fn) {
+				if (fn in r.message && frappe.meta.get_docfield(cdt, fn)) {
+					frappe.model.set_value(cdt, cdn, fn, r.message[fn]);
+				}
+			});
+			if (frappe.meta.get_docfield(cdt, "revenue_calc_notes")) {
+				frappe.model.set_value(cdt, cdn, "revenue_calc_notes", r.message.revenue_calc_notes || "");
+			}
+			if (frappe.meta.get_docfield(cdt, "cost_calc_notes")) {
+				frappe.model.set_value(cdt, cdn, "cost_calc_notes", r.message.cost_calc_notes || "");
 			}
 		}
 	});

--- a/logistics/public/js/get_charges_from_tariff.js
+++ b/logistics/public/js/get_charges_from_tariff.js
@@ -1,0 +1,557 @@
+// Copyright (c) 2026, AgilaSoft and contributors
+// Action → Get Charges from Tariff (Sea Booking, Air Booking)
+
+frappe.provide("logistics");
+
+var GET_CHARGES_TITLE_TARIFF = __("Get Charges from Tariff");
+var GCFT_FILTER_GRID_SLOTS = 8;
+
+function _gcft_readonly_party_label(frm) {
+	if (!frm || !frm.doc) {
+		return "";
+	}
+	return (frm.doc.local_customer_name || frm.doc.local_customer || "").trim();
+}
+
+function _gcft_filter_specs(frm) {
+	if (frm.doctype === "Sea Booking") {
+		return [
+			{ key: "_svc", readonly: true, label: __("Main Service"), value: __("Sea") },
+			{
+				key: "_cust",
+				readonly: true,
+				label: __("Local Customer"),
+				value: _gcft_readonly_party_label(frm),
+			},
+			{
+				key: "origin_port",
+				fieldtype: "Link",
+				options: "UNLOCO",
+				label: __("Origin Port"),
+				value: frm.doc.origin_port || "",
+			},
+			{
+				key: "destination_port",
+				fieldtype: "Link",
+				options: "UNLOCO",
+				label: __("Destination Port"),
+				value: frm.doc.destination_port || "",
+			},
+			{
+				key: "shipping_line",
+				fieldtype: "Link",
+				options: "Shipping Line",
+				label: __("Shipping Line"),
+				value: frm.doc.shipping_line || "",
+			},
+		];
+	}
+	if (frm.doctype === "Air Booking") {
+		return [
+			{ key: "_svc", readonly: true, label: __("Main Service"), value: __("Air") },
+			{
+				key: "_cust",
+				readonly: true,
+				label: __("Local Customer"),
+				value: _gcft_readonly_party_label(frm),
+			},
+			{
+				key: "origin_port",
+				fieldtype: "Link",
+				options: "UNLOCO",
+				label: __("Origin Port"),
+				value: frm.doc.origin_port || "",
+			},
+			{
+				key: "destination_port",
+				fieldtype: "Link",
+				options: "UNLOCO",
+				label: __("Destination Port"),
+				value: frm.doc.destination_port || "",
+			},
+			{
+				key: "airline",
+				fieldtype: "Link",
+				options: "Airline",
+				label: __("Airline"),
+				value: frm.doc.airline || "",
+			},
+		];
+	}
+	return [];
+}
+
+function _gcft_pad_specs(specs, n) {
+	var out = specs.slice();
+	while (out.length < n) {
+		out.push({ placeholder: true, readonly: true, label: __("Filter field"), value: "", key: null });
+	}
+	return out.slice(0, n);
+}
+
+function _gcft_mount_filter_cell($grid, spec, frm, dialog, idx) {
+	var $cell = $('<div class="logistics-gcfq-filter-cell">').appendTo($grid);
+	if (spec.placeholder) {
+		$cell.append(
+			$('<label class="logistics-gcfq-filter-label logistics-gcfq-filter-label--muted">').text(spec.label)
+		);
+		$cell.append(
+			$('<input type="text" class="form-control input-sm logistics-gcfq-filter-input" readonly tabindex="-1">').attr(
+				"placeholder",
+				__("—")
+			)
+		);
+		return;
+	}
+	$cell.append($('<label class="logistics-gcfq-filter-label">').text(spec.label));
+	if (spec.readonly) {
+		var $inp = $(
+			'<input type="text" class="form-control input-sm logistics-gcfq-filter-input" readonly tabindex="-1">'
+		).val(spec.value || "");
+		$cell.append($inp);
+		dialog._gcft_filter_controls.push({
+			key: spec.key,
+			read_only: true,
+			get_value: function () {
+				return spec.value || "";
+			},
+		});
+		return;
+	}
+	var df = {
+		fieldname: "gcft_filter_" + idx,
+		label: "",
+		fieldtype: spec.fieldtype,
+		options: spec.options || "",
+	};
+	var ctrl = frappe.ui.form.make_control({ df: df, parent: $cell, render_input: true });
+	ctrl.set_value(spec.value || "");
+	dialog._gcft_filter_controls.push({
+		key: spec.key,
+		read_only: false,
+		get_value: function () {
+			return ctrl.get_value();
+		},
+		control: ctrl,
+	});
+}
+
+function _gcft_filter_value_from_frm(frm, key) {
+	if (!frm || !frm.doc || !key) {
+		return "";
+	}
+	var v = frm.doc[key];
+	return v == null ? "" : String(v).trim();
+}
+
+function _gcft_capture_initial_filter_snapshot(dialog, frm) {
+	dialog._gcft_initial_filter_values = {};
+	(dialog._gcft_filter_controls || []).forEach(function (c) {
+		if (!c.key || c.key.charAt(0) === "_") {
+			return;
+		}
+		if (c.read_only) {
+			return;
+		}
+		var v = frm && c.key ? _gcft_filter_value_from_frm(frm, c.key) : c.get_value();
+		dialog._gcft_initial_filter_values[c.key] = v == null ? "" : String(v).trim();
+	});
+}
+
+function _gcft_collect_filter_overrides(dialog) {
+	var o = {};
+	var init = dialog._gcft_initial_filter_values || {};
+	(dialog._gcft_filter_controls || []).forEach(function (c) {
+		if (!c.key || c.key.charAt(0) === "_") {
+			return;
+		}
+		if (c.read_only) {
+			return;
+		}
+		var v = c.get_value();
+		var s = v == null ? "" : String(v).trim();
+		if (!Object.prototype.hasOwnProperty.call(init, c.key)) {
+			o[c.key] = s;
+			return;
+		}
+		var i = String(init[c.key] == null ? "" : init[c.key]).trim();
+		if (s !== i) {
+			o[c.key] = s;
+		}
+	});
+	return o;
+}
+
+function _gcft_mount_filter_panel($parent, frm, dialog, reloadList) {
+	$parent.empty();
+	dialog._gcft_filter_controls = [];
+	var $box = $('<div class="logistics-gcfq-filters">').appendTo($parent);
+	$box.append($('<div class="logistics-gcfq-filters-title">').text(__("List filter criteria")));
+	var $grid = $('<div class="logistics-gcfq-filters-grid">').appendTo($box);
+	var specs = _gcft_pad_specs(_gcft_filter_specs(frm), GCFT_FILTER_GRID_SLOTS);
+	specs.forEach(function (spec, idx) {
+		_gcft_mount_filter_cell($grid, spec, frm, dialog, idx);
+	});
+	var timer;
+	function schedule() {
+		if (!dialog._gcft_ready) {
+			return;
+		}
+		if (timer) {
+			clearTimeout(timer);
+		}
+		timer = setTimeout(function () {
+			timer = null;
+			reloadList();
+		}, 350);
+	}
+	(dialog._gcft_filter_controls || []).forEach(function (c) {
+		if (c.read_only) {
+			return;
+		}
+		if (c.control && c.control.$wrapper) {
+			c.control.$wrapper.on("change", schedule);
+		}
+	});
+	$("<button type='button' class='btn btn-sm btn-default'>")
+		.text(__("Apply filters"))
+		.appendTo($('<div class="gcfq-filter-actions">').appendTo($box))
+		.on("click", reloadList);
+}
+
+logistics.should_show_get_charges_from_tariff = function (frm) {
+	if (!frm || !frm.doc) {
+		return false;
+	}
+	if (frm.doctype !== "Sea Booking" && frm.doctype !== "Air Booking") {
+		return false;
+	}
+	var as_int =
+		typeof cint === "function"
+			? cint
+			: function (v) {
+					return parseInt(v, 10) || 0;
+				};
+	if (frm.doc.__islocal) {
+		return false;
+	}
+	if (as_int(frm.doc.docstatus) !== 0) {
+		return false;
+	}
+	if (as_int(frm.doc.is_internal_job)) {
+		return false;
+	}
+	if (
+		window.logistics &&
+		typeof logistics.job_linked_sales_quote_name === "function" &&
+		logistics.job_linked_sales_quote_name(frm)
+	) {
+		return false;
+	}
+	if (
+		window.logistics &&
+		typeof logistics.job_should_hide_get_charges_from_quotation === "function" &&
+		logistics.job_should_hide_get_charges_from_quotation(frm)
+	) {
+		return false;
+	}
+	return true;
+};
+
+logistics.add_get_charges_from_tariff_button_if_allowed = function (frm) {
+	if (
+		!window.logistics ||
+		typeof logistics.should_show_get_charges_from_tariff !== "function" ||
+		!logistics.should_show_get_charges_from_tariff(frm)
+	) {
+		return;
+	}
+	frm.add_custom_button(__("Get Charges from Tariff"), function () {
+		if (logistics.open_get_charges_from_tariff_dialog) {
+			logistics.open_get_charges_from_tariff_dialog(frm);
+		}
+	}, __("Action"));
+};
+
+function _gcft_preview_inner_html(m) {
+	if (!m || typeof m !== "object") {
+		return '<div class="logistics-gcfq-preview-empty">' + __("Preview failed.") + "</div>";
+	}
+	if (m.error) {
+		return (
+			'<div class="alert alert-danger mb-0">' + frappe.utils.escape_html(String(m.error)) + "</div>"
+		);
+	}
+	var charges = Array.isArray(m.charges) ? m.charges : [];
+	var cnt = m.charges_count != null ? m.charges_count : charges.length;
+	var lines =
+		'<div class="logistics-gcfq-preview logistics-gcfq-preview--in-card">' +
+		'<div class="logistics-gcfq-preview-toolbar">' +
+		'<span class="logistics-gcfq-preview-toolbar-title">' +
+		__("Charge preview") +
+		"</span>" +
+		'<span class="logistics-gcfq-preview-count">' +
+		frappe.utils.escape_html(String(cnt)) +
+		" " +
+		__(cnt === 1 ? "charge line" : "charge lines") +
+		"</span></div>";
+	if (!charges.length) {
+		lines +=
+			'<div class="logistics-gcfq-preview-empty">' +
+			__("No charge lines to show for this tariff.") +
+			"</div></div>";
+		return lines;
+	}
+	lines +=
+		'<div class="logistics-gcfq-table-wrap logistics-gcfq-preview-table-wrap">' +
+		'<table class="logistics-gcfq-table logistics-gcfq-preview-table">' +
+		"<thead><tr><th>" +
+		__("Service type") +
+		"</th><th>" +
+		__("Item code") +
+		"</th><th>" +
+		__("Item name") +
+		"</th><th class='gcfq-preview-th-rate'>" +
+		__("Unit rate") +
+		"</th></tr></thead><tbody>";
+	charges.slice(0, 40).forEach(function (c) {
+		if (!c) {
+			return;
+		}
+		var raw =
+			c.unit_rate !== undefined && c.unit_rate !== null && c.unit_rate !== ""
+				? c.unit_rate
+				: c.rate;
+		var rateCell = raw != null && raw !== "" ? frappe.utils.escape_html(String(raw)) : "—";
+		lines +=
+			"<tr><td>" +
+			frappe.utils.escape_html(String(c.service_type || "")) +
+			"</td><td>" +
+			frappe.utils.escape_html(String(c.item_code || "")) +
+			"</td><td>" +
+			frappe.utils.escape_html(String(c.item_name || "")) +
+			"</td><td>" +
+			rateCell +
+			"</td></tr>";
+	});
+	lines += "</tbody></table></div></div>";
+	return lines;
+}
+
+function _gcft_load_card_preview($pv, frm, tariff_name, dialog, onDone) {
+	$pv.html(
+		'<div class="gcfq-card-loading"><span class="gcfq-card-loading-spin"></span><span>' +
+			__("Loading charge preview…") +
+			"</span></div>"
+	);
+	frappe.call({
+		method: "logistics.utils.get_charges_from_tariff.preview_tariff_charges_for_job",
+		args: {
+			doctype: frm.doctype,
+			docname: frm.doc.name,
+			tariff_name: tariff_name,
+			filter_overrides: _gcft_collect_filter_overrides(dialog),
+		},
+		callback: function (r) {
+			var m = (r && r.message) || {};
+			$pv.html(_gcft_preview_inner_html(m));
+			var cnt = 0;
+			if (!m.error) {
+				cnt = m.charges_count != null ? m.charges_count : (m.charges || []).length;
+			}
+			$pv.data("gcft-charges-count", cnt);
+			if (onDone) {
+				onDone(cnt);
+			}
+		},
+		error: function () {
+			$pv.html('<div class="alert alert-danger mb-0">' + __("Preview failed.") + "</div>");
+			if (onDone) {
+				onDone(0);
+			}
+		},
+	});
+}
+
+function _gcft_apply_tariff(frm, tariff_name, dialog) {
+	frappe.confirm(
+		__(
+			"Apply charges from Tariff {0}? Existing charge lines will be replaced.",
+			[tariff_name]
+		),
+		function () {
+			frappe.call({
+				method: "logistics.utils.get_charges_from_tariff.apply_tariff_charges_to_job",
+				args: {
+					doctype: frm.doctype,
+					docname: frm.doc.name,
+					tariff_name: tariff_name,
+					filter_overrides: _gcft_collect_filter_overrides(dialog),
+				},
+				freeze: true,
+				freeze_message: __("Applying…"),
+				callback: function (r2) {
+					if (!r2 || r2.exc) {
+						frappe.msgprint(__("Apply failed."));
+						return;
+					}
+					dialog.hide();
+					frappe.show_alert({
+						message: (r2.message && r2.message.message) || __("Applied."),
+						indicator: "green",
+					});
+					frm.reload_doc();
+				},
+			});
+		}
+	);
+}
+
+function _gcft_bind_cards($wrap, frm, dialog) {
+	$wrap.off(".gcft");
+	$wrap.on("click.gcft", ".gcfq-card-toggle", function () {
+		var $card = $(this).closest(".gcfq-card");
+		$card.toggleClass("open");
+		if (!$card.hasClass("open")) {
+			return;
+		}
+		var $pv = $card.find(".gcfq-card-preview");
+		if ($pv.data("gcft-loaded")) {
+			return;
+		}
+		var tn = $card.attr("data-tariff-name") || "";
+		var $btn = $card.find(".gcfq-card-apply");
+		_gcft_load_card_preview($pv, frm, tn, dialog, function (cnt) {
+			$pv.data("gcft-loaded", true);
+			$btn.prop("disabled", !cnt);
+		});
+	});
+	$wrap.on("click.gcft", ".gcfq-card-apply", function (e) {
+		e.preventDefault();
+		e.stopPropagation();
+		var $card = $(this).closest(".gcfq-card");
+		var tn = $card.attr("data-tariff-name") || "";
+		var $pv = $card.find(".gcfq-card-preview");
+		if (!$pv.data("gcft-loaded")) {
+			$card.addClass("open");
+			var $btn = $(this);
+			_gcft_load_card_preview($pv, frm, tn, dialog, function (cnt) {
+				$pv.data("gcft-loaded", true);
+				$btn.prop("disabled", !cnt);
+				if (cnt) {
+					_gcft_apply_tariff(frm, tn, dialog);
+				}
+			});
+			return;
+		}
+		if (!$pv.data("gcft-charges-count")) {
+			frappe.msgprint(__("No charge lines to apply for this tariff."));
+			return;
+		}
+		_gcft_apply_tariff(frm, tn, dialog);
+	});
+}
+
+function _gcft_load_tariff_list(frm, dialog, $dynamic) {
+	$dynamic.html('<p class="text-muted">' + __("Loading tariffs…") + "</p>");
+	frappe.call({
+		method: "logistics.utils.get_charges_from_tariff.list_tariffs_for_job",
+		args: {
+			doctype: frm.doctype,
+			docname: frm.doc.name,
+			filter_overrides: _gcft_collect_filter_overrides(dialog),
+		},
+		callback: function (r) {
+			dialog._gcft_ready = true;
+			if (!r || r.exc) {
+				$dynamic.html('<div class="alert alert-danger">' + __("Failed to load tariffs.") + "</div>");
+				return;
+			}
+			var msg = (r.message && r.message.message) || "";
+			var tariffs = (r.message && r.message.tariffs) || [];
+			if (!tariffs.length) {
+				$dynamic.html(
+					'<div class="alert alert-warning logistics-gcfq-status-alert mb-0">' +
+						frappe.utils.escape_html(msg || __("No matching tariffs found.")) +
+						"</div>"
+				);
+				return;
+			}
+			var $cards = $('<div class="gcfq-cards">');
+			tariffs.forEach(function (row) {
+				var tn = row.name || "";
+				var title = row.tariff_name || tn;
+				var $card = $('<div class="gcfq-card">').attr("data-tariff-name", tn);
+				var $hd = $('<div class="gcfq-card-hd">');
+				var $toggle = $('<div class="gcfq-card-toggle" role="button" tabindex="0">');
+				$toggle.append($('<span class="gcfq-card-chevron">').text("\u25B8"));
+				var $block = $('<div class="gcfq-card-head-block">');
+				$block.append($('<span class="gcfq-card-mono-icon">').text((title || "?").charAt(0).toUpperCase()));
+				var $text = $('<div class="gcfq-card-head-text">');
+				$text.append($('<div class="gcfq-card-head-title">').text(title));
+				var sub = [row.tariff_type || "", row.valid_from || "", row.valid_to || ""]
+					.filter(function (x) {
+						return String(x || "").trim();
+					})
+					.join(" · ");
+				if (sub) {
+					$text.append($('<div class="gcfq-card-head-row2">').append($('<span class="gcfq-card-sub">').text(sub)));
+				}
+				$block.append($text);
+				$toggle.append($block);
+				var $apply = $("<button type='button'>")
+					.addClass("btn btn-primary btn-sm gcfq-card-apply")
+					.prop("disabled", true)
+					.text(__("Apply"));
+				$hd.append($toggle).append($apply);
+				var $bd = $('<div class="gcfq-card-bd">').append($('<div class="gcfq-card-preview">'));
+				$card.append($hd).append($bd);
+				$cards.append($card);
+			});
+			$dynamic.empty().append($('<div class="gcfq-cards-scroll">').append($cards));
+			_gcft_bind_cards($dynamic, frm, dialog);
+		},
+	});
+}
+
+logistics.open_get_charges_from_tariff_dialog = function (frm) {
+	if (!frm || !frm.doc || !frm.doc.name || frm.doc.__islocal) {
+		frappe.msgprint(__("Save the document first."));
+		return;
+	}
+	if (!logistics.should_show_get_charges_from_tariff(frm)) {
+		frappe.msgprint(
+			__(
+				"Get Charges from Tariff is not available (e.g. Sales Quote already linked, internal job, or submitted document)."
+			)
+		);
+		return;
+	}
+	if (!frm.doc.local_customer) {
+		frappe.msgprint(__("Set Local Customer first."));
+		return;
+	}
+	var d = new frappe.ui.Dialog({
+		title: GET_CHARGES_TITLE_TARIFF,
+		size: "large",
+		fields: [{ fieldtype: "HTML", fieldname: "tariff_area", options: '<div class="tariff-list"></div>' }],
+		secondary_action_label: __("Close"),
+		secondary_action: function () {
+			d.hide();
+		},
+	});
+	d.show();
+	d.$wrapper.addClass("logistics-gcfq-dialog");
+	var $wrap = d.$wrapper.find(".tariff-list").addClass("logistics-gcfq-quotation-list");
+	var $filterMount = $('<div class="logistics-gcfq-filters-mount">').appendTo($wrap);
+	var $dynamic = $('<div class="gcfq-dialog-dynamic">').appendTo($wrap);
+	d._gcft_ready = false;
+	function reloadList() {
+		_gcft_load_tariff_list(frm, d, $dynamic);
+	}
+	_gcft_mount_filter_panel($filterMount, frm, d, reloadList);
+	setTimeout(function () {
+		_gcft_capture_initial_filter_snapshot(d, frm);
+		reloadList();
+	}, 0);
+};

--- a/logistics/sea_freight/doctype/sea_booking/sea_booking.js
+++ b/logistics/sea_freight/doctype/sea_booking/sea_booking.js
@@ -633,6 +633,9 @@ frappe.ui.form.on('Sea Booking', {
 			if (window.logistics && logistics.add_get_charges_from_quotation_button_if_allowed) {
 				logistics.add_get_charges_from_quotation_button_if_allowed(frm);
 			}
+			if (window.logistics && logistics.add_get_charges_from_tariff_button_if_allowed) {
+				logistics.add_get_charges_from_tariff_button_if_allowed(frm);
+			}
 		}
 
 		// --- Create menu ---

--- a/logistics/sea_freight/doctype/sea_booking/sea_booking.py
+++ b/logistics/sea_freight/doctype/sea_booking/sea_booking.py
@@ -743,7 +743,10 @@ class SeaBooking(VirtualLinkedServicesMixin, Document):
 		)
 
 		assert_sales_quote_customer_matches_job_before_submit(self)
-		
+		from logistics.utils.get_charges_from_tariff import assert_tariff_customer_matches_job_before_submit
+
+		assert_tariff_customer_matches_job_before_submit(self)
+
 		# Validate quote reference: either sales_quote (for Sales Quote) or quote (for One-Off Quote) must be set
 		quote_type = getattr(self, "quote_type", None)
 		if quote_type == "Sales Quote":
@@ -1299,6 +1302,49 @@ class SeaBooking(VirtualLinkedServicesMixin, Document):
 				_("Warning: Could not populate all charges from Sales Quote: {0}").format(str(e)),
 				indicator="orange"
 			)
+
+	def _build_charge_dicts_from_tariff(self, tariff_name, filter_overrides=None):
+		"""Map Tariff Charge rows to Sea Booking charge dicts (preview / apply)."""
+		from logistics.utils.charge_service_type import implied_service_type_for_doctype
+		from logistics.utils.tariff_charge_copy import (
+			effective_booking_corridor,
+			filter_tariff_charge_rows_for_booking,
+			parse_gcft_filter_overrides,
+			tariff_charge_row_as_quote_like_dict,
+		)
+
+		ov = parse_gcft_filter_overrides(self.doctype, filter_overrides)
+		service_type = implied_service_type_for_doctype(self.doctype) or "Sea"
+		origin, dest, airline, shipping_line = effective_booking_corridor(self, ov)
+		tariff_doc = frappe.get_doc("Tariff", tariff_name)
+		rows = filter_tariff_charge_rows_for_booking(
+			self,
+			tariff_doc,
+			service_type,
+			origin=origin,
+			destination=dest,
+			airline=airline,
+			shipping_line=shipping_line,
+		)
+		charges = []
+		for row in rows:
+			quote_like = tariff_charge_row_as_quote_like_dict(row, tariff_name)
+			charge_row = self._map_sales_quote_sea_freight_to_charge(quote_like)
+			if not charge_row:
+				continue
+			charge_row["revenue_tariff"] = tariff_name
+			charge_row["cost_tariff"] = tariff_name
+			charge_row.pop("sales_quote_link", None)
+			charges.append(charge_row)
+		if charges:
+			self._apply_actuals_to_charge_dicts(charges)
+		return charges
+
+	def _populate_charges_from_tariff(self, tariff_name, filter_overrides=None):
+		"""Replace charge lines from an active Tariff (Action → Get Charges from Tariff)."""
+		self.set("charges", [])
+		for charge_row in self._build_charge_dicts_from_tariff(tariff_name, filter_overrides):
+			self.append("charges", charge_row)
 	
 	def _populate_charges_from_one_off_quote(self):
 		"""Populate charges based on one_off_quote_sea_freight of the filled one_off_quote."""
@@ -2948,6 +2994,41 @@ def populate_charges_from_sales_quote(
 			"error": f"Error populating charges: {str(e)}",
 			"charges": []
 		}
+
+
+@frappe.whitelist()
+def populate_charges_from_tariff(docname: str = None, tariff_name: str = None, filter_overrides=None):
+	"""Preview charge lines from a tariff without saving the Sea Booking."""
+	if not tariff_name:
+		return {"charges": []}
+	try:
+		if not frappe.db.exists("Tariff", tariff_name):
+			return {"error": _("Tariff {0} does not exist").format(tariff_name), "charges": []}
+		doc = None
+		if docname:
+			try:
+				doc = frappe.get_doc("Sea Booking", docname)
+			except Exception:
+				pass
+		temp_doc = doc if doc else frappe.new_doc("Sea Booking")
+		charges = temp_doc._build_charge_dicts_from_tariff(tariff_name, filter_overrides)
+		if not charges:
+			return {
+				"charges": [],
+				"message": _("No matching charge lines on tariff {0}.").format(tariff_name),
+				"tariff": tariff_name,
+			}
+		return {
+			"charges": charges,
+			"charges_count": len(charges),
+			"tariff": tariff_name,
+		}
+	except Exception as e:
+		frappe.log_error(
+			f"Error populating Sea Booking charges from tariff {tariff_name}: {str(e)}",
+			"Sea Booking Tariff Charges Population Error",
+		)
+		return {"error": _("Error populating charges: {0}").format(str(e)), "charges": []}
 
 
 @frappe.whitelist()

--- a/logistics/sea_freight/doctype/sea_shipment/sea_shipment.py
+++ b/logistics/sea_freight/doctype/sea_shipment/sea_shipment.py
@@ -34,6 +34,14 @@ _MBL_VIRTUAL_FIELD_SOURCES = (
 
 
 class SeaShipment(VirtualLinkedServicesMixin, Document):
+    def before_insert(self):
+        self.set_new_name()
+        from logistics.utils.house_document_defaults import (
+            auto_populate_export_house_document_from_shipment_id,
+        )
+
+        auto_populate_export_house_document_from_shipment_id(self)
+
     def validate(self):
         """Validate Sea Shipment data"""
         from logistics.utils.charges_calculation import (
@@ -355,6 +363,11 @@ class SeaShipment(VirtualLinkedServicesMixin, Document):
     def before_save(self):
         """Calculate sustainability metrics before saving"""
         super().before_save()
+        from logistics.utils.house_document_defaults import (
+            auto_populate_export_house_document_from_shipment_id,
+        )
+
+        auto_populate_export_house_document_from_shipment_id(self)
         self.calculate_sustainability_metrics()
         self.check_delays()
         self.calculate_penalties()

--- a/logistics/utils/get_charges_from_tariff.py
+++ b/logistics/utils/get_charges_from_tariff.py
@@ -1,0 +1,285 @@
+# Copyright (c) 2026, AgilaSoft and contributors
+# For license information, please see license.txt
+
+"""Tariff → booking charge flow (Sea Booking, Air Booking).
+
+**Regular bookings**: create Sea Booking or Air Booking first, then use
+**Action → Get Charges from Tariff** to pick an active tariff and apply charge lines.
+This is the tariff counterpart to **Action → Get Charges from Quotation**.
+
+**Customer match**: tariffs are listed when their type rules match the booking's
+``local_customer`` (Customer, Customer Group, Territory, Specific Customers, All Customers, Agent).
+
+**Corridor match**: Sea uses ``origin_port`` / ``destination_port`` and optional ``shipping_line``.
+Air uses ports and optional ``airline``. Blank values on a tariff charge row are wildcards.
+
+**Mutual exclusivity with Sales Quote**: when a Sales Quote is already linked on the booking,
+the tariff action is hidden on the desk — charges should come from the quotation path instead.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import frappe
+from frappe import _
+from frappe.utils import cint
+
+from logistics.utils.charge_service_type import implied_service_type_for_doctype
+from logistics.utils.tariff_charge_copy import (
+	BOOKING_DOCTYPES,
+	booking_customer,
+	effective_booking_corridor,
+	fetch_eligible_tariff_names,
+	filter_tariff_charge_rows_for_booking,
+	gcft_list_filters_payload,
+	parse_gcft_filter_overrides,
+	tariff_charge_row_as_quote_like_dict,
+)
+
+
+@contextmanager
+def _suppress_msgprint():
+	orig = frappe.msgprint
+
+	def _noop(*args, **kwargs):
+		return None
+
+	frappe.msgprint = _noop  # type: ignore[assignment]
+	try:
+		yield
+	finally:
+		frappe.msgprint = orig  # type: ignore[assignment]
+
+
+def _assert_no_sales_quote_linked(doc):
+	from logistics.utils.operational_rep_fields import _resolve_sales_quote_name_from_doc
+
+	if _resolve_sales_quote_name_from_doc(doc):
+		frappe.throw(
+			_("A Sales Quote is already linked. Use Get Charges from Quotation or clear the Sales Quote first."),
+			title=_("Sales Quote linked"),
+		)
+
+
+def _tariff_preview_rows(doc, tariff_name: str, overrides: dict | None = None) -> dict:
+	"""Build preview response using the booking's populate_charges_from_tariff whitelisted API."""
+	ov = overrides or {}
+	if doc.doctype == "Sea Booking":
+		from logistics.sea_freight.doctype.sea_booking.sea_booking import populate_charges_from_tariff
+
+		return populate_charges_from_tariff(doc.name, tariff_name, filter_overrides=ov)
+	if doc.doctype == "Air Booking":
+		from logistics.air_freight.doctype.air_booking.air_booking import populate_charges_from_tariff
+
+		return populate_charges_from_tariff(doc.name, tariff_name, filter_overrides=ov)
+	return {"error": _("Unsupported document type."), "charges": []}
+
+
+@frappe.whitelist()
+def list_tariffs_for_job(doctype: str, docname: str, filter_overrides=None):
+	"""Return active tariffs eligible for Get Charges from Tariff."""
+	if doctype not in BOOKING_DOCTYPES:
+		frappe.throw(_("Unsupported document type."))
+
+	doc = frappe.get_doc(doctype, docname)
+	frappe.has_permission(doctype, "read", doc=doc, throw=True)
+
+	service_type = implied_service_type_for_doctype(doctype)
+	if not service_type:
+		frappe.throw(_("Could not determine service type for {0}.").format(doctype))
+
+	customer = booking_customer(doc)
+	if not customer:
+		return {
+			"tariffs": [],
+			"message": _("Set Local Customer before loading charges from a tariff."),
+			"filters": None,
+		}
+
+	ov = parse_gcft_filter_overrides(doctype, filter_overrides)
+	origin, dest, airline, shipping_line = effective_booking_corridor(doc, ov)
+
+	extra_kw = {}
+	if shipping_line:
+		extra_kw["shipping_line"] = shipping_line
+	if airline:
+		extra_kw["airline"] = airline
+	filters_payload = gcft_list_filters_payload(
+		doctype, customer, origin, dest, service_type, **extra_kw
+	)
+
+	names = fetch_eligible_tariff_names(
+		doctype,
+		doc,
+		customer,
+		service_type,
+		origin=origin,
+		destination=dest,
+		airline=airline,
+		shipping_line=shipping_line,
+	)
+
+	if not names:
+		has_corridor = bool((origin or "").strip() or (dest or "").strip())
+		if doctype == "Sea Booking":
+			has_corridor = has_corridor or bool((shipping_line or "").strip())
+		elif doctype == "Air Booking":
+			has_corridor = has_corridor or bool((airline or "").strip())
+		empty_msg = (
+			_("No matching tariffs for this corridor.")
+			if has_corridor
+			else _("No matching tariffs found.")
+		)
+		return {"tariffs": [], "message": empty_msg, "filters": filters_payload}
+
+	fields = [
+		"name",
+		"tariff_name",
+		"tariff_type",
+		"customer",
+		"valid_from",
+		"valid_to",
+		"description",
+		"total_rates",
+	]
+	rows = frappe.get_all("Tariff", filters={"name": ["in", names]}, fields=fields, order_by="modified desc")
+	order = {n: i for i, n in enumerate(names)}
+	rows.sort(key=lambda r: order.get(r.name, 9999))
+	return {"tariffs": rows, "message": None, "filters": filters_payload}
+
+
+@frappe.whitelist()
+def preview_tariff_charges_for_job(
+	doctype: str, docname: str, tariff_name: str, filter_overrides=None
+):
+	"""Preview tariff charge lines without saving."""
+	if doctype not in BOOKING_DOCTYPES or not tariff_name:
+		return {"error": _("Invalid arguments.")}
+
+	doc = frappe.get_doc(doctype, docname)
+	frappe.has_permission(doctype, "read", doc=doc, throw=True)
+
+	if not frappe.db.exists("Tariff", tariff_name):
+		return {"error": _("Tariff {0} does not exist.").format(tariff_name)}
+
+	customer = booking_customer(doc)
+	if not customer:
+		return {"error": _("Set Local Customer on this document first.")}
+
+	tariff_doc = frappe.get_doc("Tariff", tariff_name)
+	from logistics.utils.tariff_charge_copy import _tariff_is_valid_on_date, _tariff_matches_job_customer
+
+	if not _tariff_is_valid_on_date(tariff_doc):
+		return {"error": _("Tariff {0} is not active or is outside its validity period.").format(tariff_name)}
+	if not _tariff_matches_job_customer(tariff_doc, customer):
+		return {"error": _("Tariff {0} does not match this booking's customer.").format(tariff_name)}
+
+	ov = parse_gcft_filter_overrides(doctype, filter_overrides)
+	service_type = implied_service_type_for_doctype(doctype)
+	origin, dest, airline, shipping_line = effective_booking_corridor(doc, ov)
+	rows = filter_tariff_charge_rows_for_booking(
+		doc,
+		tariff_doc,
+		service_type or "",
+		origin=origin,
+		destination=dest,
+		airline=airline,
+		shipping_line=shipping_line,
+	)
+	if not rows:
+		return {
+			"error": _("Tariff {0} has no charge lines matching this booking's corridor.").format(tariff_name),
+		}
+
+	return _tariff_preview_rows(doc, tariff_name, ov)
+
+
+@frappe.whitelist()
+def apply_tariff_charges_to_job(
+	doctype: str, docname: str, tariff_name: str, filter_overrides=None
+):
+	"""Replace booking charge lines from a tariff and save."""
+	if doctype not in BOOKING_DOCTYPES or not tariff_name:
+		frappe.throw(_("Invalid arguments."))
+
+	doc = frappe.get_doc(doctype, docname)
+	frappe.has_permission(doctype, "write", doc=doc, throw=True)
+
+	if doc.docstatus != 0:
+		frappe.throw(_("Only draft documents can load charges from a tariff."))
+
+	customer = booking_customer(doc)
+	if not customer:
+		frappe.throw(_("Set Local Customer on this document first."))
+
+	_assert_no_sales_quote_linked(doc)
+
+	tariff_doc = frappe.get_doc("Tariff", tariff_name)
+	from logistics.utils.tariff_charge_copy import _tariff_is_valid_on_date, _tariff_matches_job_customer
+
+	if not _tariff_is_valid_on_date(tariff_doc):
+		frappe.throw(_("Tariff {0} is not active or is outside its validity period.").format(tariff_name))
+	if not _tariff_matches_job_customer(tariff_doc, customer):
+		frappe.throw(_("Tariff {0} does not match this booking's customer.").format(tariff_name))
+
+	service_type = implied_service_type_for_doctype(doctype)
+	ov = parse_gcft_filter_overrides(doctype, filter_overrides)
+	origin, dest, airline, shipping_line = effective_booking_corridor(doc, ov)
+	rows = filter_tariff_charge_rows_for_booking(
+		doc,
+		tariff_doc,
+		service_type or "",
+		origin=origin,
+		destination=dest,
+		airline=airline,
+		shipping_line=shipping_line,
+	)
+	if not rows:
+		frappe.throw(
+			_("Tariff {0} has no charge lines matching this booking's corridor.").format(tariff_name),
+			title=_("Cannot apply tariff"),
+		)
+
+	with _suppress_msgprint():
+		if doctype == "Sea Booking":
+			doc._populate_charges_from_tariff(tariff_name, filter_overrides=ov)
+		elif doctype == "Air Booking":
+			doc._populate_charges_from_tariff(tariff_name, filter_overrides=ov)
+			if hasattr(doc, "_normalize_charges_before_save"):
+				doc._normalize_charges_before_save()
+
+	doc.save()
+
+	return {
+		"success": True,
+		"message": _("Charges applied from Tariff {0}.").format(tariff_name),
+		"name": doc.name,
+		"charges_count": len(doc.get("charges") or []),
+	}
+
+
+def assert_tariff_customer_matches_job_before_submit(doc):
+	"""Optional guard: if charge rows reference a tariff, customer must still match."""
+	if doc.doctype not in BOOKING_DOCTYPES:
+		return
+	customer = booking_customer(doc)
+	if not customer:
+		return
+	seen: set[str] = set()
+	for ch in doc.get("charges") or []:
+		for fn in ("revenue_tariff", "cost_tariff"):
+			tn = (getattr(ch, fn, None) or "").strip()
+			if not tn or tn in seen:
+				continue
+			seen.add(tn)
+			tariff_customer = None
+			if frappe.db.exists("Tariff", tn):
+				tariff_doc = frappe.get_doc("Tariff", tn)
+				from logistics.utils.tariff_charge_copy import _tariff_matches_job_customer
+
+				if not _tariff_matches_job_customer(tariff_doc, customer):
+					frappe.throw(
+						_("Tariff {0} does not match this document's customer.").format(tn),
+						title=_("Customer mismatch"),
+					)

--- a/logistics/utils/house_document_defaults.py
+++ b/logistics/utils/house_document_defaults.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2026, www.agilasoft.com and contributors
+# For license information, please see license.txt
+
+"""Default House AWB / House BL from shipment ID for export freight jobs."""
+
+from __future__ import annotations
+
+EXPORT_DIRECTION = "Export"
+
+HOUSE_DOCUMENT_FIELD_BY_DOCTYPE = {
+	"Air Shipment": "house_awb",
+	"Sea Shipment": "house_bl",
+}
+
+
+def _is_empty(value) -> bool:
+	if value is None:
+		return True
+	if isinstance(value, str) and not value.strip():
+		return True
+	return False
+
+
+def auto_populate_export_house_document_from_shipment_id(doc) -> bool:
+	"""Fill empty House AWB / House BL with the shipment document name for Export jobs."""
+	fieldname = HOUSE_DOCUMENT_FIELD_BY_DOCTYPE.get(getattr(doc, "doctype", None))
+	if not fieldname or not doc.meta.has_field(fieldname):
+		return False
+	if (getattr(doc, "direction", None) or "").strip() != EXPORT_DIRECTION:
+		return False
+	if not _is_empty(getattr(doc, fieldname, None)):
+		return False
+	if not getattr(doc, "name", None):
+		return False
+
+	doc.set(fieldname, doc.name)
+	return True

--- a/logistics/utils/tariff_charge_copy.py
+++ b/logistics/utils/tariff_charge_copy.py
@@ -1,0 +1,374 @@
+# Copyright (c) 2026, AgilaSoft and contributors
+# For license information, please see license.txt
+
+"""Tariff Charge → operational booking charge helpers.
+
+Tariff child rows (``Tariff Charge``) share the same pricing field shape as ``Sales Quote Charge``.
+Booking controllers already map quote rows via ``_map_sales_quote_*_to_charge``; this module adapts
+tariff rows into quote-like dicts and filters them for Sea / Air bookings.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import frappe
+from frappe import _
+from frappe.utils import cint, getdate, today
+
+from logistics.pricing_center.doctype.tariff.tariff_rate_rows import iter_tariff_charges_for_service
+from logistics.utils.charge_service_type import (
+	canonical_charge_service_type_for_storage,
+	implied_service_type_for_doctype,
+)
+
+BOOKING_DOCTYPES = frozenset({"Sea Booking", "Air Booking"})
+
+GCFT_FILTER_KEYS: dict[str, frozenset[str]] = {
+	"Sea Booking": frozenset({"origin_port", "destination_port", "shipping_line"}),
+	"Air Booking": frozenset({"origin_port", "destination_port", "airline"}),
+}
+
+
+def _parse_gcft_filter_overrides(doctype: str, filter_overrides) -> dict[str, str]:
+	if not filter_overrides:
+		return {}
+	if isinstance(filter_overrides, str):
+		try:
+			filter_overrides = frappe.parse_json(filter_overrides)
+		except Exception:
+			return {}
+	if not isinstance(filter_overrides, dict):
+		return {}
+	allowed = GCFT_FILTER_KEYS.get(doctype, frozenset())
+	out: dict[str, str] = {}
+	for k, v in filter_overrides.items():
+		if k not in allowed:
+			continue
+		out[k] = "" if v is None else str(v).strip()
+	return out
+
+
+def _pick_gcft_field(doc, overrides: dict, param_key: str, doc_attr: str) -> str:
+	if not overrides:
+		return (getattr(doc, doc_attr, None) or "").strip()
+	if param_key in overrides:
+		return (overrides[param_key] or "").strip()
+	return ""
+
+
+def _effective_booking_corridor(doc, overrides: dict) -> tuple[str, str, str | None, str | None]:
+	"""(origin, destination, airline, shipping_line)."""
+	if doc.doctype == "Sea Booking":
+		o = _pick_gcft_field(doc, overrides, "origin_port", "origin_port")
+		d = _pick_gcft_field(doc, overrides, "destination_port", "destination_port")
+		sl = _pick_gcft_field(doc, overrides, "shipping_line", "shipping_line")
+		return o, d, None, (sl or None)
+	if doc.doctype == "Air Booking":
+		o = _pick_gcft_field(doc, overrides, "origin_port", "origin_port")
+		d = _pick_gcft_field(doc, overrides, "destination_port", "destination_port")
+		al = _pick_gcft_field(doc, overrides, "airline", "airline")
+		return o, d, (al or None), None
+	return "", "", None, None
+
+
+def _booking_customer(doc) -> str | None:
+	if doc.doctype in BOOKING_DOCTYPES:
+		return (getattr(doc, "local_customer", None) or "").strip() or None
+	return None
+
+
+def _customer_matches_job(tariff_customer: str | None, job_customer: str | None) -> bool:
+	return (tariff_customer or "").strip().lower() == (job_customer or "").strip().lower()
+
+
+def _tariff_is_valid_on_date(tariff_doc, on_date=None) -> bool:
+	if not cint(getattr(tariff_doc, "is_active", 0)):
+		return False
+	ref = getdate(on_date or today())
+	vf = getattr(tariff_doc, "valid_from", None)
+	vt = getattr(tariff_doc, "valid_to", None)
+	if vf and getdate(vf) > ref:
+		return False
+	if vt and getdate(vt) < ref:
+		return False
+	return True
+
+
+def _tariff_matches_job_customer(tariff_doc, job_customer: str | None) -> bool:
+	if not job_customer:
+		return False
+	tt = (getattr(tariff_doc, "tariff_type", None) or "").strip()
+	if tt in ("", "All Customers"):
+		return True
+	if tt == "Customer":
+		return _customer_matches_job(getattr(tariff_doc, "customer", None), job_customer)
+	if tt == "Customer Group":
+		cg = (getattr(tariff_doc, "customer_group", None) or "").strip()
+		if not cg:
+			return False
+		return frappe.db.get_value("Customer", job_customer, "customer_group") == cg
+	if tt == "Territory":
+		ter = (getattr(tariff_doc, "territory", None) or "").strip()
+		if not ter:
+			return False
+		return frappe.db.get_value("Customer", job_customer, "territory") == ter
+	if tt == "Specific Customers":
+		for row in getattr(tariff_doc, "customers", None) or []:
+			if _customer_matches_job(getattr(row, "customer", None), job_customer):
+				return True
+		return False
+	if tt == "Agent":
+		# Agent tariffs are not customer-scoped; list when customer is set on the booking.
+		return True
+	return False
+
+
+def _wildcard_link_match(row_value: str | None, job_value: str | None) -> bool:
+	rv = (row_value or "").strip()
+	jv = (job_value or "").strip()
+	if not jv:
+		return True
+	if not rv:
+		return True
+	return rv.lower() == jv.lower()
+
+
+def tariff_charge_row_matches_booking_corridor(
+	row,
+	*,
+	doctype: str,
+	origin: str,
+	destination: str,
+	airline: str | None = None,
+	shipping_line: str | None = None,
+) -> bool:
+	"""True when corridor fields on the tariff line match the booking (blank line = wildcard)."""
+	def _g(fn):
+		return getattr(row, fn, None) if not isinstance(row, dict) else row.get(fn)
+
+	o = (origin or "").strip()
+	d = (destination or "").strip()
+	if o or d:
+		if not _wildcard_link_match(_g("origin_port"), o):
+			return False
+		if not _wildcard_link_match(_g("destination_port"), d):
+			return False
+	if doctype == "Sea Booking" and (shipping_line or "").strip():
+		if not _wildcard_link_match(_g("shipping_line"), shipping_line):
+			return False
+	if doctype == "Air Booking" and (airline or "").strip():
+		if not _wildcard_link_match(_g("airline"), airline):
+			return False
+	return True
+
+
+def _row_is_active_on_date(row, on_date=None) -> bool:
+	ref = getdate(on_date or today())
+	if hasattr(row, "tariff_rate_active") and row.tariff_rate_active is not None:
+		if not cint(row.tariff_rate_active):
+			return False
+	vf = getattr(row, "tariff_valid_from", None)
+	vt = getattr(row, "tariff_valid_to", None)
+	if vf and getdate(vf) > ref:
+		return False
+	if vt and getdate(vt) < ref:
+		return False
+	return True
+
+
+def filter_tariff_charge_rows_for_booking(
+	parent_doc,
+	tariff_doc,
+	service_type: str,
+	*,
+	origin: str = "",
+	destination: str = "",
+	airline: str | None = None,
+	shipping_line: str | None = None,
+) -> list[Any]:
+	"""Return Tariff Charge rows eligible for this booking (service + corridor + row validity)."""
+	dt = getattr(parent_doc, "doctype", None) or ""
+	out: list[Any] = []
+	for row in iter_tariff_charges_for_service(tariff_doc, service_type):
+		if not _row_is_active_on_date(row):
+			continue
+		if not tariff_charge_row_matches_booking_corridor(
+			row,
+			doctype=dt,
+			origin=origin,
+			destination=destination,
+			airline=airline,
+			shipping_line=shipping_line,
+		):
+			continue
+		out.append(row)
+	return out
+
+
+def tariff_has_matching_charge_rows(
+	parent_doc,
+	tariff_doc,
+	service_type: str,
+	*,
+	origin: str = "",
+	destination: str = "",
+	airline: str | None = None,
+	shipping_line: str | None = None,
+) -> bool:
+	return bool(
+		filter_tariff_charge_rows_for_booking(
+			parent_doc,
+			tariff_doc,
+			service_type,
+			origin=origin,
+			destination=destination,
+			airline=airline,
+			shipping_line=shipping_line,
+		)
+	)
+
+
+def fetch_eligible_tariff_names(
+	doctype: str,
+	parent_doc,
+	job_customer: str,
+	service_type: str,
+	*,
+	origin: str = "",
+	destination: str = "",
+	airline: str | None = None,
+	shipping_line: str | None = None,
+	limit: int = 150,
+) -> list[str]:
+	"""Active tariffs with at least one matching charge line for this booking."""
+	names = frappe.get_all(
+		"Tariff",
+		filters={"is_active": 1},
+		fields=["name"],
+		order_by="modified desc",
+		limit_page_length=limit * 3,
+	)
+	eligible: list[str] = []
+	for row in names:
+		name = row.name
+		try:
+			tariff_doc = frappe.get_doc("Tariff", name)
+		except Exception:
+			continue
+		if not _tariff_is_valid_on_date(tariff_doc):
+			continue
+		if not _tariff_matches_job_customer(tariff_doc, job_customer):
+			continue
+		if not tariff_has_matching_charge_rows(
+			parent_doc,
+			tariff_doc,
+			service_type,
+			origin=origin,
+			destination=destination,
+			airline=airline,
+			shipping_line=shipping_line,
+		):
+			continue
+		eligible.append(name)
+		if len(eligible) >= limit:
+			break
+	return eligible
+
+
+def tariff_charge_row_as_quote_like_dict(row, tariff_name: str) -> dict:
+	"""Adapt a Tariff Charge row so booking ``_map_sales_quote_*`` mappers can consume it."""
+	if hasattr(row, "as_dict"):
+		out = row.as_dict()
+	else:
+		out = dict(row)
+	out["revenue_tariff"] = tariff_name
+	out["cost_tariff"] = tariff_name
+	out["use_tariff_in_revenue"] = 0
+	out["use_tariff_in_cost"] = 0
+	if not out.get("calculation_method") and out.get("revenue_calculation_method"):
+		out["calculation_method"] = out["revenue_calculation_method"]
+	st = out.get("service_type")
+	if st:
+		canon = canonical_charge_service_type_for_storage(st)
+		label_by_canon = {
+			"air": "Air",
+			"sea": "Sea",
+			"transport": "Transport",
+			"custom": "Customs",
+			"warehousing": "Warehousing",
+		}
+		out["service_type"] = label_by_canon.get(canon, st)
+	return out
+
+
+def gcft_list_filters_payload(
+	doctype: str,
+	customer: str,
+	origin: str,
+	dest: str,
+	service_type: str,
+	**kwargs,
+) -> dict:
+	"""Structured labels for the Get Charges from Tariff dialog."""
+	if service_type == "Sea":
+		sl = (kwargs.get("shipping_line") or "").strip()
+		extra = [{"label": _("Shipping Line"), "value": sl}] if sl else []
+		rules = [
+			_("Active tariffs only"),
+			_("Tariff validity must include today"),
+			_("Customer must match the tariff type rules (Customer, Group, Territory, etc.)"),
+			_("At least one Sea charge line must match the corridor filters"),
+			_("Blank origin, destination, or shipping line on a tariff line matches any value"),
+		]
+		out = {
+			"service_type": service_type,
+			"customer_label": _("Local Customer"),
+			"customer": customer,
+			"origin_label": _("Origin Port"),
+			"origin": origin,
+			"destination_label": _("Destination Port"),
+			"destination": dest,
+			"rules": rules,
+		}
+		if extra:
+			out["extra_criteria"] = extra
+		return out
+	al = (kwargs.get("airline") or "").strip()
+	extra = [{"label": _("Airline"), "value": al}] if al else []
+	rules = [
+		_("Active tariffs only"),
+		_("Tariff validity must include today"),
+		_("Customer must match the tariff type rules (Customer, Group, Territory, etc.)"),
+		_("At least one Air charge line must match the corridor filters"),
+		_("Blank origin, destination, or airline on a tariff line matches any value"),
+	]
+	out = {
+		"service_type": service_type,
+		"customer_label": _("Local Customer"),
+		"customer": customer,
+		"origin_label": _("Origin Port"),
+		"origin": origin,
+		"destination_label": _("Destination Port"),
+		"destination": dest,
+		"rules": rules,
+	}
+	if extra:
+		out["extra_criteria"] = extra
+	return out
+
+
+def parse_gcft_filter_overrides(doctype: str, filter_overrides) -> dict[str, str]:
+	return _parse_gcft_filter_overrides(doctype, filter_overrides)
+
+
+def effective_booking_corridor(doc, overrides: dict) -> tuple[str, str, str | None, str | None]:
+	return _effective_booking_corridor(doc, overrides)
+
+
+def booking_customer(doc) -> str | None:
+	return _booking_customer(doc)
+
+
+def implied_service_for_booking(doctype: str) -> str | None:
+	return implied_service_type_for_doctype(doctype)

--- a/logistics/utils/test_get_charges_from_tariff.py
+++ b/logistics/utils/test_get_charges_from_tariff.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2026, AgilaSoft and contributors
+# See license.txt
+
+"""Unit tests for Get Charges from Tariff helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from frappe.tests.utils import FrappeTestCase
+
+from logistics.utils.tariff_charge_copy import (
+	_customer_matches_job,
+	_tariff_matches_job_customer,
+	tariff_charge_row_as_quote_like_dict,
+	tariff_charge_row_matches_booking_corridor,
+)
+
+
+class TestTariffChargeCopyHelpers(FrappeTestCase):
+	def test_customer_match_case_insensitive(self):
+		self.assertTrue(_customer_matches_job("CUST-1", "cust-1"))
+
+	def test_tariff_all_customers_matches_any_customer(self):
+		tariff = MagicMock()
+		tariff.tariff_type = "All Customers"
+		self.assertTrue(_tariff_matches_job_customer(tariff, "ACME"))
+
+	def test_tariff_customer_type_requires_match(self):
+		tariff = MagicMock()
+		tariff.tariff_type = "Customer"
+		tariff.customer = "ACME"
+		self.assertTrue(_tariff_matches_job_customer(tariff, "acme"))
+		self.assertFalse(_tariff_matches_job_customer(tariff, "OTHER"))
+
+	def test_corridor_blank_tariff_row_is_wildcard(self):
+		row = {"origin_port": "", "destination_port": "", "shipping_line": ""}
+		self.assertTrue(
+			tariff_charge_row_matches_booking_corridor(
+				row,
+				doctype="Sea Booking",
+				origin="SGSIN",
+				destination="USLAX",
+				shipping_line="MAEU",
+			)
+		)
+
+	def test_corridor_requires_match_when_row_is_set(self):
+		row = {"origin_port": "SGSIN", "destination_port": "USLAX", "shipping_line": ""}
+		self.assertTrue(
+			tariff_charge_row_matches_booking_corridor(
+				row,
+				doctype="Sea Booking",
+				origin="SGSIN",
+				destination="USLAX",
+			)
+		)
+		self.assertFalse(
+			tariff_charge_row_matches_booking_corridor(
+				row,
+				doctype="Sea Booking",
+				origin="HKHKG",
+				destination="USLAX",
+			)
+		)
+
+	def test_tariff_row_adapter_sets_tariff_links(self):
+		row = MagicMock()
+		row.as_dict.return_value = {
+			"item_code": "FRT-SEA",
+			"service_type": "Sea",
+			"revenue_calculation_method": "Per Unit",
+			"unit_rate": 100,
+		}
+		out = tariff_charge_row_as_quote_like_dict(row, "TAR-001")
+		self.assertEqual(out["revenue_tariff"], "TAR-001")
+		self.assertEqual(out["cost_tariff"], "TAR-001")
+		self.assertEqual(out["use_tariff_in_revenue"], 0)

--- a/logistics/utils/test_house_document_defaults.py
+++ b/logistics/utils/test_house_document_defaults.py
@@ -1,0 +1,163 @@
+# Copyright (c) 2026, www.agilasoft.com and Contributors
+# See license.txt
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import today
+
+from logistics.air_freight.tests.test_helpers import (
+	create_test_branch,
+	create_test_consignee,
+	create_test_cost_center,
+	create_test_profit_center,
+	create_test_shipper,
+	create_test_unloco,
+	setup_basic_master_data,
+)
+from logistics.utils.house_document_defaults import (
+	auto_populate_export_house_document_from_shipment_id,
+)
+
+
+class TestHouseDocumentDefaults(FrappeTestCase):
+	def setUp(self):
+		data = setup_basic_master_data()
+		self.company = data["company"]
+		self.customer = data["customer"]
+		self.shipper = create_test_shipper()
+		self.consignee = create_test_consignee()
+		create_test_unloco("USLAX", "Los Angeles", "LAX", "US", "Airport")
+		create_test_unloco("USJFK", "New York JFK", "JFK", "US", "Airport")
+		try:
+			self.branch = create_test_branch(self.company)
+			self.cost_center = create_test_cost_center(self.company)
+			self.profit_center = create_test_profit_center(self.company)
+		except Exception:
+			self.branch = frappe.db.get_value("Branch", {"custom_company": self.company}, "name")
+			self.cost_center = frappe.db.get_value(
+				"Cost Center", {"company": self.company, "is_group": 0}, "name"
+			)
+			self.profit_center = frappe.db.get_value("Profit Center", {"company": self.company}, "name")
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_export_air_shipment_auto_populates_house_awb_from_id(self):
+		shipment = frappe.get_doc(
+			{
+				"doctype": "Air Shipment",
+				"booking_date": today(),
+				"company": self.company,
+				"local_customer": self.customer,
+				"direction": "Export",
+				"shipper": self.shipper,
+				"consignee": self.consignee,
+				"origin_port": "USLAX",
+				"destination_port": "USJFK",
+				"branch": self.branch,
+				"cost_center": self.cost_center,
+				"profit_center": self.profit_center,
+			}
+		)
+		shipment.insert()
+
+		self.assertEqual(shipment.house_awb, shipment.name)
+
+	def test_import_air_shipment_does_not_auto_populate_house_awb(self):
+		shipment = frappe.get_doc(
+			{
+				"doctype": "Air Shipment",
+				"booking_date": today(),
+				"company": self.company,
+				"local_customer": self.customer,
+				"direction": "Import",
+				"shipper": self.shipper,
+				"consignee": self.consignee,
+				"origin_port": "USLAX",
+				"destination_port": "USJFK",
+				"branch": self.branch,
+				"cost_center": self.cost_center,
+				"profit_center": self.profit_center,
+			}
+		)
+		shipment.insert()
+
+		self.assertFalse(shipment.house_awb)
+
+	def test_existing_air_shipment_house_awb_is_not_overwritten(self):
+		shipment = frappe.get_doc(
+			{
+				"doctype": "Air Shipment",
+				"booking_date": today(),
+				"company": self.company,
+				"local_customer": self.customer,
+				"direction": "Export",
+				"shipper": self.shipper,
+				"consignee": self.consignee,
+				"origin_port": "USLAX",
+				"destination_port": "USJFK",
+				"branch": self.branch,
+				"cost_center": self.cost_center,
+				"profit_center": self.profit_center,
+				"house_awb": "CUSTOM-HAWB",
+			}
+		)
+		shipment.insert()
+
+		self.assertEqual(shipment.house_awb, "CUSTOM-HAWB")
+
+	def test_export_sea_shipment_auto_populates_house_bl_from_id(self):
+		shipment = frappe.get_doc(
+			{
+				"doctype": "Sea Shipment",
+				"booking_date": today(),
+				"company": self.company,
+				"local_customer": self.customer,
+				"direction": "Export",
+				"shipper": self.shipper,
+				"consignee": self.consignee,
+				"origin_port": "USLAX",
+				"destination_port": "USJFK",
+				"branch": self.branch,
+				"cost_center": self.cost_center,
+				"profit_center": self.profit_center,
+			}
+		)
+		shipment.insert()
+
+		self.assertEqual(shipment.house_bl, shipment.name)
+
+	def test_export_sea_shipment_populates_when_direction_changes_on_save(self):
+		shipment = frappe.get_doc(
+			{
+				"doctype": "Sea Shipment",
+				"booking_date": today(),
+				"company": self.company,
+				"local_customer": self.customer,
+				"direction": "Import",
+				"shipper": self.shipper,
+				"consignee": self.consignee,
+				"origin_port": "USLAX",
+				"destination_port": "USJFK",
+				"branch": self.branch,
+				"cost_center": self.cost_center,
+				"profit_center": self.profit_center,
+			}
+		)
+		shipment.insert()
+		self.assertFalse(shipment.house_bl)
+
+		shipment.direction = "Export"
+		shipment.save()
+
+		self.assertEqual(shipment.house_bl, shipment.name)
+
+	def test_auto_populate_helper_is_noop_without_name(self):
+		shipment = frappe.get_doc(
+			{
+				"doctype": "Air Shipment",
+				"direction": "Export",
+			}
+		)
+		self.assertFalse(auto_populate_export_house_document_from_shipment_id(shipment))
+		self.assertFalse(shipment.house_awb)


### PR DESCRIPTION
- Register charge_type_cleanup.js in app_include_js so it loads app-wide
- Also attach it to Sales Quote via doctype_js for reliable form loading
- Add a Sales Quote fallback that still fills estimate fields when the cleanup script is missing
- Populate estimated_revenue, estimated_cost, quantities, and calc notes from the charge-type response
- Prevent blank charge estimates when cleanup helpers are not available
- 