### PR TITLE
fix: Clear document cache before navigating to newly created bookings/orders

### DIFF
--- a/logistics/pricing_center/doctype/sales_quote/sales_quote.js
+++ b/logistics/pricing_center/doctype/sales_quote/sales_quote.js
@@ -2600,30 +2600,38 @@ function show_air_booking_confirmation(frm) {
 								} else if (r.message && r.message.message) {
 									frappe.msgprint({ title: __("Information"), message: r.message.message, indicator: "blue" });
 								}
-								function try_navigate(attempt) {
-									if (attempt > 15) {
-										if (frm.doc.quotation_type === "One-off") {
-											logistics_set_one_off_order_route_nav();
-										}
-										frappe.set_route("Form", "Air Booking", air_booking_name);
-										return;
+							function try_navigate(attempt) {
+								if (attempt > 15) {
+									if (frm.doc.quotation_type === "One-off") {
+										logistics_set_one_off_order_route_nav();
 									}
-									frappe.call({
-										method: "logistics.air_freight.doctype.air_booking.air_booking.air_booking_exists",
-										args: { docname: air_booking_name },
-										callback: function(res) {
-											if (res.message === true) {
-												if (frm.doc.quotation_type === "One-off") {
-													logistics_set_one_off_order_route_nav();
-												}
-												frappe.set_route("Form", "Air Booking", air_booking_name);
-											} else {
-												setTimeout(function() { try_navigate(attempt + 1); }, 300);
-											}
-										},
-										error: function() { setTimeout(function() { try_navigate(attempt + 1); }, 300); }
-									});
+									// Clear cached document before navigating to ensure fresh load
+									if (frappe.model && frappe.model.clear_doc) {
+										frappe.model.clear_doc("Air Booking", air_booking_name);
+									}
+									frappe.set_route("Form", "Air Booking", air_booking_name);
+									return;
 								}
+								frappe.call({
+									method: "logistics.air_freight.doctype.air_booking.air_booking.air_booking_exists",
+									args: { docname: air_booking_name },
+									callback: function(res) {
+										if (res.message === true) {
+											if (frm.doc.quotation_type === "One-off") {
+												logistics_set_one_off_order_route_nav();
+											}
+											// Clear cached document before navigating to ensure fresh load
+											if (frappe.model && frappe.model.clear_doc) {
+												frappe.model.clear_doc("Air Booking", air_booking_name);
+											}
+											frappe.set_route("Form", "Air Booking", air_booking_name);
+										} else {
+											setTimeout(function() { try_navigate(attempt + 1); }, 300);
+										}
+									},
+									error: function() { setTimeout(function() { try_navigate(attempt + 1); }, 300); }
+								});
+							}
 								try_navigate(1);
 							},
 							error: function() {
@@ -2732,17 +2740,21 @@ function create_air_booking_from_sales_quote(frm) {
 	// Check if one-off and booking already exists
 	if (frm.doc.quotation_type === "One-off") {
 		frappe.db.get_value("Air Booking", {"sales_quote": frm.doc.name}, "name", function(r) {
-			if (r && r.name) {
-				frappe.msgprint({
-					title: __("Cannot Create Multiple Orders"),
-					message: __("This is a One-Off Sales Quote and an Air Booking already exists. Only one booking can be created from a One-Off quote."),
-					indicator: "orange"
-				});
-				// Event existing booking
-				logistics_set_one_off_order_route_nav();
-				frappe.set_route("Form", "Air Booking", r.name);
-				return;
+		if (r && r.name) {
+			frappe.msgprint({
+				title: __("Cannot Create Multiple Orders"),
+				message: __("This is a One-Off Sales Quote and an Air Booking already exists. Only one booking can be created from a One-Off quote."),
+				indicator: "orange"
+			});
+			// Event existing booking
+			logistics_set_one_off_order_route_nav();
+			// Clear cached document before navigating to ensure fresh load
+			if (frappe.model && frappe.model.clear_doc) {
+				frappe.model.clear_doc("Air Booking", r.name);
 			}
+			frappe.set_route("Form", "Air Booking", r.name);
+			return;
+		}
 			// No existing booking - proceed with creation
 			show_air_booking_confirmation(frm);
 		});
@@ -2784,6 +2796,10 @@ function create_sea_booking_from_sales_quote(frm) {
 					indicator: "orange",
 				});
 				logistics_set_one_off_order_route_nav();
+				// Clear cached document before navigating to ensure fresh load
+				if (frappe.model && frappe.model.clear_doc) {
+					frappe.model.clear_doc("Sea Booking", existing_name);
+				}
 				frappe.set_route("Form", "Sea Booking", existing_name);
 				return;
 			}
@@ -2835,23 +2851,31 @@ function show_sea_booking_confirmation(frm) {
 									? __("Sea Booking {0} already exists for this quote.", [r.message.sea_booking])
 									: __("Sea Booking {0} has been created successfully.", [r.message.sea_booking])),
 								indicator: opened_existing ? "blue" : "green",
-							});
+						});
+						setTimeout(function() {
+							if (frm.doc.quotation_type === "One-off") {
+								logistics_set_one_off_order_route_nav();
+							}
+							// Clear cached document before navigating to ensure fresh load
+							if (frappe.model && frappe.model.clear_doc) {
+								frappe.model.clear_doc("Sea Booking", r.message.sea_booking);
+							}
+							frappe.set_route("Form", "Sea Booking", r.message.sea_booking);
+						}, 100);
+					} else if (r.message && r.message.message) {
+						frappe.msgprint({ title: __("Information"), message: r.message.message, indicator: "blue" });
+						if (r.message.sea_booking) {
 							setTimeout(function() {
 								if (frm.doc.quotation_type === "One-off") {
 									logistics_set_one_off_order_route_nav();
 								}
+								// Clear cached document before navigating to ensure fresh load
+								if (frappe.model && frappe.model.clear_doc) {
+									frappe.model.clear_doc("Sea Booking", r.message.sea_booking);
+								}
 								frappe.set_route("Form", "Sea Booking", r.message.sea_booking);
 							}, 100);
-						} else if (r.message && r.message.message) {
-							frappe.msgprint({ title: __("Information"), message: r.message.message, indicator: "blue" });
-							if (r.message.sea_booking) {
-								setTimeout(function() {
-									if (frm.doc.quotation_type === "One-off") {
-										logistics_set_one_off_order_route_nav();
-									}
-									frappe.set_route("Form", "Sea Booking", r.message.sea_booking);
-								}, 100);
-							}
+						}
 						}
 					},
 					error: function(r) {

--- a/logistics/public/js/blanket_call_off_dialog.js
+++ b/logistics/public/js/blanket_call_off_dialog.js
@@ -638,22 +638,30 @@ function _bco_execute_create(state, dialog, selected, payloadParent) {
 				frappe.msgprint(__("Call-off creation failed."));
 				return;
 			}
-			dialog.hide();
-			frappe.show_alert({
-				message: r.message.message || __("Created."),
-				indicator: "green",
-			});
-			var dt = r.message.doctype;
-			var nm = r.message.name;
-			if (dt && nm) {
-				if (window.logistics_navigate_when_doc_exists) {
-					window.logistics_navigate_when_doc_exists(dt, nm, function () {
-						frappe.set_route("Form", dt, nm);
-					});
-				} else {
+		dialog.hide();
+		frappe.show_alert({
+			message: r.message.message || __("Created."),
+			indicator: "green",
+		});
+		var dt = r.message.doctype;
+		var nm = r.message.name;
+		if (dt && nm) {
+			if (window.logistics_navigate_when_doc_exists) {
+				window.logistics_navigate_when_doc_exists(dt, nm, function () {
+					// Clear any cached document data before navigating to ensure fresh load
+					if (frappe.model && frappe.model.clear_doc) {
+						frappe.model.clear_doc(dt, nm);
+					}
 					frappe.set_route("Form", dt, nm);
+				});
+			} else {
+				// Clear any cached document data before navigating to ensure fresh load
+				if (frappe.model && frappe.model.clear_doc) {
+					frappe.model.clear_doc(dt, nm);
 				}
+				frappe.set_route("Form", dt, nm);
 			}
+		}
 		},
 	});
 }

--- a/logistics/public/js/create_from_sales_quote.js
+++ b/logistics/public/js/create_from_sales_quote.js
@@ -17,6 +17,10 @@ frappe.provide("logistics.sea_freight");
  */
 function _logistics_set_route_when_exists(doctype, docname, after) {
 	function navigate() {
+		// Clear any cached document data before navigating to ensure fresh load
+		if (frappe.model && frappe.model.clear_doc) {
+			frappe.model.clear_doc(doctype, docname);
+		}
 		frappe.set_route("Form", doctype, docname);
 		if (typeof after === "function") {
 			after();

--- a/logistics/public/js/docket_booking_dialog.js
+++ b/logistics/public/js/docket_booking_dialog.js
@@ -333,6 +333,10 @@
 	function _routeAfterCreate(msg) {
 		function _go(doctype, docname) {
 			function navigate() {
+				// Clear any cached document data before navigating to ensure fresh load
+				if (frappe.model && frappe.model.clear_doc) {
+					frappe.model.clear_doc(doctype, docname);
+				}
 				frappe.set_route("Form", doctype, docname);
 			}
 			if (window.logistics_navigate_when_doc_exists) {

--- a/logistics/public/js/exhibit_booking_dialog.js
+++ b/logistics/public/js/exhibit_booking_dialog.js
@@ -300,6 +300,10 @@
 	function _routeAfterCreate(msg) {
 		function _go(doctype, docname) {
 			function navigate() {
+				// Clear any cached document data before navigating to ensure fresh load
+				if (frappe.model && frappe.model.clear_doc) {
+					frappe.model.clear_doc(doctype, docname);
+				}
 				frappe.set_route("Form", doctype, docname);
 			}
 			if (window.logistics_navigate_when_doc_exists) {

--- a/logistics/public/js/sales_quote_booking_dialog.js
+++ b/logistics/public/js/sales_quote_booking_dialog.js
@@ -429,6 +429,10 @@
 	function _routeAfterCreate(msg) {
 		function _go(doctype, docname) {
 			function navigate() {
+				// Clear any cached document data before navigating to ensure fresh load
+				if (frappe.model && frappe.model.clear_doc) {
+					frappe.model.clear_doc(doctype, docname);
+				}
 				frappe.set_route("Form", doctype, docname);
 			}
 			if (window.logistics_navigate_when_doc_exists) {

--- a/logistics/public/js/special_project_booking_dialog.js
+++ b/logistics/public/js/special_project_booking_dialog.js
@@ -568,6 +568,10 @@
 	function _routeAfterCreate(msg) {
 		function _go(doctype, docname) {
 			function navigate() {
+				// Clear any cached document data before navigating to ensure fresh load
+				if (frappe.model && frappe.model.clear_doc) {
+					frappe.model.clear_doc(doctype, docname);
+				}
 				frappe.set_route("Form", doctype, docname);
 			}
 			if (window.logistics_navigate_when_doc_exists) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When creating a new Sea Booking, Air Booking, or other order types from Sales Quote and then navigating to the newly created form, Frappe's client-side document cache could load stale data instead of fetching the freshly created record from the server. This caused issues where:

- The form displayed cached data from a previously viewed record
- Error messages appeared (e.g., "Sea Booking X not found")
- The form loaded with incorrect/old data instead of the newly created empty document

The issue was specifically reported in ASP-379 where after clicking "Create Booking" on a sea booking from the main service, a prompt appeared but the system proceeded to the sea booking module with potentially stale data.

## Root Cause

The codebase uses `frappe.set_route("Form", doctype, docname)` to navigate to newly created documents. However, Frappe maintains a client-side cache of loaded documents. When navigating to a document that shares the same doctype as a recently viewed document, Frappe may serve the cached version instead of fetching fresh data from the server, even though the document name is different.

## Solution

Added `frappe.model.clear_doc(doctype, docname)` calls immediately before `frappe.set_route()` in all booking/order creation flows. This ensures that any cached document data is cleared before navigation, forcing Frappe to fetch the freshly created document from the server.

## Changes

Updated all booking/order creation navigation flows:

- `sales_quote_booking_dialog.js` - Main service booking creation dialog
- `sales_quote.js` - One-off quote Sea/Air Booking creation
- `special_project_booking_dialog.js` - Special project booking creation
- `exhibit_booking_dialog.js` - Exhibit booking creation
- `docket_booking_dialog.js` - Docket booking creation
- `blanket_call_off_dialog.js` - Blanket call-off creation
- `create_from_sales_quote.js` - Shared navigation utility

## Testing

To test this fix:

1. Create a Sea Booking from a Sales Quote (Main Service)
2. Verify the newly created Sea Booking form loads with fresh data
3. Create another Sea Booking from a different Sales Quote
4. Verify no cached data from the first booking appears in the second
5. Repeat for Air Booking, Transport Order, and other order types

The fix ensures that newly created documents always load with fresh server data, preventing cache-related display issues.

Related: ASP-379
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d4c6589-c998-43bd-9378-d9aa16830b20?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d4c6589-c998-43bd-9378-d9aa16830b20&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

