### PR TITLE
Air Freight Control Tower: Company and dimension filters

### DIFF
--- a/logistics/air_freight/air_freight_control_tower.py
+++ b/logistics/air_freight/air_freight_control_tower.py
@@ -4,8 +4,8 @@
 
 """Air Freight Control Tower dashboard API.
 
-Aggregates ATN Airfreight Control Tower KPIs into a single payload for the
-``air-freight-control-tower`` desk page:
+Aggregates air-freight operational KPIs for the ``air-freight-control-tower``
+desk page, filtered by Company / Branch / Cost Center / Profit Center / UNLOCO:
 
 - Number of open job files
 - Average age of open job files
@@ -19,48 +19,276 @@ from __future__ import unicode_literals
 
 import frappe
 from frappe import _
-from frappe.utils import flt, nowdate
+from frappe.utils import cint, flt, nowdate
 
-DEFAULT_ORGANIZATION = "ATN Airfreight"
-AIR_MODULES = ["Air Shipment"]
+OPEN_EXCLUDES = ("Completed", "Closed", "Cancelled")
+AIR_SHIPMENT = "Air Shipment"
+AIR_MILESTONE = "Air Shipment Milestone"
+
+
+def _parse_filters(filters=None, company=None, branch=None, cost_center=None,
+		profit_center=None, unloco=None, fiscal_year=None):
+	"""Normalize whitelist args into a filter dict.
+
+	Accepts either a JSON ``filters`` object or individual kwargs (desk call).
+	"""
+	if isinstance(filters, str):
+		filters = frappe.parse_json(filters) or {}
+	if not isinstance(filters, dict):
+		filters = {}
+
+	out = {
+		"company": (filters.get("company") or company or "").strip(),
+		"branch": (filters.get("branch") or branch or "").strip(),
+		"cost_center": (filters.get("cost_center") or cost_center or "").strip(),
+		"profit_center": (filters.get("profit_center") or profit_center or "").strip(),
+		"unloco": (filters.get("unloco") or unloco or "").strip(),
+	}
+	fy = filters.get("fiscal_year") or fiscal_year
+	out["fiscal_year"] = int(fy) if fy else int(nowdate()[:4])
+	return out
+
+
+def _dim_clauses(filters, prefix=""):
+	"""SQL conditions for company / branch / cost_center / profit_center."""
+	conditions = []
+	values = []
+	for key in ("company", "branch", "cost_center", "profit_center"):
+		val = filters.get(key)
+		if not val:
+			continue
+		conditions.append("{0}{1} = %s".format(prefix, key))
+		values.append(val)
+	return conditions, values
+
+
+def _unloco_clause(filters, prefix=""):
+	"""Match origin_port or destination_port when UNLOCO is set."""
+	unloco = filters.get("unloco")
+	if not unloco:
+		return [], []
+	return (
+		["({0}origin_port = %s OR {0}destination_port = %s)".format(prefix)],
+		[unloco, unloco],
+	)
+
+
+def _air_shipment_kpis(filters):
+	"""Open / avg age / handled counts for Air Shipment."""
+	today = nowdate()
+	year = filters["fiscal_year"]
+	year_start = "{0}-01-01".format(year)
+	year_end = "{0}-12-31".format(year)
+
+	dim_c, dim_v = _dim_clauses(filters)
+	unloco_c, unloco_v = _unloco_clause(filters)
+
+	open_excludes_ph = ", ".join(["%s"] * len(OPEN_EXCLUDES))
+	open_where = dim_c + unloco_c + ["job_status NOT IN ({0})".format(open_excludes_ph)]
+	open_values = dim_v + unloco_v + list(OPEN_EXCLUDES)
+
+	open_count = 0
+	open_age_sum = 0
+	try:
+		rs = frappe.db.sql(
+			"""
+			SELECT COUNT(*) AS n,
+			       SUM(GREATEST(DATEDIFF(%s, booking_date), 0)) AS age_sum
+			FROM `tabAir Shipment`
+			WHERE {where}
+			""".format(where=" AND ".join(open_where) or "1=1"),
+			tuple([today] + open_values),
+		)
+		open_count = int(rs[0][0]) if rs and rs[0] and rs[0][0] is not None else 0
+		open_age_sum = int(rs[0][1]) if rs and rs[0] and rs[0][1] is not None else 0
+	except Exception:
+		frappe.log_error(frappe.get_traceback(), "afct_open_jobs")
+
+	handled_where = dim_c + unloco_c + ["booking_date BETWEEN %s AND %s"]
+	handled_values = dim_v + unloco_v + [year_start, year_end]
+	handled_count = 0
+	try:
+		rs = frappe.db.sql(
+			"""
+			SELECT COUNT(*) FROM `tabAir Shipment`
+			WHERE {where}
+			""".format(where=" AND ".join(handled_where) or "1=1"),
+			tuple(handled_values),
+		)
+		handled_count = int(rs[0][0]) if rs and rs[0] and rs[0][0] is not None else 0
+	except Exception:
+		frappe.log_error(frappe.get_traceback(), "afct_handled_jobs")
+
+	avg_age = (open_age_sum / open_count) if open_count else 0.0
+	return {
+		"open_job_files_count": open_count,
+		"avg_age_open_jobs": avg_age,
+		"jobs_handled_count": handled_count,
+		"by_module": [{
+			"module": AIR_SHIPMENT,
+			"open": open_count,
+			"handled": handled_count,
+			"open_avg_age": avg_age,
+		}],
+	}
+
+
+def _avg_lead_time(filters):
+	"""Average actual vs planned milestone days on Air Shipments matching filters."""
+	if not frappe.db.exists("DocType", AIR_MILESTONE):
+		return 0.0
+
+	dim_c, dim_v = _dim_clauses(filters, prefix="p.")
+	unloco_c, unloco_v = _unloco_clause(filters, prefix="p.")
+	extra = ""
+	if dim_c or unloco_c:
+		extra = " AND " + " AND ".join(dim_c + unloco_c)
+
+	try:
+		rs = frappe.db.sql(
+			"""
+			SELECT
+			    SUM(
+			        TIMESTAMPDIFF(
+			            SECOND,
+			            COALESCE(c.planned_end, c.planned_start),
+			            COALESCE(c.actual_end, c.actual_start)
+			        )
+			    ) AS sum_sec,
+			    COUNT(*) AS n
+			FROM `tab{child}` c
+			JOIN `tab{parent}` p ON p.name = c.parent
+			WHERE c.parenttype = %s
+			  AND (c.actual_end IS NOT NULL OR c.actual_start IS NOT NULL)
+			  AND (c.planned_end IS NOT NULL OR c.planned_start IS NOT NULL)
+			  {extra}
+			""".format(child=AIR_MILESTONE, parent=AIR_SHIPMENT, extra=extra),
+			tuple([AIR_SHIPMENT] + dim_v + unloco_v),
+		)
+		sum_sec = flt(rs[0][0]) if rs and rs[0] and rs[0][0] is not None else 0.0
+		count = int(rs[0][1]) if rs and rs[0] and rs[0][1] is not None else 0
+	except Exception:
+		frappe.log_error(frappe.get_traceback(), "afct_avg_lead_time")
+		return 0.0
+
+	if not count:
+		return 0.0
+	return (sum_sec / count) / 86400.0
+
+
+def _top_airlines(filters, n=5):
+	year = filters["fiscal_year"]
+	year_start = "{0}-01-01".format(year)
+	year_end = "{0}-12-31".format(year)
+	dim_c, dim_v = _dim_clauses(filters)
+	unloco_c, unloco_v = _unloco_clause(filters)
+	conditions = dim_c + unloco_c + [
+		"booking_date BETWEEN %s AND %s",
+		"airline IS NOT NULL",
+		"airline != ''",
+	]
+	values = dim_v + unloco_v + [year_start, year_end]
+	try:
+		rs = frappe.db.sql(
+			"""
+			SELECT airline AS label, COUNT(*) AS value
+			FROM `tabAir Shipment`
+			WHERE {where}
+			GROUP BY airline
+			ORDER BY value DESC
+			LIMIT %s
+			""".format(where=" AND ".join(conditions)),
+			tuple(values + [cint(n)]),
+			as_dict=True,
+		)
+	except Exception:
+		frappe.log_error(frappe.get_traceback(), "afct_top_airlines")
+		rs = []
+	return [{"label": r["label"], "value": flt(r["value"])} for r in rs]
+
+
+def _returned_billings_count(filters):
+	year = filters["fiscal_year"]
+	year_start = "{0}-01-01".format(year)
+	year_end = "{0}-12-31".format(year)
+	if not frappe.db.exists("DocType", "Returned Billing"):
+		return 0
+
+	dim_c, dim_v = _dim_clauses(filters)
+	conditions = dim_c + ["returned_on BETWEEN %s AND %s"]
+	values = dim_v + [year_start, year_end]
+	# Prefer Air Freight module rows when the column exists.
+	try:
+		if frappe.db.has_column("Returned Billing", "module"):
+			conditions.append("(module = %s OR IFNULL(module, '') = '')")
+			values.append("Air Freight")
+	except Exception:
+		pass
+
+	# UNLOCO is not on Returned Billing — when set, restrict via linked Air Shipment.
+	unloco = filters.get("unloco")
+	try:
+		if unloco:
+			conditions.append(
+				"""(
+					IFNULL(job_no, '') != ''
+					AND EXISTS (
+						SELECT 1 FROM `tabAir Shipment` s
+						WHERE s.name = `tabReturned Billing`.job_no
+						  AND (s.origin_port = %s OR s.destination_port = %s)
+					)
+				)"""
+			)
+			values.extend([unloco, unloco])
+		rs = frappe.db.sql(
+			"SELECT COUNT(*) FROM `tabReturned Billing` WHERE {0}".format(
+				" AND ".join(conditions) or "1=1"
+			),
+			tuple(values),
+		)
+		return int(rs[0][0]) if rs and rs[0] and rs[0][0] is not None else 0
+	except Exception:
+		frappe.log_error(frappe.get_traceback(), "afct_returned_billings")
+		return 0
 
 
 @frappe.whitelist()
-def get_dashboard_data(organization=None, fiscal_year=None):
-	"""Return all Air Freight Control Tower metrics in one call.
+def get_dashboard_data(filters=None, company=None, branch=None, cost_center=None,
+		profit_center=None, unloco=None, fiscal_year=None):
+	"""Return all Air Freight Control Tower metrics in one call."""
+	f = _parse_filters(
+		filters=filters,
+		company=company,
+		branch=branch,
+		cost_center=cost_center,
+		profit_center=profit_center,
+		unloco=unloco,
+		fiscal_year=fiscal_year,
+	)
 
-	Falls back to ``ATN Airfreight`` when organization is blank. Job KPIs are
-	scoped to Air Shipment so the page stays air-freight specific even when
-	org dimension mappings are empty (wildcard).
-	"""
-	organization = (organization or "").strip() or DEFAULT_ORGANIZATION
-	year = int(fiscal_year) if fiscal_year else int(nowdate()[:4])
+	kpi = _air_shipment_kpis(f)
+	lead_time = _avg_lead_time(f)
+	airlines = _top_airlines(f, n=5)
+	returned = _returned_billings_count(f)
 
-	from logistics.control_tower.api import get_jobs_kpi, get_top_n
-
-	kpi = get_jobs_kpi(organization, modules=AIR_MODULES, fiscal_year=year) or {}
-	airlines = get_top_n(organization, "airline", n=5, fiscal_year=year) or []
-
-	# Normalize airline rows for the chart / ranking list.
 	top_airlines = []
 	for row in airlines:
 		top_airlines.append({
 			"label": row.get("label") or _("Unknown"),
 			"value": flt(row.get("value") or 0),
 		})
-
 	max_airline = max([r["value"] for r in top_airlines], default=0) or 1
 
 	return {
-		"organization": organization,
-		"fiscal_year": year,
+		"filters": f,
+		"fiscal_year": f["fiscal_year"],
 		"as_of": nowdate(),
 		"kpis": {
 			"open_job_files_count": int(kpi.get("open_job_files_count") or 0),
 			"avg_age_open_jobs": round(flt(kpi.get("avg_age_open_jobs") or 0), 1),
 			"jobs_handled_count": int(kpi.get("jobs_handled_count") or 0),
-			"avg_lead_time_per_milestone": round(flt(kpi.get("avg_lead_time_per_milestone") or 0), 1),
-			"returned_billings_count": int(kpi.get("returned_billings_count") or 0),
+			"avg_lead_time_per_milestone": round(flt(lead_time or 0), 1),
+			"returned_billings_count": int(returned or 0),
 		},
 		"top_airlines": top_airlines,
 		"top_airlines_max": max_airline,
@@ -75,24 +303,13 @@ def get_dashboard_data(organization=None, fiscal_year=None):
 
 
 @frappe.whitelist()
-def get_organizations():
-	"""Organizations available for the Air Freight Control Tower filter."""
-	preferred = DEFAULT_ORGANIZATION
-	rows = frappe.get_all(
-		"Control Tower Organization",
-		filters={"enabled": 1},
-		fields=["name", "organization_name", "group", "home_module"],
-		order_by="organization_name asc",
-	)
-	# Prefer Air Freight home module orgs, then the rest.
-	air_first = [r for r in rows if (r.get("home_module") or "") == "Air Freight"]
-	other = [r for r in rows if (r.get("home_module") or "") != "Air Freight"]
-	ordered = air_first + other
-	if not ordered:
-		ordered = [{
-			"name": preferred,
-			"organization_name": preferred,
-			"group": "Cost Center",
-			"home_module": "Air Freight",
-		}]
-	return {"default": preferred, "organizations": ordered}
+def get_filter_defaults():
+	"""Default Company for the dashboard filter bar."""
+	company = frappe.defaults.get_user_default("Company")
+	if not company:
+		companies = frappe.get_all("Company", pluck="name", limit=1, order_by="name asc")
+		company = companies[0] if companies else ""
+	return {
+		"company": company or "",
+		"fiscal_year": int(nowdate()[:4]),
+	}

--- a/logistics/air_freight/page/air_freight_control_tower/air_freight_control_tower.js
+++ b/logistics/air_freight/page/air_freight_control_tower/air_freight_control_tower.js
@@ -10,8 +10,6 @@ frappe.pages["air-freight-control-tower"].on_page_load = function (wrapper) {
 };
 
 (function () {
-	const DEFAULT_ORG = "ATN Airfreight";
-
 	class AirFreightControlTowerPage {
 		constructor(wrapper) {
 			this.wrapper = $(wrapper);
@@ -20,10 +18,16 @@ frappe.pages["air-freight-control-tower"].on_page_load = function (wrapper) {
 				title: __("Air Freight Control Tower"),
 				single_column: true,
 			});
-			this._orgs_loaded = false;
+			this.filter_controls = {};
+			this._refresh_timer = null;
+			this._booting = true;
 			this.make_layout();
+			this.mount_filters();
 			this.bind_events();
-			this._load_organizations(() => this.refresh());
+			this._load_defaults(() => {
+				this._booting = false;
+				this.refresh();
+			});
 		}
 
 		make_layout() {
@@ -38,20 +42,40 @@ frappe.pages["air-freight-control-tower"].on_page_load = function (wrapper) {
 								${__("Live view of open files, lead times, airline mix, and returned billings.")}
 							</p>
 						</div>
-						<div class="afct-toolbar">
-							<label class="afct-field">
-								<span>${__("Organization")}</span>
-								<select id="afct-org" class="form-control input-sm"></select>
-							</label>
-							<label class="afct-field afct-field-year">
-								<span>${__("Fiscal Year")}</span>
-								<input id="afct-year" type="number" class="form-control input-sm" value="${year}" min="2000" max="2100" />
-							</label>
+					</header>
+
+					<section class="afct-filters" aria-label="${__("Dashboard filters")}">
+						<label class="afct-field">
+							<span>${__("Company")}</span>
+							<div class="afct-control" id="afct-company"></div>
+						</label>
+						<label class="afct-field">
+							<span>${__("Branch")}</span>
+							<div class="afct-control" id="afct-branch"></div>
+						</label>
+						<label class="afct-field">
+							<span>${__("Cost Center")}</span>
+							<div class="afct-control" id="afct-cost-center"></div>
+						</label>
+						<label class="afct-field">
+							<span>${__("Profit Center")}</span>
+							<div class="afct-control" id="afct-profit-center"></div>
+						</label>
+						<label class="afct-field">
+							<span>${__("UNLOCO")}</span>
+							<div class="afct-control" id="afct-unloco"></div>
+						</label>
+						<label class="afct-field afct-field-year">
+							<span>${__("Fiscal Year")}</span>
+							<input id="afct-year" type="number" class="form-control input-sm" value="${year}" min="2000" max="2100" />
+						</label>
+						<div class="afct-field afct-field-actions">
+							<span>&nbsp;</span>
 							<button type="button" class="btn btn-primary btn-sm afct-refresh" id="afct-refresh">
 								<i class="fa fa-refresh"></i> ${__("Refresh")}
 							</button>
 						</div>
-					</header>
+					</section>
 
 					<section class="afct-kpi-row" id="afct-kpis" aria-live="polite">
 						${this._kpi_skeleton()}
@@ -119,13 +143,8 @@ frappe.pages["air-freight-control-tower"].on_page_load = function (wrapper) {
 					}
 
 					.afct-hero {
-						display: flex;
-						flex-wrap: wrap;
-						justify-content: space-between;
-						gap: 18px 28px;
-						align-items: flex-end;
 						padding: 22px 22px 20px;
-						margin-bottom: 16px;
+						margin-bottom: 12px;
 						border-radius: var(--afct-radius);
 						background:
 							radial-gradient(1200px 280px at 8% -20%, rgba(20, 131, 200, 0.28), transparent 55%),
@@ -167,46 +186,63 @@ frappe.pages["air-freight-control-tower"].on_page_load = function (wrapper) {
 						line-height: 1.45;
 						color: rgba(232, 242, 250, 0.72);
 					}
-					.afct-toolbar {
-						display: flex;
-						flex-wrap: wrap;
-						align-items: flex-end;
-						gap: 10px;
+
+					.afct-filters {
+						display: grid;
+						grid-template-columns: repeat(auto-fit, minmax(9.5rem, 1fr));
+						gap: 10px 12px;
+						align-items: end;
+						padding: 14px 14px 12px;
+						margin-bottom: 14px;
+						border-radius: var(--afct-radius);
+						background: #fff;
+						border: 1px solid var(--afct-line);
 						position: relative;
-						z-index: 1;
+						z-index: 5;
 					}
 					.afct-field {
 						display: flex;
 						flex-direction: column;
 						gap: 4px;
 						margin: 0;
-						min-width: 11rem;
+						min-width: 0;
 					}
-					.afct-field-year { min-width: 6.5rem; max-width: 7.5rem; }
-					.afct-field span {
+					.afct-field-year { max-width: 7.5rem; }
+					.afct-field-actions { max-width: 8rem; }
+					.afct-field > span {
 						font-size: 0.7rem;
 						text-transform: uppercase;
 						letter-spacing: 0.06em;
-						color: rgba(232, 242, 250, 0.65);
+						color: var(--afct-muted);
 						font-weight: 600;
 					}
-					.afct-field .form-control {
-						border: 1px solid rgba(255,255,255,0.18);
-						background: rgba(255,255,255,0.1);
-						color: #fff;
-						height: 32px;
-						border-radius: 8px;
+					.afct-control .form-group { margin-bottom: 0; }
+					.afct-control .control-input-wrapper,
+					.afct-control .control-input { width: 100%; }
+					.afct-control .clearfix,
+					.afct-control .help-box,
+					.afct-control .control-label { display: none !important; }
+					.afct-control input.input-with-feedback,
+					.afct-control .form-control,
+					.afct-field-year .form-control {
+						height: 32px !important;
+						min-height: 32px !important;
+						border-radius: 8px !important;
+						border: 1px solid var(--afct-line) !important;
+						background: var(--afct-paper) !important;
+						font-size: 0.82rem !important;
+						box-shadow: none !important;
 					}
-					.afct-field .form-control option { color: #0b1f33; }
 					.afct-refresh {
 						height: 32px;
+						width: 100%;
 						border-radius: 8px;
 						border: none;
-						background: #e8f2fa !important;
-						color: var(--afct-ink) !important;
+						background: var(--afct-ink) !important;
+						color: #e8f2fa !important;
 						font-weight: 600;
 					}
-					.afct-refresh:hover { filter: brightness(0.96); }
+					.afct-refresh:hover { filter: brightness(1.08); }
 
 					.afct-kpi-row {
 						display: grid;
@@ -423,10 +459,103 @@ frappe.pages["air-freight-control-tower"].on_page_load = function (wrapper) {
 						.afct-brand { font-size: 1.15rem; }
 						.afct-mod-row { grid-template-columns: 1fr 1fr; }
 						.afct-mod-head { display: none; }
+						.afct-field-year, .afct-field-actions { max-width: none; }
 					}
 				</style>
 			`);
 			this.page.main.empty().append($ui);
+		}
+
+		mount_filters() {
+			const self = this;
+			const company_ctrl = this._make_link("afct-company", {
+				fieldname: "company",
+				options: "Company",
+				placeholder: __("Select Company"),
+			});
+			company_ctrl.df.onchange = () => {
+				self._clear_company_dependents();
+				self._schedule_refresh();
+			};
+
+			const branch_ctrl = this._make_link("afct-branch", {
+				fieldname: "branch",
+				options: "Branch",
+				placeholder: __("All Branches"),
+				get_query: () => self._company_query(),
+			});
+			branch_ctrl.df.onchange = () => self._schedule_refresh();
+
+			const cost_ctrl = this._make_link("afct-cost-center", {
+				fieldname: "cost_center",
+				options: "Cost Center",
+				placeholder: __("All Cost Centers"),
+				get_query: () => self._company_query({ is_group: 0 }),
+			});
+			cost_ctrl.df.onchange = () => self._schedule_refresh();
+
+			const profit_ctrl = this._make_link("afct-profit-center", {
+				fieldname: "profit_center",
+				options: "Profit Center",
+				placeholder: __("All Profit Centers"),
+				get_query: () => self._company_query(),
+			});
+			profit_ctrl.df.onchange = () => self._schedule_refresh();
+
+			const unloco_ctrl = this._make_link("afct-unloco", {
+				fieldname: "unloco",
+				options: "UNLOCO",
+				placeholder: __("All UNLOCOs"),
+			});
+			unloco_ctrl.df.onchange = () => self._schedule_refresh();
+
+			this.filter_controls = {
+				company: company_ctrl,
+				branch: branch_ctrl,
+				cost_center: cost_ctrl,
+				profit_center: profit_ctrl,
+				unloco: unloco_ctrl,
+			};
+		}
+
+		_make_link(parent_id, df) {
+			const ctrl = frappe.ui.form.make_control({
+				df: Object.assign(
+					{
+						fieldtype: "Link",
+						only_select: 1,
+					},
+					df
+				),
+				parent: this.wrapper.find("#" + parent_id),
+				render_input: true,
+			});
+			ctrl.refresh();
+			return ctrl;
+		}
+
+		_company_query(extra) {
+			const filters = Object.assign({}, extra || {});
+			const company = this._get_control_value("company");
+			if (company) {
+				filters.company = company;
+			}
+			return { filters: filters };
+		}
+
+		_get_control_value(key) {
+			const ctrl = this.filter_controls[key];
+			if (!ctrl) return "";
+			return (ctrl.get_value && ctrl.get_value()) || "";
+		}
+
+		_clear_company_dependents() {
+			["branch", "cost_center", "profit_center"].forEach((key) => {
+				const ctrl = this.filter_controls[key];
+				if (ctrl && ctrl.set_value) {
+					ctrl.set_value("");
+				}
+			});
 		}
 
 		_kpi_skeleton() {
@@ -454,31 +583,40 @@ frappe.pages["air-freight-control-tower"].on_page_load = function (wrapper) {
 
 		bind_events() {
 			this.wrapper.on("click", "#afct-refresh", () => this.refresh());
-			this.wrapper.on("change", "#afct-org, #afct-year", () => this.refresh());
+			this.wrapper.on("change", "#afct-year", () => this._schedule_refresh());
 		}
 
-		_load_organizations(done) {
+		_schedule_refresh() {
+			if (this._booting) {
+				return;
+			}
+			if (this._refresh_timer) {
+				clearTimeout(this._refresh_timer);
+			}
+			this._refresh_timer = setTimeout(() => this.refresh(), 250);
+		}
+
+		_load_defaults(done) {
 			frappe.call({
-				method: "logistics.air_freight.air_freight_control_tower.get_organizations",
+				method: "logistics.air_freight.air_freight_control_tower.get_filter_defaults",
 				callback: (r) => {
 					const data = r.message || {};
-					const $sel = this.wrapper.find("#afct-org");
-					$sel.empty();
-					(data.organizations || []).forEach((o) => {
-						const name = o.organization_name || o.name;
-						$sel.append($("<option>").attr("value", name).text(name));
-					});
-					const def = data.default || DEFAULT_ORG;
-					if ($sel.find(`option[value="${def}"]`).length) {
-						$sel.val(def);
+					if (data.company && this.filter_controls.company) {
+						this.filter_controls.company.set_value(data.company);
 					}
-					this._orgs_loaded = true;
+					if (data.fiscal_year) {
+						this.wrapper.find("#afct-year").val(data.fiscal_year);
+					}
 					if (done) done();
 				},
 				error: () => {
-					const $sel = this.wrapper.find("#afct-org");
-					$sel.empty().append($("<option>").attr("value", DEFAULT_ORG).text(DEFAULT_ORG));
-					this._orgs_loaded = true;
+					const fallback =
+						frappe.defaults.get_user_default("Company") ||
+						(frappe.boot && frappe.boot.sysdefaults && frappe.boot.sysdefaults.company) ||
+						"";
+					if (fallback && this.filter_controls.company) {
+						this.filter_controls.company.set_value(fallback);
+					}
 					if (done) done();
 				},
 			});
@@ -486,9 +624,23 @@ frappe.pages["air-freight-control-tower"].on_page_load = function (wrapper) {
 
 		_filters() {
 			return {
-				organization: this.wrapper.find("#afct-org").val() || DEFAULT_ORG,
+				company: this._get_control_value("company"),
+				branch: this._get_control_value("branch"),
+				cost_center: this._get_control_value("cost_center"),
+				profit_center: this._get_control_value("profit_center"),
+				unloco: this._get_control_value("unloco"),
 				fiscal_year: this.wrapper.find("#afct-year").val() || new Date().getFullYear(),
 			};
+		}
+
+		_filter_summary(filters) {
+			const parts = [];
+			if (filters.company) parts.push(filters.company);
+			if (filters.branch) parts.push(filters.branch);
+			if (filters.cost_center) parts.push(filters.cost_center);
+			if (filters.profit_center) parts.push(filters.profit_center);
+			if (filters.unloco) parts.push(filters.unloco);
+			return parts.join(" · ") || __("All companies");
 		}
 
 		refresh() {
@@ -499,7 +651,7 @@ frappe.pages["air-freight-control-tower"].on_page_load = function (wrapper) {
 				args: filters,
 				callback: (r) => {
 					this.wrapper.find("#afct-refresh").prop("disabled", false);
-					this.render(r.message || {});
+					this.render(r.message || {}, filters);
 				},
 				error: () => {
 					this.wrapper.find("#afct-refresh").prop("disabled", false);
@@ -511,20 +663,21 @@ frappe.pages["air-freight-control-tower"].on_page_load = function (wrapper) {
 			});
 		}
 
-		render(data) {
+		render(data, filters) {
+			filters = filters || data.filters || this._filters();
 			const kpis = data.kpis || {};
 			this._render_kpis(kpis);
 			this._render_airlines(data.top_airlines || [], data.top_airlines_max || 1);
 			this._render_returned(kpis, data.fiscal_year);
 			this._render_modules(data.by_module || []);
-			this._render_links(data.links || {}, data.organization);
+			this._render_links(data.links || {});
 			const asOf = data.as_of || "";
 			this.wrapper.find("#afct-asof").text(
 				asOf
 					? __("As of {0} · {1} · FY {2}", [
 							frappe.datetime.str_to_user(asOf),
-							data.organization || "",
-							data.fiscal_year || "",
+							this._filter_summary(filters),
+							data.fiscal_year || filters.fiscal_year || "",
 					  ])
 					: ""
 			);
@@ -633,7 +786,7 @@ frappe.pages["air-freight-control-tower"].on_page_load = function (wrapper) {
 			$host.html(head + body);
 		}
 
-		_render_links(links, organization) {
+		_render_links(links) {
 			const items = [];
 			if (links.control_tower_dashboard) {
 				items.push({
@@ -644,17 +797,13 @@ frappe.pages["air-freight-control-tower"].on_page_load = function (wrapper) {
 			if (links.jobs_report) {
 				items.push({
 					label: __("Jobs KPI Report"),
-					route: `/app/query-report/${encodeURIComponent(links.jobs_report)}?organization=${encodeURIComponent(
-						organization || DEFAULT_ORG
-					)}`,
+					route: `/app/query-report/${encodeURIComponent(links.jobs_report)}`,
 				});
 			}
 			if (links.returned_billings_report) {
 				items.push({
 					label: __("Returned Billings"),
-					route: `/app/query-report/${encodeURIComponent(links.returned_billings_report)}?organization=${encodeURIComponent(
-						organization || DEFAULT_ORG
-					)}`,
+					route: `/app/query-report/${encodeURIComponent(links.returned_billings_report)}`,
 				});
 			}
 			const html = items


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Follow-up to #1345. Replaces the Air Freight Control Tower **Organization** filter with a **Company** Link dropdown and adds dimension filters.

### Filters
- **Company** (Link dropdown; defaults to user default company)
- **Branch**
- **Cost Center**
- **Profit Center**
- **UNLOCO** (matches origin or destination port)
- **Fiscal Year**

Branch / Cost Center / Profit Center options are scoped to the selected Company.

### Implementation
- KPI queries in `logistics.air_freight.air_freight_control_tower` apply these dimensions directly on Air Shipment, milestones, and Returned Billing.
- Filter bar uses Frappe Link controls for searchable dropdowns.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aeb4b1e1-e7a7-402f-9307-4be5303f5806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aeb4b1e1-e7a7-402f-9307-4be5303f5806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

