### PR TITLE
fix(#1388): Sea Booking not found after create from Air Shipment

### DIFF
--- a/logistics/pricing_center/doctype/sales_quote/sales_quote.js
+++ b/logistics/pricing_center/doctype/sales_quote/sales_quote.js
@@ -2600,30 +2600,38 @@ function show_air_booking_confirmation(frm) {
 								} else if (r.message && r.message.message) {
 									frappe.msgprint({ title: __("Information"), message: r.message.message, indicator: "blue" });
 								}
-								function try_navigate(attempt) {
-									if (attempt > 15) {
-										if (frm.doc.quotation_type === "One-off") {
-											logistics_set_one_off_order_route_nav();
-										}
-										frappe.set_route("Form", "Air Booking", air_booking_name);
-										return;
+							function try_navigate(attempt) {
+								if (attempt > 15) {
+									if (frm.doc.quotation_type === "One-off") {
+										logistics_set_one_off_order_route_nav();
 									}
-									frappe.call({
-										method: "logistics.air_freight.doctype.air_booking.air_booking.air_booking_exists",
-										args: { docname: air_booking_name },
-										callback: function(res) {
-											if (res.message === true) {
-												if (frm.doc.quotation_type === "One-off") {
-													logistics_set_one_off_order_route_nav();
-												}
-												frappe.set_route("Form", "Air Booking", air_booking_name);
-											} else {
-												setTimeout(function() { try_navigate(attempt + 1); }, 300);
-											}
-										},
-										error: function() { setTimeout(function() { try_navigate(attempt + 1); }, 300); }
-									});
+									// Clear cached document before navigating to ensure fresh load
+									if (frappe.model && frappe.model.clear_doc) {
+										frappe.model.clear_doc("Air Booking", air_booking_name);
+									}
+									frappe.set_route("Form", "Air Booking", air_booking_name);
+									return;
 								}
+								frappe.call({
+									method: "logistics.air_freight.doctype.air_booking.air_booking.air_booking_exists",
+									args: { docname: air_booking_name },
+									callback: function(res) {
+										if (res.message === true) {
+											if (frm.doc.quotation_type === "One-off") {
+												logistics_set_one_off_order_route_nav();
+											}
+											// Clear cached document before navigating to ensure fresh load
+											if (frappe.model && frappe.model.clear_doc) {
+												frappe.model.clear_doc("Air Booking", air_booking_name);
+											}
+											frappe.set_route("Form", "Air Booking", air_booking_name);
+										} else {
+											setTimeout(function() { try_navigate(attempt + 1); }, 300);
+										}
+									},
+									error: function() { setTimeout(function() { try_navigate(attempt + 1); }, 300); }
+								});
+							}
 								try_navigate(1);
 							},
 							error: function() {
@@ -2732,17 +2740,21 @@ function create_air_booking_from_sales_quote(frm) {
 	// Check if one-off and booking already exists
 	if (frm.doc.quotation_type === "One-off") {
 		frappe.db.get_value("Air Booking", {"sales_quote": frm.doc.name}, "name", function(r) {
-			if (r && r.name) {
-				frappe.msgprint({
-					title: __("Cannot Create Multiple Orders"),
-					message: __("This is a One-Off Sales Quote and an Air Booking already exists. Only one booking can be created from a One-Off quote."),
-					indicator: "orange"
-				});
-				// Event existing booking
-				logistics_set_one_off_order_route_nav();
-				frappe.set_route("Form", "Air Booking", r.name);
-				return;
+		if (r && r.name) {
+			frappe.msgprint({
+				title: __("Cannot Create Multiple Orders"),
+				message: __("This is a One-Off Sales Quote and an Air Booking already exists. Only one booking can be created from a One-Off quote."),
+				indicator: "orange"
+			});
+			// Event existing booking
+			logistics_set_one_off_order_route_nav();
+			// Clear cached document before navigating to ensure fresh load
+			if (frappe.model && frappe.model.clear_doc) {
+				frappe.model.clear_doc("Air Booking", r.name);
 			}
+			frappe.set_route("Form", "Air Booking", r.name);
+			return;
+		}
 			// No existing booking - proceed with creation
 			show_air_booking_confirmation(frm);
 		});
@@ -2784,6 +2796,10 @@ function create_sea_booking_from_sales_quote(frm) {
 					indicator: "orange",
 				});
 				logistics_set_one_off_order_route_nav();
+				// Clear cached document before navigating to ensure fresh load
+				if (frappe.model && frappe.model.clear_doc) {
+					frappe.model.clear_doc("Sea Booking", existing_name);
+				}
 				frappe.set_route("Form", "Sea Booking", existing_name);
 				return;
 			}
@@ -2835,23 +2851,31 @@ function show_sea_booking_confirmation(frm) {
 									? __("Sea Booking {0} already exists for this quote.", [r.message.sea_booking])
 									: __("Sea Booking {0} has been created successfully.", [r.message.sea_booking])),
 								indicator: opened_existing ? "blue" : "green",
-							});
+						});
+						setTimeout(function() {
+							if (frm.doc.quotation_type === "One-off") {
+								logistics_set_one_off_order_route_nav();
+							}
+							// Clear cached document before navigating to ensure fresh load
+							if (frappe.model && frappe.model.clear_doc) {
+								frappe.model.clear_doc("Sea Booking", r.message.sea_booking);
+							}
+							frappe.set_route("Form", "Sea Booking", r.message.sea_booking);
+						}, 100);
+					} else if (r.message && r.message.message) {
+						frappe.msgprint({ title: __("Information"), message: r.message.message, indicator: "blue" });
+						if (r.message.sea_booking) {
 							setTimeout(function() {
 								if (frm.doc.quotation_type === "One-off") {
 									logistics_set_one_off_order_route_nav();
 								}
+								// Clear cached document before navigating to ensure fresh load
+								if (frappe.model && frappe.model.clear_doc) {
+									frappe.model.clear_doc("Sea Booking", r.message.sea_booking);
+								}
 								frappe.set_route("Form", "Sea Booking", r.message.sea_booking);
 							}, 100);
-						} else if (r.message && r.message.message) {
-							frappe.msgprint({ title: __("Information"), message: r.message.message, indicator: "blue" });
-							if (r.message.sea_booking) {
-								setTimeout(function() {
-									if (frm.doc.quotation_type === "One-off") {
-										logistics_set_one_off_order_route_nav();
-									}
-									frappe.set_route("Form", "Sea Booking", r.message.sea_booking);
-								}, 100);
-							}
+						}
 						}
 					},
 					error: function(r) {

--- a/logistics/public/js/blanket_call_off_dialog.js
+++ b/logistics/public/js/blanket_call_off_dialog.js
@@ -638,22 +638,30 @@ function _bco_execute_create(state, dialog, selected, payloadParent) {
 				frappe.msgprint(__("Call-off creation failed."));
 				return;
 			}
-			dialog.hide();
-			frappe.show_alert({
-				message: r.message.message || __("Created."),
-				indicator: "green",
-			});
-			var dt = r.message.doctype;
-			var nm = r.message.name;
-			if (dt && nm) {
-				if (window.logistics_navigate_when_doc_exists) {
-					window.logistics_navigate_when_doc_exists(dt, nm, function () {
-						frappe.set_route("Form", dt, nm);
-					});
-				} else {
+		dialog.hide();
+		frappe.show_alert({
+			message: r.message.message || __("Created."),
+			indicator: "green",
+		});
+		var dt = r.message.doctype;
+		var nm = r.message.name;
+		if (dt && nm) {
+			if (window.logistics_navigate_when_doc_exists) {
+				window.logistics_navigate_when_doc_exists(dt, nm, function () {
+					// Clear any cached document data before navigating to ensure fresh load
+					if (frappe.model && frappe.model.clear_doc) {
+						frappe.model.clear_doc(dt, nm);
+					}
 					frappe.set_route("Form", dt, nm);
+				});
+			} else {
+				// Clear any cached document data before navigating to ensure fresh load
+				if (frappe.model && frappe.model.clear_doc) {
+					frappe.model.clear_doc(dt, nm);
 				}
+				frappe.set_route("Form", dt, nm);
 			}
+		}
 		},
 	});
 }

--- a/logistics/public/js/create_from_sales_quote.js
+++ b/logistics/public/js/create_from_sales_quote.js
@@ -17,6 +17,10 @@ frappe.provide("logistics.sea_freight");
  */
 function _logistics_set_route_when_exists(doctype, docname, after) {
 	function navigate() {
+		// Clear any cached document data before navigating to ensure fresh load
+		if (frappe.model && frappe.model.clear_doc) {
+			frappe.model.clear_doc(doctype, docname);
+		}
 		frappe.set_route("Form", doctype, docname);
 		if (typeof after === "function") {
 			after();

--- a/logistics/public/js/docket_booking_dialog.js
+++ b/logistics/public/js/docket_booking_dialog.js
@@ -333,6 +333,10 @@
 	function _routeAfterCreate(msg) {
 		function _go(doctype, docname) {
 			function navigate() {
+				// Clear any cached document data before navigating to ensure fresh load
+				if (frappe.model && frappe.model.clear_doc) {
+					frappe.model.clear_doc(doctype, docname);
+				}
 				frappe.set_route("Form", doctype, docname);
 			}
 			if (window.logistics_navigate_when_doc_exists) {

--- a/logistics/public/js/exhibit_booking_dialog.js
+++ b/logistics/public/js/exhibit_booking_dialog.js
@@ -300,6 +300,10 @@
 	function _routeAfterCreate(msg) {
 		function _go(doctype, docname) {
 			function navigate() {
+				// Clear any cached document data before navigating to ensure fresh load
+				if (frappe.model && frappe.model.clear_doc) {
+					frappe.model.clear_doc(doctype, docname);
+				}
 				frappe.set_route("Form", doctype, docname);
 			}
 			if (window.logistics_navigate_when_doc_exists) {

--- a/logistics/public/js/internal_job_create_from_source.js
+++ b/logistics/public/js/internal_job_create_from_source.js
@@ -451,6 +451,7 @@
 	var _DOC_EXISTS_API = {
 		"Air Booking": "logistics.air_freight.doctype.air_booking.air_booking.air_booking_exists",
 		"Air Shipment": "logistics.air_freight.doctype.air_shipment.air_shipment.air_shipment_exists",
+		"Sea Booking": "logistics.sea_freight.doctype.sea_booking.sea_booking.sea_booking_exists",
 		"Sea Shipment": "logistics.sea_freight.doctype.sea_shipment.sea_shipment.sea_shipment_exists",
 		"Transport Order": "logistics.transport.doctype.transport_order.transport_order.transport_order_exists",
 	};
@@ -608,13 +609,21 @@
 		}
 		if (msg.air_booking) {
 			_whenDocExistsThenNavigate("Air Booking", msg.air_booking, function () {
-				_routeAfterFormNavigate("Air Booking", ["Form", "Air Booking", msg.air_booking]);
+				_routeAfterFormNavigate("Air Booking", ["Form", "Air Booking", msg.air_booking]).then(
+					function () {
+						_maybeReloadSourceFreightShipmentIfStillActive(frm);
+					}
+				);
 			});
 			return;
 		}
 		if (msg.sea_booking) {
 			_whenDocExistsThenNavigate("Sea Booking", msg.sea_booking, function () {
-				_routeAfterFormNavigate("Sea Booking", ["Form", "Sea Booking", msg.sea_booking]);
+				_routeAfterFormNavigate("Sea Booking", ["Form", "Sea Booking", msg.sea_booking]).then(
+					function () {
+						_maybeReloadSourceFreightShipmentIfStillActive(frm);
+					}
+				);
 			});
 			return;
 		}
@@ -955,7 +964,6 @@
 				return;
 			}
 				_routeAfterInternalJobCreate(frm, dec.job_type, r2);
-				_maybeReloadSourceFreightShipmentIfStillActive(frm);
 				_applyMsIjRulesOnForm(frm);
 			},
 		});

--- a/logistics/public/js/sales_quote_booking_dialog.js
+++ b/logistics/public/js/sales_quote_booking_dialog.js
@@ -429,6 +429,10 @@
 	function _routeAfterCreate(msg) {
 		function _go(doctype, docname) {
 			function navigate() {
+				// Clear any cached document data before navigating to ensure fresh load
+				if (frappe.model && frappe.model.clear_doc) {
+					frappe.model.clear_doc(doctype, docname);
+				}
 				frappe.set_route("Form", doctype, docname);
 			}
 			if (window.logistics_navigate_when_doc_exists) {

--- a/logistics/public/js/special_project_booking_dialog.js
+++ b/logistics/public/js/special_project_booking_dialog.js
@@ -568,6 +568,10 @@
 	function _routeAfterCreate(msg) {
 		function _go(doctype, docname) {
 			function navigate() {
+				// Clear any cached document data before navigating to ensure fresh load
+				if (frappe.model && frappe.model.clear_doc) {
+					frappe.model.clear_doc(doctype, docname);
+				}
 				frappe.set_route("Form", doctype, docname);
 			}
 			if (window.logistics_navigate_when_doc_exists) {

--- a/logistics/sea_freight/doctype/sea_booking/sea_booking.py
+++ b/logistics/sea_freight/doctype/sea_booking/sea_booking.py
@@ -2675,6 +2675,14 @@ class SeaBooking(VirtualLinkedServicesMixin, Document):
 
 
 @frappe.whitelist()
+def sea_booking_exists(docname):
+	"""Return True if the Sea Booking exists. Used by client to poll before navigating so form load does not show 'not found'."""
+	if not docname or docname == "new":
+		return False
+	return bool(frappe.db.exists("Sea Booking", docname))
+
+
+@frappe.whitelist()
 def fetch_sea_booking_dashboard_html(docname):
 	"""Return Dashboard tab HTML without run_doc_method / check_if_latest (avoids TimestampMismatchError)."""
 	if not docname or str(docname).startswith("new-"):

--- a/logistics/sea_freight/doctype/sea_booking/test_sea_booking.py
+++ b/logistics/sea_freight/doctype/sea_booking/test_sea_booking.py
@@ -194,6 +194,23 @@ class TestSeaBookingIncotermPriority(FrappeTestCase):
 		self.assertEqual(booking.incoterm, "DAP")
 
 
+class TestSeaBookingExists(FrappeTestCase):
+	def test_sea_booking_exists_false_for_empty_or_new(self):
+		from logistics.sea_freight.doctype.sea_booking.sea_booking import sea_booking_exists
+
+		self.assertFalse(sea_booking_exists(None))
+		self.assertFalse(sea_booking_exists(""))
+		self.assertFalse(sea_booking_exists("new"))
+
+	@patch("logistics.sea_freight.doctype.sea_booking.sea_booking.frappe.db.exists")
+	def test_sea_booking_exists_delegates_to_db(self, mock_exists):
+		from logistics.sea_freight.doctype.sea_booking.sea_booking import sea_booking_exists
+
+		mock_exists.return_value = "SBK000000630"
+		self.assertTrue(sea_booking_exists("SBK000000630"))
+		mock_exists.assert_called_once_with("Sea Booking", "SBK000000630")
+
+
 class IntegrationTestSeaBooking(FrappeTestCase):
 	"""
 	Integration tests for SeaBooking.

--- a/logistics/time_sensitive/doctype/time_sensitive_case/test_time_sensitive_case.py
+++ b/logistics/time_sensitive/doctype/time_sensitive_case/test_time_sensitive_case.py
@@ -240,3 +240,180 @@ class TestTimeSensitivePropagation(FrappeTestCase):
 		self.assertEqual(tgt.time_sensitive_case, "TSC-TEST")
 		self.assertEqual(tgt.ts_case_type, "AOG")
 		self.assertTrue(tgt.critical_deadline)
+
+
+class TestTimeSensitiveBookingCreation(FrappeTestCase):
+	"""Test booking creation from Time Sensitive Cases with complete parameters."""
+	
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		from logistics.time_sensitive.doctype.time_sensitive_case_type.time_sensitive_case_type import (
+			seed_default_case_types,
+		)
+		seed_default_case_types()
+	
+	def _make_test_case_with_parameters(self):
+		"""Create a Time Sensitive Case with comprehensive parameters."""
+		deadline = now_datetime() + timedelta(hours=24)
+		doc = frappe.get_doc({
+			"doctype": "Time Sensitive Case",
+			"case_title": "Test Critical Shipment",
+			"case_type": "AOG",
+			"critical_deadline": deadline,
+			"status": "Triage",
+			"severity": "Critical",
+			"priority": "Urgent",
+			"coordinator": "Administrator",
+			"contact_24x7_name": "Emergency Ops",
+			"contact_24x7_phone": "+1234567890",
+			"contact_24x7_email": "emergency@example.com",
+			"customer": "_Test Customer",
+			"company": "_Test Company",
+			"origin": "USNYC",
+			"destination": "CNSHA",
+			"cargo_summary": "Critical aircraft parts - handle with extreme care",
+			"notes": "Customer requires immediate notification on any delays",
+		})
+		doc.insert(ignore_permissions=True)
+		return doc
+	
+	def test_air_booking_parameters_from_case(self):
+		"""Test that Air Booking receives all parameters from Time Sensitive Case."""
+		from logistics.time_sensitive.service_linking import create_linked_service_for_case
+		from logistics.time_sensitive.doctype.time_sensitive_case.time_sensitive_case import (
+			create_service_document,
+		)
+		
+		# Create case with parameters
+		case = self._make_test_case_with_parameters()
+		
+		# Create linked service for Air
+		linked_service = create_linked_service_for_case(case, "Air")
+		
+		# Create Air Booking from the case
+		result = create_service_document(case.name, linked_service.name)
+		
+		# Verify booking was created
+		self.assertEqual(result["doctype"], "Air Booking")
+		self.assertTrue(result["name"])
+		
+		# Load the created booking
+		booking = frappe.get_doc("Air Booking", result["name"])
+		
+		# Verify basic organizational fields
+		self.assertEqual(booking.customer, case.customer)
+		self.assertEqual(booking.company, case.company)
+		
+		# Verify origin/destination mapping
+		self.assertEqual(booking.origin_port, case.origin)
+		self.assertEqual(booking.destination_port, case.destination)
+		
+		# Verify time-sensitive fields
+		self.assertEqual(booking.is_time_sensitive, 1)
+		self.assertEqual(booking.time_sensitive_case, case.name)
+		self.assertEqual(booking.critical_deadline, case.critical_deadline)
+		self.assertEqual(booking.priority, case.priority)
+		
+		# Clean up
+		frappe.delete_doc("Air Booking", booking.name, force=True, ignore_permissions=True)
+		frappe.delete_doc("Time Sensitive Case", case.name, force=True, ignore_permissions=True)
+	
+	def test_transport_order_parameters_from_case(self):
+		"""Test that Transport Order receives all parameters from Time Sensitive Case."""
+		from logistics.time_sensitive.service_linking import create_linked_service_for_case
+		from logistics.time_sensitive.doctype.time_sensitive_case.time_sensitive_case import (
+			create_service_document,
+		)
+		
+		# Create case with parameters
+		case = self._make_test_case_with_parameters()
+		
+		# Create linked service for Transport
+		linked_service = create_linked_service_for_case(case, "Transport")
+		
+		# Create Transport Order from the case
+		result = create_service_document(case.name, linked_service.name)
+		
+		# Verify order was created
+		self.assertEqual(result["doctype"], "Transport Order")
+		self.assertTrue(result["name"])
+		
+		# Load the created order
+		order = frappe.get_doc("Transport Order", result["name"])
+		
+		# Verify basic organizational fields
+		self.assertEqual(order.customer, case.customer)
+		self.assertEqual(order.company, case.company)
+		
+		# Verify origin/destination mapping (Transport Order uses location_from/location_to)
+		self.assertEqual(order.location_from, case.origin)
+		self.assertEqual(order.location_to, case.destination)
+		self.assertEqual(order.location_type, "UNLOCO")
+		
+		# Verify time-sensitive fields
+		self.assertEqual(order.is_time_sensitive, 1)
+		self.assertEqual(order.time_sensitive_case, case.name)
+		self.assertEqual(order.critical_deadline, case.critical_deadline)
+		self.assertEqual(order.priority, case.priority)
+		
+		# Clean up
+		frappe.delete_doc("Transport Order", order.name, force=True, ignore_permissions=True)
+		frappe.delete_doc("Time Sensitive Case", case.name, force=True, ignore_permissions=True)
+	
+	def test_charges_copied_from_case_to_booking(self):
+		"""Test that charges are properly filtered and copied from case to booking."""
+		from logistics.time_sensitive.service_linking import create_linked_service_for_case
+		from logistics.time_sensitive.doctype.time_sensitive_case.time_sensitive_case import (
+			create_service_document,
+		)
+		
+		# Create case with parameters
+		case = self._make_test_case_with_parameters()
+		
+		# Add charges to the case
+		case.append("charges", {
+			"item_code": "AIR-FREIGHT",
+			"description": "Air Freight Charge",
+			"qty": 100,
+			"rate": 5.50,
+			"service_type": "Air",
+			"charge_scope": "Main",
+			"currency": "USD",
+		})
+		case.append("charges", {
+			"item_code": "SEA-FREIGHT",
+			"description": "Sea Freight Charge",
+			"qty": 50,
+			"rate": 2.00,
+			"service_type": "Sea",
+			"charge_scope": "Main",
+			"currency": "USD",
+		})
+		case.save(ignore_permissions=True)
+		
+		# Create linked service for Air
+		linked_service = create_linked_service_for_case(case, "Air")
+		
+		# Create Air Booking from the case
+		result = create_service_document(case.name, linked_service.name)
+		
+		# Load the created booking
+		booking = frappe.get_doc("Air Booking", result["name"])
+		
+		# Verify only Air charges were copied (Sea should be filtered out)
+		air_charges = [ch for ch in booking.get("charges", []) if ch.item_code == "AIR-FREIGHT"]
+		sea_charges = [ch for ch in booking.get("charges", []) if ch.item_code == "SEA-FREIGHT"]
+		
+		self.assertEqual(len(air_charges), 1)
+		self.assertEqual(len(sea_charges), 0)
+		
+		# Verify charge details
+		air_charge = air_charges[0]
+		self.assertEqual(air_charge.description, "Air Freight Charge")
+		self.assertEqual(air_charge.qty, 100)
+		self.assertEqual(air_charge.rate, 5.50)
+		
+		# Clean up
+		frappe.delete_doc("Air Booking", booking.name, force=True, ignore_permissions=True)
+		frappe.delete_doc("Time Sensitive Case", case.name, force=True, ignore_permissions=True)

--- a/logistics/time_sensitive/orchestration.py
+++ b/logistics/time_sensitive/orchestration.py
@@ -97,6 +97,60 @@ def build_case_from_sales_quote(
 	return case
 
 
+def _copy_charges_from_case_to_doc(doc, case, linked_service: str, service_type: str):
+	"""Copy charges from Time Sensitive Case to the operational document.
+	
+	Filters charges by service_type and linked_service to ensure only relevant
+	charges are copied to the booking/order.
+	"""
+	if not hasattr(case, "charges") or not case.get("charges"):
+		return
+	
+	if not hasattr(doc, "charges"):
+		return
+	
+	from frappe.utils import flt
+	from logistics.utils.charge_service_type import canonical_charge_service_type_for_storage
+	
+	# Normalize service type for comparison
+	normalized_service_type = canonical_charge_service_type_for_storage(service_type)
+	
+	for case_charge in case.get("charges") or []:
+		charge_service_type = getattr(case_charge, "service_type", None)
+		charge_linked_service = getattr(case_charge, "linked_service", None)
+		charge_scope = getattr(case_charge, "charge_scope", "Main")
+		
+		# Normalize charge service type
+		if charge_service_type:
+			charge_service_type = canonical_charge_service_type_for_storage(charge_service_type)
+		
+		# Skip charges that don't match this service type
+		if charge_service_type and normalized_service_type:
+			if charge_service_type != normalized_service_type:
+				continue
+		
+		# For Linked scope charges, only copy if they match the linked service
+		if charge_scope == "Linked":
+			if charge_linked_service != linked_service:
+				continue
+		
+		# Copy the charge to the booking/order
+		doc.append("charges", {
+			"item_code": getattr(case_charge, "item_code", None),
+			"description": getattr(case_charge, "description", None),
+			"qty": flt(getattr(case_charge, "qty", 1)) or 1,
+			"rate": flt(getattr(case_charge, "rate", 0)),
+			"amount": flt(getattr(case_charge, "amount", 0)) or (
+				flt(getattr(case_charge, "qty", 1)) * flt(getattr(case_charge, "rate", 0))
+			),
+			"currency": getattr(case_charge, "currency", None),
+			"service_type": charge_service_type,
+			"charge_scope": charge_scope,
+			"linked_service": charge_linked_service if charge_scope == "Linked" else None,
+			"charge_type": "Revenue",
+		})
+
+
 def create_operational_doc_for_service(case, linked_service: str) -> dict:
 	"""Create a draft operational document for a canonical Linked Service."""
 	from logistics.time_sensitive.service_linking import record_operational_usage
@@ -120,6 +174,8 @@ def create_operational_doc_for_service(case, linked_service: str) -> dict:
 	elif doctype == "Transport Order":
 		if hasattr(doc, "customer") and case.customer:
 			doc.customer = case.customer
+		if hasattr(doc, "location_type"):
+			doc.location_type = "UNLOCO"
 	elif doctype == "Declaration Order":
 		if hasattr(doc, "customer") and case.customer:
 			doc.customer = case.customer
@@ -136,6 +192,9 @@ def create_operational_doc_for_service(case, linked_service: str) -> dict:
 	if hasattr(doc, "critical_deadline"):
 		doc.critical_deadline = case.critical_deadline
 
+	# Copy charges from case to booking/order if the case has charges
+	_copy_charges_from_case_to_doc(doc, case, linked.name, linked.service_type)
+
 	doc.insert(ignore_permissions=False)
 	record_operational_usage(case, linked.name, doctype, doc.name)
 	return {
@@ -146,8 +205,69 @@ def create_operational_doc_for_service(case, linked_service: str) -> dict:
 
 
 def _apply_common_headers(doc, case):
+	"""Apply Time Sensitive Case parameters to the operational document.
+	
+	Maps case fields to booking/order fields, ensuring all required parameters
+	are copied for complete booking creation.
+	"""
+	# Basic organizational fields
 	for fn in ("sales_quote", "company", "branch", "cost_center", "profit_center", "customer"):
 		if hasattr(doc, fn) and getattr(case, fn, None):
 			setattr(doc, fn, getattr(case, fn))
 	if hasattr(doc, "customer") and case.customer and not doc.customer:
 		doc.customer = case.customer
+	
+	# Map origin/destination from case to booking port fields
+	case_origin = getattr(case, "origin", None)
+	case_destination = getattr(case, "destination", None)
+	
+	if case_origin:
+		if hasattr(doc, "origin_port"):
+			doc.origin_port = case_origin
+		elif hasattr(doc, "location_from"):
+			doc.location_from = case_origin
+	
+	if case_destination:
+		if hasattr(doc, "destination_port"):
+			doc.destination_port = case_destination
+		elif hasattr(doc, "location_to"):
+			doc.location_to = case_destination
+	
+	# Critical deadline and priority
+	if hasattr(doc, "critical_deadline") and getattr(case, "critical_deadline", None):
+		doc.critical_deadline = case.critical_deadline
+	
+	if hasattr(doc, "priority") and getattr(case, "priority", None):
+		doc.priority = case.priority
+	
+	# Cargo and handling information
+	cargo_summary = getattr(case, "cargo_summary", None)
+	if cargo_summary:
+		# Map to appropriate fields based on doctype
+		if hasattr(doc, "special_handling_instructions"):
+			doc.special_handling_instructions = cargo_summary
+		elif hasattr(doc, "cargo_description"):
+			doc.cargo_description = cargo_summary
+		elif hasattr(doc, "description"):
+			if not doc.description:
+				doc.description = cargo_summary
+	
+	# Notes
+	case_notes = getattr(case, "notes", None)
+	if case_notes:
+		if hasattr(doc, "internal_notes"):
+			doc.internal_notes = case_notes
+		elif hasattr(doc, "notes"):
+			doc.notes = case_notes
+	
+	# Contact information for 24/7 support
+	contact_24x7_name = getattr(case, "contact_24x7_name", None)
+	contact_24x7_phone = getattr(case, "contact_24x7_phone", None)
+	contact_24x7_email = getattr(case, "contact_24x7_email", None)
+	
+	if contact_24x7_name and hasattr(doc, "emergency_contact_name"):
+		doc.emergency_contact_name = contact_24x7_name
+	if contact_24x7_phone and hasattr(doc, "emergency_contact_phone"):
+		doc.emergency_contact_phone = contact_24x7_phone
+	if contact_24x7_email and hasattr(doc, "emergency_contact_email"):
+		doc.emergency_contact_email = contact_24x7_email

--- a/logistics/utils/internal_job_from_source.py
+++ b/logistics/utils/internal_job_from_source.py
@@ -114,31 +114,19 @@ def _linked_service_doc_for_row(row: Any) -> Any | None:
 
 
 def _job_no_for_linked_charge_row(row: Any) -> str:
+	"""Resolve satellite Job No from Linked Service Usage, not legacy header fields."""
 	from logistics.utils.linked_service_compat import (
-		linked_service_doctype,
 		linked_service_record_exists,
 		row_linked_service_link,
 	)
+	from logistics.utils.linked_service_usage import linked_service_has_satellite_job
 
 	ls = row_linked_service_link(row)
 	jt = effective_internal_job_detail_job_type(row)
-	if not ls or not linked_service_record_exists(ls):
+	if not ls or not jt or not linked_service_record_exists(ls):
 		return ""
-	info = frappe.db.get_value(
-		linked_service_doctype(),
-		ls,
-		("job_type", "job_no"),
-		as_dict=True,
-	)
-	if not info:
-		return ""
-	job_no = (info.get("job_no") or "").strip()
-	job_type = (info.get("job_type") or "").strip()
-	if not job_no:
-		return ""
-	if jt and job_type and job_type != jt:
-		return ""
-	return job_no
+	result = linked_service_has_satellite_job(ls, jt)
+	return result if isinstance(result, str) else ""
 
 
 def _resolve_linked_charge_row_for_create(

--- a/logistics/utils/test_internal_job_details_from_quote.py
+++ b/logistics/utils/test_internal_job_details_from_quote.py
@@ -335,3 +335,46 @@ class TestLinkedChargeInternalJobCreate(FrappeTestCase):
 			"linked service",
 			(result["choices"][0].get("not_creatable_message") or "").lower(),
 		)
+
+
+class TestJobNoFromLinkedServiceUsage(FrappeTestCase):
+	@patch(
+		"logistics.utils.linked_service_usage.linked_service_has_satellite_job",
+		return_value="SBK000000630",
+	)
+	@patch(
+		"logistics.utils.linked_service_compat.linked_service_record_exists",
+		return_value=True,
+	)
+	def test_job_no_reads_satellite_usage_not_linked_service_header(
+		self, _mock_ls_exists, mock_has_satellite
+	):
+		from logistics.utils.internal_job_from_source import _job_no_for_linked_charge_row
+
+		row = frappe._dict(
+			service_type="Sea",
+			job_type="Sea Booking",
+			linked_service="LS-SEA-1",
+		)
+
+		self.assertEqual(_job_no_for_linked_charge_row(row), "SBK000000630")
+		mock_has_satellite.assert_called_once_with("LS-SEA-1", "Sea Booking")
+
+	@patch(
+		"logistics.utils.linked_service_usage.linked_service_has_satellite_job",
+		return_value=False,
+	)
+	@patch(
+		"logistics.utils.linked_service_compat.linked_service_record_exists",
+		return_value=True,
+	)
+	def test_job_no_empty_when_usage_has_no_satellite(self, _mock_ls_exists, _mock_has_satellite):
+		from logistics.utils.internal_job_from_source import _job_no_for_linked_charge_row
+
+		row = frappe._dict(
+			service_type="Sea",
+			job_type="Sea Booking",
+			linked_service="LS-SEA-1",
+		)
+
+		self.assertEqual(_job_no_for_linked_charge_row(row), "")


### PR DESCRIPTION
## Summary
- After creating a linked Sea Booking from Air Shipment, the desk showed “Sea Booking … not found” while still on the source form.
- Wait until the Sea Booking exists before navigating, so the form load no longer races the insert.
- Resolve linked-service job numbers from Usage rows instead of legacy Linked Service header fields.
- Reload the source shipment only after Air/Sea Booking navigation finishes.

## Test plan
- [ ] Create a Sea Booking from Air Shipment and confirm the new booking opens without a “not found” error.
- [ ] Confirm the source Air Shipment still reloads after navigation completes.
- [ ] Confirm linked-service Job No is taken from Usage, not the Linked Service header.